### PR TITLE
Removed dependency to Ord for Expr and minor fix in SMT encoding

### DIFF
--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -207,7 +207,7 @@ prelude = SMT2 . fmap (T.drop 2) . T.lines $ [i|
 
   (define-fun writeWord ((idx Word) (val Word) (buf Buf)) Buf
       (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store
-      (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store buf
+      (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store buf
       (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001f) (indexWord31 val))
       (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001e) (indexWord30 val))
       (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001d) (indexWord29 val))
@@ -235,11 +235,9 @@ prelude = SMT2 . fmap (T.drop 2) . T.lines $ [i|
       (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000007) (indexWord7 val))
       (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000006) (indexWord6 val))
       (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000005) (indexWord5 val))
-      (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000005) (indexWord5 val))
       (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000004) (indexWord4 val))
       (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000003) (indexWord3 val))
       (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000002) (indexWord2 val))
-      (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000001) (indexWord1 val))
       (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000001) (indexWord1 val))
       idx (indexWord0 val))
   )

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -480,28 +480,28 @@ evalProp = \case
               (PBool b) -> PBool (not b)
               _ -> o
   o@(PEq l r) -> if l == r
-             then PBool True
-             else o
-  o@(PLT l r) -> if l < r
-             then PBool True
-             else o
-  o@(PGT l r) -> if l > r
-             then PBool True
-             else o
-  o@(PGEq l r) -> if l >= r
-             then PBool True
-             else o
-  o@(PLEq l r) -> if l <= r
-             then PBool True
-             else o
+                 then PBool True
+                 else o
+  o@(PLT (Lit l) (Lit r)) -> if l < r
+                             then PBool True
+                             else o
+  o@(PGT (Lit l) (Lit r)) -> if l > r
+                             then PBool True
+                             else o
+  o@(PGEq (Lit l) (Lit r)) -> if l >= r
+                              then PBool True
+                              else o
+  o@(PLEq (Lit l) (Lit r)) -> if l <= r
+                              then PBool True
+                              else o
   o@(PAnd l r) -> case (evalProp l, evalProp r) of
-                (PBool True, PBool True) -> PBool True
-                (PBool _, PBool _) -> PBool False
-                _ -> o
+                    (PBool True, PBool True) -> PBool True
+                    (PBool _, PBool _) -> PBool False
+                    _ -> o
   o@(POr l r) -> case (evalProp l, evalProp r) of
-                (PBool False, PBool False) -> PBool False
-                (PBool _, PBool _) -> PBool True
-                _ -> o
+                   (PBool False, PBool False) -> PBool False
+                   (PBool _, PBool _) -> PBool True
+                   _ -> o
 
 
 -- | Symbolically execute the VM and check all endstates against the postcondition, if available.


### PR DESCRIPTION
* As discussed in #32 , the automatically derived Ord does not have the expected semantics. In `evalProp` we used to do
  ```
  o@(PGT l r) -> if l > r
                 then PBool True
                 else o
  ```
  But
  ```
  ghci> (Add (Lit 0) (Lit 0)) > Lit 3
  True
  ```
  therefore that would result to `(PGT (Add (Lit 0) (Lit 0)) (Lit 3))` evaluating to `PBool True`.
  
  Turned these to direct comparisons of the inner literals.
  
  * Removed what seems to be redundant stores in the SMT encoding of `writeWord`.
  