### PR TITLE
Cleanup GHC2021 standard extensions

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -2,15 +2,8 @@
 
 {-# Language CPP #-}
 {-# Language DataKinds #-}
-{-# Language StandaloneDeriving #-}
 {-# Language DeriveAnyClass #-}
-{-# Language FlexibleInstances #-}
-{-# Language DeriveGeneric #-}
 {-# Language GADTs #-}
-{-# Language LambdaCase #-}
-{-# Language OverloadedStrings #-}
-{-# Language TypeOperators #-}
-{-# Language RecordWildCards #-}
 
 module Main where
 

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -28,7 +28,33 @@ data-files:
 extra-source-files:
   CHANGELOG.md
 
+common shared
+  default-extensions:
+    LambdaCase
+    OverloadedStrings
+    RecordWildCards
+    TypeFamilies
+    ViewPatterns
+    -- GHC2021 default extensions, remove me when GHC is updated to 9.2
+    BangPatterns
+    ConstraintKinds
+    DeriveDataTypeable
+    DeriveFunctor
+    DeriveGeneric
+    DoAndIfThenElse
+    EmptyDataDecls
+    FlexibleContexts
+    FlexibleInstances
+    ForeignFunctionInterface
+    GeneralizedNewtypeDeriving
+    PolyKinds
+    RankNTypes
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeOperators
+
 library
+  import: shared
   exposed-modules:
     EVM,
     EVM.ABI,
@@ -132,24 +158,9 @@ library
     tuple                             >= 0.3.0.2 && < 0.4,
   hs-source-dirs:
     src
-  default-language:
-    Haskell2010
-  default-extensions:
-    BangPatterns,
-    DeriveDataTypeable,
-    DeriveGeneric,
-    FlexibleContexts,
-    GeneralizedNewtypeDeriving,
-    LambdaCase,
-    OverloadedStrings,
-    Rank2Types,
-    RecordWildCards,
-    TypeFamilies,
-    ViewPatterns
 
 executable hevm
-  default-language:
-    Haskell2010
+  import: shared
   hs-source-dirs:
     hevm-cli
   main-is:
@@ -198,8 +209,7 @@ executable hevm
     vty
 
 test-suite test
-  default-language:
-    Haskell2010
+  import: shared
   ghc-options:
     -Wall
   type:

--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1,15 +1,8 @@
 {-# Language ImplicitParams #-}
-{-# Language ConstraintKinds #-}
-{-# Language FlexibleInstances #-}
 {-# Language DataKinds #-}
 {-# Language GADTs #-}
-{-# Language RecordWildCards #-}
-{-# Language ScopedTypeVariables #-}
-{-# Language StandaloneDeriving #-}
 {-# Language StrictData #-}
 {-# Language TemplateHaskell #-}
-{-# Language TypeOperators #-}
-{-# Language ViewPatterns #-}
 
 module EVM where
 

--- a/src/hevm/src/EVM/Concrete.hs
+++ b/src/hevm/src/EVM/Concrete.hs
@@ -1,4 +1,3 @@
-{-# Language FlexibleInstances #-}
 {-# Language StrictData #-}
 
 module EVM.Concrete where

--- a/src/hevm/src/EVM/Dapp.hs
+++ b/src/hevm/src/EVM/Dapp.hs
@@ -1,5 +1,4 @@
 {-# Language TemplateHaskell #-}
-{-# Language OverloadedStrings #-}
 
 module EVM.Dapp where
 

--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -1,5 +1,4 @@
 {-# Language DataKinds #-}
-{-# Language FlexibleInstances #-}
 
 {-|
    Helper functions for working with Expr instances.

--- a/src/hevm/src/EVM/Facts.hs
+++ b/src/hevm/src/EVM/Facts.hs
@@ -1,11 +1,7 @@
 {-# Language PartialTypeSignatures #-}
 {-# Language DataKinds #-}
-{-# Language FlexibleInstances #-}
 {-# Language ExtendedDefaultRules #-}
 {-# Language PatternSynonyms #-}
-{-# Language RecordWildCards #-}
-{-# Language ScopedTypeVariables #-}
-{-# Language ViewPatterns #-}
 
 -- Converts between Ethereum contract states and simple trees of
 -- texts.  Dumps and loads such trees as Git repositories (the state

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -1,7 +1,5 @@
 {-# Language GADTs #-}
 {-# Language DataKinds #-}
-{-# Language StandaloneDeriving #-}
-{-# Language LambdaCase #-}
 
 module EVM.Fetch where
 

--- a/src/hevm/src/EVM/Patricia.hs
+++ b/src/hevm/src/EVM/Patricia.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE FlexibleInstances #-}
-
 module EVM.Patricia where
 
 import EVM.RLP

--- a/src/hevm/src/EVM/Precompiled.hs
+++ b/src/hevm/src/EVM/Precompiled.hs
@@ -1,5 +1,3 @@
-{-# Language ForeignFunctionInterface #-}
-
 module EVM.Precompiled (execute) where
 
 import Data.ByteString (ByteString)

--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -1,9 +1,6 @@
 {-# Language DataKinds #-}
 {-# Language GADTs #-}
-{-# Language PolyKinds #-}
-{-# Language ScopedTypeVariables #-}
 {-# Language TypeApplications #-}
-{-# Language LambdaCase #-}
 {-# Language QuasiQuotes #-}
 
 {- |

--- a/src/hevm/src/EVM/Solidity.hs
+++ b/src/hevm/src/EVM/Solidity.hs
@@ -2,7 +2,6 @@
 {-# Language DataKinds #-}
 {-# Language StrictData #-}
 {-# Language TemplateHaskell #-}
-{-# Language OverloadedStrings #-}
 {-# Language QuasiQuotes #-}
 
 module EVM.Solidity

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -1,5 +1,4 @@
 {-# Language DataKinds #-}
-{-# Language OverloadedStrings #-}
 
 module EVM.SymExec where
 

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -1,13 +1,9 @@
 {-# Language CPP #-}
 {-# Language TemplateHaskell #-}
 {-# Language TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module EVM.Types where
 

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -1,4 +1,3 @@
-{-# Language LambdaCase #-}
 {-# Language DataKinds #-}
 {-# Language ImplicitParams #-}
 

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -1,13 +1,6 @@
-{-# Language OverloadedStrings #-}
 {-# Language GADTs #-}
-{-# Language ViewPatterns #-}
-{-# Language ScopedTypeVariables #-}
-{-# Language LambdaCase #-}
 {-# Language QuasiQuotes #-}
-{-# Language FlexibleInstances #-}
-{-# Language GeneralizedNewtypeDeriving #-}
 {-# Language DataKinds #-}
-{-# Language StandaloneDeriving #-}
 
 module Main where
 


### PR DESCRIPTION
## Description
Starting from GHC 9.2 (we're currently at 9.0.2) the `GHC2021` standard is the default that includes a number of extensions (https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/control.html#extension-GHC2021). This PR lists the subset used by hevm in `hevm.cabal` and removes them from files.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
