### PR TITLE
Let's add `tags` to .gitignore

### DIFF
--- a/src/hevm/.gitignore
+++ b/src/hevm/.gitignore
@@ -4,3 +4,4 @@ dist-newstyle/
 cabal.project.local*
 .stack-work/
 tests/
+tags


### PR DESCRIPTION
## Description
This is useful for me, as it also bans ripgrep from looking at the `tags` file. Unfortunately, the Haskell Language Server is not reliable enough when editing code, so I need to use ripgrep & ctags to navigate code.
