### PR TITLE
Performance: BA.unpack -> BA.convert

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -1409,7 +1409,7 @@ executePrecompile preCompileAddr gasCap inOffset inSize outOffset outSize xs  = 
         0x2 ->
           let
             hash = case input of
-                     ConcreteBuf input' -> ConcreteBuf $ BS.pack $ BA.unpack (Crypto.hash input' :: Digest SHA256)
+                     ConcreteBuf input' -> ConcreteBuf $ BA.convert (Crypto.hash input' :: Digest SHA256)
                      _ -> WriteWord (Lit 0) (SHA256 input) EmptyBuf
           in do
             assign (state . stack) (Lit 1 : xs)
@@ -1424,7 +1424,7 @@ executePrecompile preCompileAddr gasCap inOffset inSize outOffset outSize xs  = 
 
           let
             padding = BS.pack $ replicate 12 0
-            hash' = BS.pack $ BA.unpack (Crypto.hash input' :: Digest RIPEMD160)
+            hash' = BA.convert (Crypto.hash input' :: Digest RIPEMD160)
             hash  = ConcreteBuf $ padding <> hash'
           in do
             assign (state . stack) (Lit 1 : xs)

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -1088,8 +1088,7 @@ packNibbles _ = error "can't pack odd number of nibbles"
 keccakBytes :: ByteString -> ByteString
 keccakBytes =
   (hash :: ByteString -> Digest Keccak_256)
-    >>> BA.unpack
-    >>> BS.pack
+    >>> BA.convert
 
 word32 :: [Word8] -> Word32
 word32 xs = sum [ fromIntegral x `shiftL` (8*n)


### PR DESCRIPTION
## Description
I was doing some profiling on Echidna and found `BA.unpack` to leak memory. This doesn't happen with `BA.convert`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
