### PR TITLE
Makig formatting possible to use in SymExec

### DIFF
--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -491,5 +491,3 @@ formatExpr = go
           , ")"
           ]
       a -> show a
-
-

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -1,7 +1,7 @@
 {-# Language DataKinds #-}
 {-# Language ImplicitParams #-}
 {-# Language TemplateHaskell #-}
-module EVM.Format where
+module EVM.Format (formatExpr, contractNamePart, contractPathPart, showTree, showTraceTree) where
 
 import Prelude hiding (Word)
 import qualified EVM
@@ -9,7 +9,6 @@ import EVM.Dapp (DappInfo (..), dappSolcByHash, dappAbiMap, showTraceLocation, d
 import EVM.Dapp (DappContext (..), contextInfo, contextEnv)
 import EVM (VM, VMResult(..), cheatCode, traceForest, traceData, Error (..), result)
 import EVM (Trace, TraceData (..), Query (..), FrameContext (..))
-import EVM.SymExec
 import EVM.Types (maybeLitWord, W256 (..), num, word, Expr(..), EType(..), hexByteString, foldExpr, mapExpr)
 import EVM.Types (Addr, ByteStringS(..))
 import EVM.ABI (AbiValue (..), Event (..), AbiType (..), SolError (..))
@@ -492,3 +491,5 @@ formatExpr = go
           , ")"
           ]
       a -> show a
+
+

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -35,6 +35,7 @@ import qualified Data.Text as T
 import Data.List (find)
 import Data.Maybe (isJust, fromJust)
 import Debug.Trace
+import EVM.Format (formatExpr)
 
 data ProofResult a b c = Qed a | Cex b | Timeout c
   deriving (Show)


### PR DESCRIPTION
This is not an amazing diff, but it fixes the issue of not being able to use the function `formatExpr` in `SymExec.hs`, which was quite a pain before. I guess this should be fixed better... maybe you can give some advice?