### PR TITLE
Fixing up P issues

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1067,10 +1067,10 @@ exec1 = do
             (x:y:xs) -> forceConcrete x "JUMPI: symbolic jumpdest" $ \x' ->
                 burn g_high $
                   let jump :: Bool -> EVM ()
-                      jump False = assign (state . stack) xs >> next
+                      jump True = assign (state . stack) xs >> next
                       jump _    = checkJump x' xs
                   in case maybeLitWord y of
-                      Just y' -> jump (1 == y')
+                      Just y' -> jump (0 == y')
                       -- if the jump condition is symbolic, we explore both sides
                       Nothing -> do
                         loc <- codeloc
@@ -1622,7 +1622,7 @@ branch loc cond continue = do
   assign result . Just . VMFailure . Query $ PleaseAskSMT cond pathconds choosePath
   where
      choosePath (Case v) = do assign result Nothing
-                              pushTo constraints $ if v then (cond .== (Lit 1)) else (cond .== (Lit 0))
+                              pushTo constraints $ if v then (cond ./= (Lit 0)) else (cond .== (Lit 0))
                               iteration <- use (iterations . at loc . non 0)
                               assign (cache . path . at (loc, iteration)) (Just v)
                               assign (iterations . at loc) (Just (iteration + 1))

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1067,10 +1067,10 @@ exec1 = do
             (x:y:xs) -> forceConcrete x "JUMPI: symbolic jumpdest" $ \x' ->
                 burn g_high $
                   let jump :: Bool -> EVM ()
-                      jump True = assign (state . stack) xs >> next
+                      jump False = assign (state . stack) xs >> next
                       jump _    = checkJump x' xs
                   in case maybeLitWord y of
-                      Just y' -> jump (0 == y')
+                      Just y' -> jump (0 /= y')
                       -- if the jump condition is symbolic, we explore both sides
                       Nothing -> do
                         loc <- codeloc

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -8,7 +8,7 @@ module EVM.Fetch where
 import Prelude hiding (Word)
 
 import EVM.ABI
-import EVM.Types    (Addr, W256, hexText, Expr(Lit, LitByte), Expr(..), Prop(..), (.&&), (.==))
+import EVM.Types    (Addr, W256, hexText, Expr(Lit, LitByte), Expr(..), Prop(..), (.&&), (.==), (./=))
 import EVM.SMT
 import EVM          (EVM, Contract, Block, initialContract, nonce, balance, external)
 import qualified EVM.FeeSchedule as FeeSchedule
@@ -179,7 +179,7 @@ oracle solvers info q = do
     EVM.PleaseAskSMT branchcondition pathconditions continue -> do
          let pathconds = foldl' PAnd (PBool True) pathconditions
          -- Is is possible to satisfy the condition?
-         continue <$> checkBranch solvers (branchcondition .== (Lit 1)) pathconds
+         continue <$> checkBranch solvers (branchcondition ./= (Lit 0)) pathconds
 
     -- if we are using a symbolic storage model,
     -- we generate a new array to the fetched contract here

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -320,7 +320,7 @@ flattenExpr = go []
   where
     go :: [Prop] -> Expr End -> [([Prop], Expr End)]
     go pcs = \case
-      ITE c t f -> go ((PEq c (Lit 1)) : pcs) t <> go ((PEq c (Lit 0)) : pcs) f
+      ITE c t f -> go (PNeg ((PEq c (Lit 0))) : pcs) t <> go (PEq c (Lit 0) : pcs) f
       Invalid -> [(pcs, Invalid)]
       SelfDestruct -> [(pcs, SelfDestruct)]
       Revert buf -> [(pcs, Revert buf)]
@@ -475,33 +475,33 @@ reachable solvers = go []
 -- | Evaluate the provided proposition down to its most concrete result
 evalProp :: Prop -> Prop
 evalProp = \case
-  PBool b -> PBool b
-  PNeg p -> case p of
+  o@(PBool b) -> o
+  o@(PNeg p)  -> case p of
               (PBool b) -> PBool (not b)
-              _ -> PNeg p
-  PEq l r -> if l == r
+              _ -> o
+  o@(PEq l r) -> if l == r
              then PBool True
-             else PEq l r
-  PLT l r -> if l < r
+             else o
+  o@(PLT l r) -> if l < r
              then PBool True
-             else PEq l r
-  PGT l r -> if l > r
+             else o
+  o@(PGT l r) -> if l > r
              then PBool True
-             else PEq l r
-  PGEq l r -> if l >= r
+             else o
+  o@(PGEq l r) -> if l >= r
              then PBool True
-             else PEq l r
-  PLEq l r -> if l <= r
+             else o
+  o@(PLEq l r) -> if l <= r
              then PBool True
-             else PEq l r
-  PAnd l r -> case (evalProp l, evalProp r) of
+             else o
+  o@(PAnd l r) -> case (evalProp l, evalProp r) of
                 (PBool True, PBool True) -> PBool True
                 (PBool _, PBool _) -> PBool False
-                _ -> PAnd l r
-  POr l r -> case (evalProp l, evalProp r) of
+                _ -> o
+  o@(POr l r) -> case (evalProp l, evalProp r) of
                 (PBool False, PBool False) -> PBool False
                 (PBool _, PBool _) -> PBool True
-                _ -> POr l r
+                _ -> o
 
 
 -- | Symbolically execute the VM and check all endstates against the postcondition, if available.

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -464,9 +464,10 @@ tests = testGroup "hevm"
             |]
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
-          {-bs <- runSMT $ query $ do
-            (Cex, -) <- checkAssert allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
-              case view (state . calldata . _1) vm of
+          {-
+          bs <- runSMT $ query $ do
+            (Cex _, vm) <- checkAssert allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
+            case view (state . calldata . _1) vm of
               SymbolicBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
               ConcreteBuffer _ -> error "unexpected"
 

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -412,7 +412,7 @@ tests = testGroup "hevm"
                     break;
                   }
                  deposit_count = deposit_count >> 1;
-                }
+                 }
                 assert(found);
               }
              }

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -419,30 +419,32 @@ tests = testGroup "hevm"
             |]
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
+        {-
         ,
         -- TODO: CVC5 is not installed by nix, disabling
-        -- testCase "Deposit contract loop (cvc5)" $ do
-        --   Just c <- solcRuntime "Deposit"
-        --     [i|
-        --     contract Deposit {
-        --       function deposit(uint256 deposit_count) external pure {
-        --         require(deposit_count < 2**32 - 1);
-        --         ++deposit_count;
-        --         bool found = false;
-        --         for (uint height = 0; height < 32; height++) {
-        --           if ((deposit_count & 1) == 1) {
-        --             found = true;
-        --             break;
-        --           }
-        --          deposit_count = deposit_count >> 1;
-        --          }
-        --         assert(found);
-        --       }
-        --      }
-        --     |]
-        --   [Qed res] <- withSolvers CVC5 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
-        --   putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
-        -- ,
+        testCase "Deposit contract loop (cvc5)" $ do
+          Just c <- solcRuntime "Deposit"
+            [i|
+            contract Deposit {
+              function deposit(uint256 deposit_count) external pure {
+                require(deposit_count < 2**32 - 1);
+                ++deposit_count;
+                bool found = false;
+                for (uint height = 0; height < 32; height++) {
+                  if ((deposit_count & 1) == 1) {
+                    found = true;
+                    break;
+                  }
+                 deposit_count = deposit_count >> 1;
+                 }
+                assert(found);
+              }
+             }
+            |]
+          [Qed res] <- withSolvers CVC5 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
+          putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
+        ,
+        -- TODO: this is supposed to return a Cex but instead returns a Qed
         testCase "Deposit contract loop (error version)" $ do
           Just c <- solcRuntime "Deposit"
             [i|
@@ -462,9 +464,6 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
-          putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
-          {-
           bs <- runSMT $ query $ do
             (Cex _, vm) <- checkAssert allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
             case view (state . calldata . _1) vm of

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -462,13 +462,14 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
+          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
           {-bs <- runSMT $ query $ do
             (Cex, -) <- checkAssert allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []
               case view (state . calldata . _1) vm of
               SymbolicBuffer bs -> BS.pack <$> mapM (getValue.fromSized) bs
               ConcreteBuffer _ -> error "unexpected"
+
           let [deposit] = decodeAbiValues [AbiUIntType 8] bs
           assertEqual "overflowing uint8" deposit (AbiUInt 8 255)
      ,
@@ -711,6 +712,7 @@ tests = testGroup "hevm"
           Cex _ <- equivalenceCheck aPrgm bPrgm Nothing Nothing Nothing
           return ()
           -}
+
     ]
   ]
   where

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -406,13 +406,13 @@ tests = testGroup "hevm"
                 require(deposit_count < 2**32 - 1);
                 ++deposit_count;
                 bool found = false;
-                 for (uint height = 0; height < 32; height++) {
-                   if ((deposit_count & 1) == 1) {
-                     found = true;
-                     break;
-                   }
-                  deposit_count = deposit_count >> 1;
-                 }
+                for (uint height = 0; height < 32; height++) {
+                  if ((deposit_count & 1) == 1) {
+                    found = true;
+                    break;
+                  }
+                 deposit_count = deposit_count >> 1;
+                }
                 assert(found);
               }
              }

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -420,7 +420,7 @@ tests = testGroup "hevm"
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
-        testCase "Deposit contract loop (cvc4)" $ do
+        testCase "Deposit contract loop (cvc5)" $ do
           Just c <- solcRuntime "Deposit"
             [i|
             contract Deposit {
@@ -439,7 +439,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
+          [Qed res] <- withSolvers CVC5 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "Deposit contract loop (error version)" $ do

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -418,7 +418,6 @@ tests = testGroup "hevm"
              }
             |]
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
-          putStrLn $ formatExpr res
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "Deposit contract loop (cvc4)" $ do
@@ -441,7 +440,6 @@ tests = testGroup "hevm"
              }
             |]
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
-          putStrLn $ formatExpr res
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "Deposit contract loop (error version)" $ do

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -462,7 +462,6 @@ tests = testGroup "hevm"
              }
             |]
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
-          putStrLn $ formatExpr res
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
           {-bs <- runSMT $ query $ do
             (Cex, -) <- checkAssert allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) []

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -420,27 +420,28 @@ tests = testGroup "hevm"
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
-        testCase "Deposit contract loop (cvc5)" $ do
-          Just c <- solcRuntime "Deposit"
-            [i|
-            contract Deposit {
-              function deposit(uint256 deposit_count) external pure {
-                require(deposit_count < 2**32 - 1);
-                ++deposit_count;
-                bool found = false;
-                for (uint height = 0; height < 32; height++) {
-                  if ((deposit_count & 1) == 1) {
-                    found = true;
-                    break;
-                  }
-                 deposit_count = deposit_count >> 1;
-                 }
-                assert(found);
-              }
-             }
-            |]
-          [Qed res] <- withSolvers CVC5 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
-          putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
+        -- TODO: CVC5 is not installed by nix, disabling
+        -- testCase "Deposit contract loop (cvc5)" $ do
+        --   Just c <- solcRuntime "Deposit"
+        --     [i|
+        --     contract Deposit {
+        --       function deposit(uint256 deposit_count) external pure {
+        --         require(deposit_count < 2**32 - 1);
+        --         ++deposit_count;
+        --         bool found = false;
+        --         for (uint height = 0; height < 32; height++) {
+        --           if ((deposit_count & 1) == 1) {
+        --             found = true;
+        --             break;
+        --           }
+        --          deposit_count = deposit_count >> 1;
+        --          }
+        --         assert(found);
+        --       }
+        --      }
+        --     |]
+        --   [Qed res] <- withSolvers CVC5 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
+        --   putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "Deposit contract loop (error version)" $ do
           Just c <- solcRuntime "Deposit"

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -442,7 +442,7 @@ tests = testGroup "hevm"
         --     |]
         --   [Qed res] <- withSolvers CVC5 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
         --   putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
-        ,
+        -- ,
         testCase "Deposit contract loop (error version)" $ do
           Just c <- solcRuntime "Deposit"
             [i|

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -372,7 +372,7 @@ tests = testGroup "hevm"
           [Cex _, Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256)", [AbiUIntType 256])) []
           putStrLn "expected 2 counterexamples found"
         ,
-        expectFail $ testCase "assert-fail-notequal" $ do
+        testCase "assert-fail-notequal" $ do
           Just c <- solcRuntime "AssertFailNotEqual"
             [i|
             contract AssertFailNotEqual {


### PR DESCRIPTION
This fixes what I believe are bugs and makes it easier to make sure this rewrite set is correct.

I believe this is a bug:

```
 PGT l r -> if l > r
             then PBool True
             else PEq l r
```

Notice the `PEq` instead of `PGT` ? I mean we do check if it's bigger syntactically, but we may not be able to determine that, right? Also, it could be smaller, not just equal? So we should return ` PGT l r` right?

Similarly for `PLT` and`PLEq`. Maybe my understanding is wrong though :S Please check.