### PR TITLE
Removing function that's superfluous

### DIFF
--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -224,13 +224,13 @@ type Fetcher = EVM.Query -> IO (EVM ())
 -- will be pruned anyway.
 checkBranch :: SolverGroup -> Prop -> Prop -> IO EVM.BranchCondition
 checkBranch solvers branchcondition pathconditions = do
-  checkSat' solvers (assertProp (branchcondition .&& pathconditions), []) >>= \case
+  checkSat' solvers (assertProps [(branchcondition .&& pathconditions)], []) >>= \case
      -- the condition is unsatisfiable
      Unsat -> -- if pathconditions are consistent then the condition must be false
             return $ EVM.Case False
      -- Sat means its possible for condition to hold
      Sat _ -> -- is its negation also possible?
-            checkSat' solvers (assertProp (pathconditions .&& (PNeg branchcondition)), []) >>= \case
+            checkSat' solvers (assertProps [(pathconditions .&& (PNeg branchcondition))], []) >>= \case
                -- No. The condition must hold
                Unsat -> return $ EVM.Case True
                -- Yes. Both branches possible

--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -84,20 +84,6 @@ assertWords es = flip evalState initState $ do
        <> SMT2 [""]
        <> (SMT2 $ fmap (\e -> "(assert (= " <> e `sp` one <> "))") encs)
 
-assertProp :: Prop -> SMT2
-assertProp p = flip evalState initState $ do
-  enc <- propToSMT p
-  intermediates <- declareIntermediates
-  pure $ prelude
-       <> (declareBufs . referencedBufs' $ p)
-       <> SMT2 [""]
-       <> (declareVars . referencedVars' $ p)
-       <> SMT2 [""]
-       <> (declareFrameContext . referencedFrameContext' $ p)
-       <> intermediates
-       <> SMT2 [""]
-       <> SMT2 ["(assert " <> enc <> ")"]
-
 assertProps :: [Prop] -> SMT2
 assertProps ps = flip evalState initState $ do
   encs <- mapM propToSMT ps


### PR DESCRIPTION
## Description

Removes a superfluous function, `assertProp a`, as it can be simulated with `assertProps [a]`. This removes duplication of relatively complicated code.