### PR TITLE
fix bugs in readByte and indexWord

### DIFF
--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -173,14 +173,14 @@ readByte (Lit x) (ConcreteBuf b)
     then LitByte (BS.index b (num x))
     else LitByte 0x0
 readByte i@(Lit x) (WriteByte (Lit idx) val src)
-  = if num x == idx
+  = if x == idx
     then val
     else readByte i src
 readByte i@(Lit x) (WriteWord (Lit idx) val src)
-  = if num x <= idx && idx < num (x + 8)
+  = if idx <= x && x <= idx + 31
     then case val of
-           (Lit _) -> indexWord i val
-           _ -> IndexWord (Lit $ idx - num x) val
+           (Lit _) -> indexWord (Lit $ x - idx) val
+           _ -> IndexWord (Lit $ x - idx) val
     else readByte i src
 readByte i@(Lit x) (CopySlice (Lit dstOffset) (Lit srcOffset) (Lit size) src dst)
   = if dstOffset <= num x && num x < (dstOffset + size)
@@ -480,7 +480,7 @@ isLitByte _ = False
 
 -- | Returns the byte at idx from the given word.
 indexWord :: Expr EWord -> Expr EWord -> Expr Byte
-indexWord (Lit idx) (Lit w) = LitByte . fromIntegral $ shiftR w (num idx * 8)
+indexWord (Lit idx) (Lit w) = LitByte . fromIntegral $ shiftR w (248 - num idx * 8)
 indexWord (Lit idx) (JoinBytes zero        one        two       three
                                four        five       six       seven
                                eight       nine       ten       eleven

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -54,7 +54,61 @@ runSubSet p = defaultMain . applyPattern p $ tests
 
 tests :: TestTree
 tests = testGroup "hevm"
-  [ testGroup "ABI"
+  [ testGroup "MemoryTests"
+    [ testCase "read-write-same-byte"  $ assertEqual ""
+        (LitByte 0x12)
+        (Expr.readByte (Lit 0x20) (WriteByte (Lit 0x20) (LitByte 0x12) EmptyBuf))
+    , testCase "read-write-same-word"  $ assertEqual ""
+        (Lit 0x12)
+        (Expr.readWord (Lit 0x20) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf))
+    , testCase "read-byte-write-word"  $ assertEqual ""
+        -- reading at byte 31 a word that's been written should return LSB
+        (LitByte 0x12)
+        (Expr.readByte (Lit 0x1f) (WriteWord (Lit 0x0) (Lit 0x12) EmptyBuf))
+    , testCase "read-byte-write-word2"  $ assertEqual ""
+        -- Same as above, but offset not 0
+        (LitByte 0x12)
+        (Expr.readByte (Lit 0x20) (WriteWord (Lit 0x1) (Lit 0x12) EmptyBuf))
+    ,testCase "read-write-with-offset"  $ assertEqual ""
+        -- 0x3F = 63 decimal, 0x20 = 32. 0x12 = 18
+        --    We write 128bits (32 Bytes), representing 18 at offset 32.
+        --    Hence, when reading out the 63rd byte, we should read out the LSB 8 bits
+        --           which is 0x12
+        (LitByte 0x12)
+        (Expr.readByte (Lit 0x3F) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf))
+    ,testCase "read-write-with-offset2"  $ assertEqual ""
+        --  0x20 = 32, 0x3D = 61
+        --  we write 128 bits (32 Bytes) representing 0x10012, at offset 32.
+        --  we then read out a byte at offset 61.
+        --  So, at 63 we'd read 0x12, at 62 we'd read 0x00, at 61 we should read 0x1
+        (LitByte 0x1)
+        (Expr.readByte (Lit 0x3D) (WriteWord (Lit 0x20) (Lit 0x10012) EmptyBuf))
+    , testCase "read-write-with-extension-to-zero" $ assertEqual ""
+        -- write word and read it at the same place (i.e. 0 offset)
+        (Lit 0x12)
+        (Expr.readWord (Lit 0x0) (WriteWord (Lit 0x0) (Lit 0x12) EmptyBuf))
+    , testCase "read-write-with-extension-to-zero-with-offset" $ assertEqual ""
+        -- write word and read it at the same offset of 4
+        (Lit 0x12)
+        (Expr.readWord (Lit 0x4) (WriteWord (Lit 0x4) (Lit 0x12) EmptyBuf))
+    , testCase "read-write-with-extension-to-zero-with-offset2" $ assertEqual ""
+        -- write word and read it at the same offset of 16
+        (Lit 0x12)
+        (Expr.readWord (Lit 0x20) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf))
+    , testCase "indexword-MSB" $ assertEqual ""
+        -- 31st is the LSB byte (of 32)
+        (LitByte 0x78)
+        (Expr.indexWord (Lit 31) (Lit 0x12345678))
+    , testCase "indexword-LSB" $ assertEqual ""
+        -- 0th is the MSB byte (of 32), Lit 0xff22bb... is exactly 32 Bytes.
+        (LitByte 0xff)
+        (Expr.indexWord (Lit 0) (Lit 0xff22bb4455667788990011223344556677889900112233445566778899001122))
+    , testCase "indexword-LSB2" $ assertEqual ""
+        -- same as above, but with offset 2
+        (LitByte 0xbb)
+        (Expr.indexWord (Lit 2) (Lit 0xff22bb4455667788990011223344556677889900112233445566778899001122))
+    ]
+  , testGroup "ABI"
     [ testProperty "Put/get inverse" $ \x ->
         case runGetOrFail (getAbi (abiValueType x)) (runPut (putAbi x)) of
           Right ("", _, x') -> x' == x

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -666,7 +666,7 @@ tests = testGroup "hevm"
           (Qed res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (length res) <> " paths" -}
         ,
-        expectFail $ testCase "injectivity of keccak (32 bytes)" $ do
+        testCase "injectivity of keccak (32 bytes)" $ do
           Just c <- solcRuntime "A"
             [i|
             contract A {


### PR DESCRIPTION
Fixes what I think are bugs in the implementation of `readByte` and `indexWord`.

Previously, `readByte` and `readWord`, which uses `writeByte`, would return spurious results. 

```
ghci> readByte (Lit 0x20) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf)
LitByte 0
ghci> readByte (Lit 0x3F) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf)
LitByte 0
ghci> readByte (Lit 0x3D) (WriteWord (Lit 0x20) (Lit 0x10012) EmptyBuf)
LitByte 0

ghci> readWord (Lit 0x0) (WriteWord (Lit 0x0) (Lit 0x12) EmptyBuf)
Lit 0x1200000000000000000000000000000000000000000000000000000000000000
ghci> readWord (Lit 0x4) (WriteWord (Lit 0x4) (Lit 0x12) EmptyBuf)
Lit 0x0
ghci> readWord (Lit 0x20) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf)
Lit 0x0
```

After these fixes the results seem correct

```
ghci> readByte (Lit 0x20) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf)
LitByte 0
ghci> readByte (Lit 0x3F) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf)
LitByte 18
ghci> readByte (Lit 0x3D) (WriteWord (Lit 0x20) (Lit 0x10012) EmptyBuf)
LitByte 1

ghci> readWord (Lit 0x0) (WriteWord (Lit 0x0) (Lit 0x12) EmptyBuf)
Lit 0x12
ghci> readWord (Lit 0x4) (WriteWord (Lit 0x4) (Lit 0x12) EmptyBuf)
Lit 0x12
ghci> readWord (Lit 0x20) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf)
Lit 0x12
```


### indexWord
Previously, `indexWord` was assuming that the 0th byte was the lower order byte.  But, in the current storage model the 0th byte in the highest order byte. 
 
 Changed this
`indexWord (Lit idx) (Lit w) = LitByte . fromIntegral $ shiftR w (num idx * 8)`
to
`indexWord (Lit idx) (Lit w) = LitByte . fromIntegral $ shiftR w (248 - num idx * 8)`


### readByte
`readByte` of a `WriteWord` was doing the following 

```
readByte i@(Lit x) (WriteWord (Lit idx) val src)
  = if num x <= idx && idx < num (x + 8)
    then case val of
           (Lit _) -> indexWord i val
           _ -> IndexWord (Lit $ idx - num x) val
```
I think `x` and `idx` are mixed up in the above code since `x` is the index of the byte we want to read and `idx` the index of the word in the buffer. Also, since the length of the word is 32 bytes, 8 should be 32. Lastly, the first `indexWord` is using the index of the offset of the byte in the buffer not the offset of the byte in the value, which is already at some offset `idx`

Now changed to:

```
readByte i@(Lit x) (WriteWord (Lit idx) val src)
  = if idx <= x && x <= idx + 31
    then case val of
           (Lit _) -> indexWord (Lit $ x - idx) val
           _ -> IndexWord (Lit $ x - idx) val
```













