### PR TITLE
Simp rules -- now on top of new `main`

### DIFF
--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -380,11 +380,11 @@ simplify e = if (mapExpr go e == e)
       | otherwise = Lit 0
     -- we write at least 32, so if x <= 32, it's FALSE
     go o@(EVM.Types.LT (BufLength (WriteWord {})) (Lit x))
-      | x <= 32 = Lit 0x0
+      | x <= 32 = Lit 0
       | otherwise = o
     -- we write at least 32, so if x < 32, it's TRUE
     go o@(EVM.Types.GT (BufLength (WriteWord {})) (Lit x))
-      | x < 32 = Lit 0x1
+      | x < 32 = Lit 1
       | otherwise = o
     go o@(Sub a b)
       | a == b = Lit 0

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -340,9 +340,6 @@ simplify e = if (mapExpr go e == e)
     go (CopySlice (Lit 0x0) (Lit 0x0) (Lit 0x0) _ dst) = dst
 
     -- simplify buffers
-    go o@(ReadWord off1 (WriteWord off2 x _))
-      | off1 == off2 = x
-      | otherwise = o
     go o@(ReadWord (Lit _) _) = Expr.simplifyReads o
     go o@(ReadByte (Lit _) _) = Expr.simplifyReads o
 


### PR DESCRIPTION
## Description

These are likely uncontroversial except for the `ReadWord`/`WriteWord` -- however, for the moment, that really makes the generated IR a _lot_ nicer. So I'd like to have it in until I can understand & improve `simplifyReads`.

This new PR is needed because the old PR (#18 ) was on top of an old `main` and would never give us a green light.
