### PR TITLE
Minor typo in safemath 

### DIFF
--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -842,8 +842,8 @@ tests = testGroup "hevm"
           [Qed _] <-  withSolvers Z3 1 $ \s -> verify s vm Nothing Nothing Nothing (Just $ checkAssertions defaultPanicCodes)
           putStrLn "Proven"
         ,
-        expectFail $ testCase "safemath distributivity (sol)" $ do
-          Just c <- solcRuntime "A"
+        testCase "safemath distributivity (sol)" $ do
+          Just c <- solcRuntime "C"
             [i|
               contract C {
                 function distributivity(uint x, uint y, uint z) public {


### PR DESCRIPTION
Fixed contract name in safemath test and now the test passes. On a side note, the test takes a lot of time to prove (~85'' in my computer) and the expr IR has 46 branches.