### PR TITLE
Panic code tests

### DIFF
--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -263,7 +263,7 @@ tests = testGroup "hevm"
      ,
      -- TODO 0x22 is missing: "0x22: If you access a storage byte array that is incorrectly encoded."
      -- TODO below should NOT fail
-     expectFail $ testCase "pop-empty-array" $ do
+     testCase "pop-empty-array" $ do
         Just c <- solcRuntime "MyContract"
             [i|
             contract MyContract {

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -320,14 +320,14 @@ tests = testGroup "hevm"
                 return a;
               }
               function fun(uint256 a) external returns (uint) {
-                if (a == 0) {
+                if (a != 44) {
                   funvar = fun2;
                 }
                 return funvar(a);
               }
              }
             |]
-        [Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s [0x51] c (Just ("funn(uint256)", [AbiUIntType 256])) []
+        [Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s [0x51] c (Just ("fun(uint256)", [AbiUIntType 256])) []
         putStrLn "expected counterexample found"
  ]
 


### PR DESCRIPTION
## Description
This PR adds tests for each panic code. All seem to work, except for things that cannot currently be handled by HEVM due to missing symbolic representation: too much memory allocation, and function variable calls.

Hence, this tests all panic codes except `0x22: If you access a storage byte array that is incorrectly encoded.`. This is marked as a todo.

Let me know what you think! I think it's a valuable "unit" test for each of the panic codes.