### PR TITLE
Fixing PNeg p -> p and also a grammar typo in the same function

### DIFF
--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -471,12 +471,12 @@ reachable solvers = go []
       EVM.Types.IllegalOverflow -> pure ([], EVM.Types.IllegalOverflow)
       TmpErr e -> error $ "TmpErr: " <> show e
 
--- | Evaluate the provided proposition down to it's most concrete result
+-- | Evaluate the provided proposition down to its most concrete result
 evalProp :: Prop -> Prop
 evalProp = \case
   PBool b -> PBool b
   PNeg (PBool b) -> PBool (not b)
-  PNeg p -> p
+  PNeg p -> PNeg p
   PEq l r -> if l == r
              then PBool True
              else PEq l r


### PR DESCRIPTION
## Description
Fixes bug with PNeg being forgotten, and also fixes a grammar typo.
