### PR TITLE
Remove missing license-file from hevm.cabal

### DIFF
--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -14,8 +14,6 @@ homepage:
   https://github.com/dapphub/dapptools
 license:
   AGPL-3.0-only
-license-file:
-  COPYING
 author:
   Mikael Brockman, Martin Lundfall, dxo
 maintainer:


### PR DESCRIPTION
## Description
The file doesn't exist and nix fails to build hevm as a haskell dependency because of that.
## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
