### PR TITLE
IDX cannot be larger than 31 here, make it undefined

### DIFF
--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -521,7 +521,7 @@ indexWord (Lit idx) (JoinBytes zero        one        two       three
   | idx == 29 = twentynine
   | idx == 30 = thirty
   | idx == 31 = thirtyone
-  | otherwise = LitByte 0
+  | otherwise = undefined
 indexWord idx w = IndexWord idx w
 
 

--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -521,7 +521,7 @@ indexWord (Lit idx) (JoinBytes zero        one        two       three
   | idx == 29 = twentynine
   | idx == 30 = thirty
   | idx == 31 = thirtyone
-  | otherwise = undefined
+  | otherwise = error $ "Internal error: idx must be <= 31 (actual: " <> (show . num $ idx) <> ")"
 indexWord idx w = IndexWord idx w
 
 


### PR DESCRIPTION
## Description
Since `idx` should never be more than 31 here, let's make it `undefined`, so we get an error in case of some problems.