### PR TITLE
Fix builds on macos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,15 +51,15 @@
                 "--extra-lib-dirs=${pkgs.gmp.override { withStatic = true; }}/lib"
                 "--extra-lib-dirs=${packages.libsecp256k1}/lib"
                 "--extra-lib-dirs=${packages.libff}/lib"
-                "--extra-lib-dirs=${pkgs.ncurses.override {enableStatic = true; }}/lib"
+                "--extra-lib-dirs=${pkgs.ncurses.override { enableStatic = true; }}/lib"
                 "--extra-lib-dirs=${pkgs.zlib.static}/lib"
                 "--extra-lib-dirs=${pkgs.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
             ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
                 "--extra-lib-dirs=${pkgs.libiconv}/lib"
                 "--extra-lib-dirs=${pkgs.libiconv.override { enableStatic = true; }}/lib"
            ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-                "--extra-lib-dirs=${pkgs.glibc.static}/lib"
                 "--extra-lib-dirs=${pkgs.glibc}/lib"
+                "--extra-lib-dirs=${pkgs.glibc.static}/lib"
             ];
           }));
         };

--- a/flake.nix
+++ b/flake.nix
@@ -54,9 +54,12 @@
                 "--extra-lib-dirs=${pkgs.ncurses.override {enableStatic = true; }}/lib"
                 "--extra-lib-dirs=${pkgs.zlib.static}/lib"
                 "--extra-lib-dirs=${pkgs.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+                "--extra-lib-dirs=${pkgs.libiconv}/lib"
+                "--extra-lib-dirs=${pkgs.libiconv.override { enableStatic = true; }}/lib"
            ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-                "--extra-lib-dirs=${pkgs.glibc}/lib"
                 "--extra-lib-dirs=${pkgs.glibc.static}/lib"
+                "--extra-lib-dirs=${pkgs.glibc}/lib"
             ];
           }));
         };
@@ -81,8 +84,8 @@
           ];
           withHoogle = true;
         }).overrideAttrs (_: {
-          LD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${pkgs.libff}/lib";
-          DYLD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${pkgs.libff}/lib";
+          LD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${packages.libff}/lib";
+          DYLD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${packages.libff}/lib";
         });
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
           withHoogle = true;
         }).overrideAttrs (_: {
           LD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${pkgs.libff}/lib";
+          DYLD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${pkgs.libff}/lib";
         });
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -84,8 +84,8 @@
           ];
           withHoogle = true;
         }).overrideAttrs (_: {
-          LD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${packages.libff}/lib";
-          DYLD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${packages.libff}/lib";
+          LD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${packages.libff.override {enableStatic = false;}}/lib";
+          DYLD_LIBRARY_PATH = "${pkgs.secp256k1}/lib:${packages.libff.override {enableStatic = false;}}/lib";
         });
       }
     );

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -71,9 +71,7 @@ library
     -Wall -Wno-deprecations -Wno-unticked-promoted-constructors
   extra-libraries:
     secp256k1, ff
-  if os(darwin)
-     extra-libraries: c++
-  else
+  if os(linux)
      extra-libraries: stdc++
   c-sources:
     ethjet/tinykeccak.c, ethjet/ethjet.c
@@ -211,6 +209,10 @@ test-suite test
     test.hs
   extra-libraries:
     secp256k1
+  if os(darwin)
+     extra-libraries: c++
+  else
+     extra-libraries: stdc++
   build-depends:
     HUnit >= 1.6,
     QuickCheck,
@@ -219,7 +221,6 @@ test-suite test
     binary,
     containers,
     bytestring,
-    free,
     here,
     hevm,
     lens,
@@ -228,5 +229,4 @@ test-suite test
     tasty-hunit >= 0.10,
     tasty-quickcheck >= 0.9,
     text,
-    vector,
-    sbv
+    vector

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -161,7 +161,10 @@ executable hevm
   other-modules:
     Paths_hevm
   if os(darwin)
+    extra-libraries: c++
     ld-options: -Wl,-keep_dwarf_unwind
+  else
+    extra-libraries: stdc++
   build-depends:
     QuickCheck,
     aeson,


### PR DESCRIPTION
This isn't a full fix, but at least it gets rid of the missing libraries errors that we were seeing before. I'm still running into this issue though when building the tests: https://github.com/NixOS/nixpkgs/issues/149937.