### PR TITLE
Enable more tests

### DIFF
--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -173,14 +173,14 @@ readByte (Lit x) (ConcreteBuf b)
     then LitByte (BS.index b (num x))
     else LitByte 0x0
 readByte i@(Lit x) (WriteByte (Lit idx) val src)
-  = if num x == idx
+  = if x == idx
     then val
     else readByte i src
 readByte i@(Lit x) (WriteWord (Lit idx) val src)
-  = if num x <= idx && idx < num (x + 8)
+  = if idx <= x && x <= idx + 31
     then case val of
-           (Lit _) -> indexWord i val
-           _ -> IndexWord (Lit $ idx - num x) val
+           (Lit _) -> indexWord (Lit $ x - idx) val
+           _ -> IndexWord (Lit $ x - idx) val
     else readByte i src
 readByte i@(Lit x) (CopySlice (Lit dstOffset) (Lit srcOffset) (Lit size) src dst)
   = if dstOffset <= num x && num x < (dstOffset + size)
@@ -480,7 +480,7 @@ isLitByte _ = False
 
 -- | Returns the byte at idx from the given word.
 indexWord :: Expr EWord -> Expr EWord -> Expr Byte
-indexWord (Lit idx) (Lit w) = LitByte . fromIntegral $ shiftR w (num idx * 8)
+indexWord (Lit idx) (Lit w) = LitByte . fromIntegral $ shiftR w (248 - num idx * 8)
 indexWord (Lit idx) (JoinBytes zero        one        two       three
                                four        five       six       seven
                                eight       nine       ten       eleven

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -754,7 +754,7 @@ tests = testGroup "hevm"
           [Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("call_A()", [])) []
           putStrLn "expected counterexample found"
         ,
-        expectFail $ testCase "keccak concrete and sym agree" $ do
+        testCase "keccak concrete and sym agree" $ do
           Just c <- solcRuntime "C"
             [i|
               contract C {
@@ -767,7 +767,6 @@ tests = testGroup "hevm"
             |]
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("kecc(uint256)", [AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
-
         ,
         ignoreTest $ testCase "safemath distributivity (yul)" $ do
           let yulsafeDistributivity = hex "6355a79a6260003560e01c14156016576015601f565b5b60006000fd60a1565b603d602d604435600435607c565b6039602435600435607c565b605d565b6052604b604435602435605d565b600435607c565b141515605a57fe5b5b565b6000828201821115151560705760006000fd5b82820190505b92915050565b6000818384048302146000841417151560955760006000fd5b82820290505b92915050565b"

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -54,7 +54,61 @@ runSubSet p = defaultMain . applyPattern p $ tests
 
 tests :: TestTree
 tests = testGroup "hevm"
-  [ testGroup "ABI"
+  [ testGroup "MemoryTests"
+    [ testCase "read-write-same-byte"  $ assertEqual ""
+        (LitByte 0x12)
+        (Expr.readByte (Lit 0x20) (WriteByte (Lit 0x20) (LitByte 0x12) EmptyBuf))
+    , testCase "read-write-same-word"  $ assertEqual ""
+        (Lit 0x12)
+        (Expr.readWord (Lit 0x20) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf))
+    , testCase "read-byte-write-word"  $ assertEqual ""
+        -- reading at byte 31 a word that's been written should return LSB
+        (LitByte 0x12)
+        (Expr.readByte (Lit 0x1f) (WriteWord (Lit 0x0) (Lit 0x12) EmptyBuf))
+    , testCase "read-byte-write-word2"  $ assertEqual ""
+        -- Same as above, but offset not 0
+        (LitByte 0x12)
+        (Expr.readByte (Lit 0x20) (WriteWord (Lit 0x1) (Lit 0x12) EmptyBuf))
+    ,testCase "read-write-with-offset"  $ assertEqual ""
+        -- 0x3F = 63 decimal, 0x20 = 32. 0x12 = 18
+        --    We write 128bits (32 Bytes), representing 18 at offset 32.
+        --    Hence, when reading out the 63rd byte, we should read out the LSB 8 bits
+        --           which is 0x12
+        (LitByte 0x12)
+        (Expr.readByte (Lit 0x3F) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf))
+    ,testCase "read-write-with-offset2"  $ assertEqual ""
+        --  0x20 = 32, 0x3D = 61
+        --  we write 128 bits (32 Bytes) representing 0x10012, at offset 32.
+        --  we then read out a byte at offset 61.
+        --  So, at 63 we'd read 0x12, at 62 we'd read 0x00, at 61 we should read 0x1
+        (LitByte 0x1)
+        (Expr.readByte (Lit 0x3D) (WriteWord (Lit 0x20) (Lit 0x10012) EmptyBuf))
+    , testCase "read-write-with-extension-to-zero" $ assertEqual ""
+        -- write word and read it at the same place (i.e. 0 offset)
+        (Lit 0x12)
+        (Expr.readWord (Lit 0x0) (WriteWord (Lit 0x0) (Lit 0x12) EmptyBuf))
+    , testCase "read-write-with-extension-to-zero-with-offset" $ assertEqual ""
+        -- write word and read it at the same offset of 4
+        (Lit 0x12)
+        (Expr.readWord (Lit 0x4) (WriteWord (Lit 0x4) (Lit 0x12) EmptyBuf))
+    , testCase "read-write-with-extension-to-zero-with-offset2" $ assertEqual ""
+        -- write word and read it at the same offset of 16
+        (Lit 0x12)
+        (Expr.readWord (Lit 0x20) (WriteWord (Lit 0x20) (Lit 0x12) EmptyBuf))
+    , testCase "indexword-MSB" $ assertEqual ""
+        -- 31st is the LSB byte (of 32)
+        (LitByte 0x78)
+        (Expr.indexWord (Lit 31) (Lit 0x12345678))
+    , testCase "indexword-LSB" $ assertEqual ""
+        -- 0th is the MSB byte (of 32), Lit 0xff22bb... is exactly 32 Bytes.
+        (LitByte 0xff)
+        (Expr.indexWord (Lit 0) (Lit 0xff22bb4455667788990011223344556677889900112233445566778899001122))
+    , testCase "indexword-LSB2" $ assertEqual ""
+        -- same as above, but with offset 2
+        (LitByte 0xbb)
+        (Expr.indexWord (Lit 2) (Lit 0xff22bb4455667788990011223344556677889900112233445566778899001122))
+    ]
+  , testGroup "ABI"
     [ testProperty "Put/get inverse" $ \x ->
         case runGetOrFail (getAbi (abiValueType x)) (runPut (putAbi x)) of
           Right ("", _, x') -> x' == x

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -666,7 +666,7 @@ tests = testGroup "hevm"
           (Qed res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
           putStrLn $ "successfully explored: " <> show (length res) <> " paths" -}
         ,
-        expectFail $ testCase "injectivity of keccak (32 bytes)" $ do
+        testCase "injectivity of keccak (32 bytes)" $ do
           Just c <- solcRuntime "A"
             [i|
             contract A {

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -589,29 +589,6 @@ tests = testGroup "hevm"
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         {-
         ,
-        -- TODO: CVC5 is not installed by nix, disabling
-        testCase "Deposit contract loop (cvc5)" $ do
-          Just c <- solcRuntime "Deposit"
-            [i|
-            contract Deposit {
-              function deposit(uint256 deposit_count) external pure {
-                require(deposit_count < 2**32 - 1);
-                ++deposit_count;
-                bool found = false;
-                for (uint height = 0; height < 32; height++) {
-                  if ((deposit_count & 1) == 1) {
-                    found = true;
-                    break;
-                  }
-                 deposit_count = deposit_count >> 1;
-                 }
-                assert(found);
-              }
-             }
-            |]
-          [Qed res] <- withSolvers CVC5 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) []
-          putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
-        ,
         -- TODO: this is supposed to return a Cex but instead returns a Qed
         testCase "Deposit contract loop (error version)" $ do
           Just c <- solcRuntime "Deposit"
@@ -652,19 +629,6 @@ tests = testGroup "hevm"
             |]
           [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c Nothing []
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
-{-      ,
-
-        testCase "injectivity of keccak (32 bytes)" $ do
-          Just c <- solcRuntime "A"
-            [i|
-            contract A {
-              function f(uint x, uint y) public pure {
-                if (keccak256(abi.encodePacked(x)) == keccak256(abi.encodePacked(y))) assert(x == y);
-              }
-            }
-            |]
-          (Qed res, _) <- runSMTWith cvc4 $ query $ checkAssert defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) []
-          putStrLn $ "successfully explored: " <> show (length res) <> " paths" -}
         ,
         testCase "injectivity of keccak (32 bytes)" $ do
           Just c <- solcRuntime "A"


### PR DESCRIPTION
This enables all remaining commented tests, modulo the  Equivalence checking testing group. Most of the tests don't work so they require `expectFailure`.  The code that is inspecting counterexamples in few tests is still commented out since we don't have proper cex parsing yet. 

Also, tests that are duplicates for different solvers are deleted, since we plan to run tests with multiple solvers later.