### PR TITLE
Fix part of the State space leak

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2491,8 +2491,7 @@ readMemory offset size vm = copySlice offset (Lit 0) size (view (state . memory)
 
 -- * Tracing
 
-withTraceLocation
-  :: (MonadState VM m) => TraceData -> m Trace
+withTraceLocation :: TraceData -> EVM Trace
 withTraceLocation x = do
   vm <- get
   let this = fromJust $ currentContract vm
@@ -2530,7 +2529,7 @@ zipperRootForest z =
 traceForest :: VM -> Forest Trace
 traceForest = view (traces . to zipperRootForest)
 
-traceTopLog :: (MonadState VM m) => [Expr Log] -> m ()
+traceTopLog :: [Expr Log] -> EVM ()
 traceTopLog [] = noop
 traceTopLog ((LogEntry addr bytes topics) : _) = do
   trace <- withTraceLocation (EventTrace addr bytes topics)

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -47,16 +47,16 @@ vmForEthrunCreation creationCode =
 
 exec :: State VM VMResult
 exec = do
-  () <- exec1
   vm <- get
-  maybe exec pure (view result vm)
+  case view result vm of
+    Nothing -> exec1 >> exec
+    Just r -> pure r
 
 run :: State VM VM
 run = do
-  () <- exec1
   vm <- get
   case view result vm of
-    Nothing -> run
+    Nothing -> exec1 >> run
     Just _ -> pure vm
 
 execWhile :: (VM -> Bool) -> State VM Int

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -8,12 +8,10 @@ import EVM.Expr (litAddr)
 import qualified EVM.FeeSchedule as FeeSchedule
 
 import Control.Lens
-import Control.Monad.State.Class (MonadState)
-import Control.Monad.State.Strict (runState)
+import Control.Monad.Trans.State.Strict (get, State)
 import Data.ByteString (ByteString)
 import Data.Maybe (isNothing)
 
-import qualified Control.Monad.State.Class as State
 
 ethrunAddress :: Addr
 ethrunAddress = Addr 0x00a329c0648769a73afac7f9381e08fb43dbea72
@@ -47,26 +45,27 @@ vmForEthrunCreation creationCode =
     }) & set (env . contracts . at ethrunAddress)
              (Just (initialContract (RuntimeCode (ConcreteRuntimeCode ""))))
 
-exec :: MonadState VM m => m VMResult
-exec =
-  use EVM.result >>= \case
-    Nothing -> State.state (runState exec1) >> exec
-    Just x  -> return x
+exec :: State VM VMResult
+exec = do
+  () <- exec1
+  vm <- get
+  maybe exec pure (view result vm)
 
-run :: MonadState VM m => m VM
-run =
-  use EVM.result >>= \case
-    Nothing -> State.state (runState exec1) >> run
-    Just _  -> State.get
+run :: State VM VM
+run = do
+  () <- exec1
+  vm <- get
+  case view result vm of
+    Nothing -> run
+    Just _ -> pure vm
 
-execWhile :: MonadState VM m => (VM -> Bool) -> m Int
+execWhile :: (VM -> Bool) -> State VM Int
 execWhile p = go 0
   where
     go i = do
-      x <- State.get
-      if p x && isNothing (view result x)
+      vm <- get
+      if p vm && isNothing (view result vm)
         then do
-          State.state (runState exec1)
           go $! (i + 1)
       else
-        return i
+        pure i

--- a/src/EVM/Stepper.hs
+++ b/src/EVM/Stepper.hs
@@ -133,9 +133,9 @@ interpret fetcher =
     eval (action :>>= k) =
       case action of
         Exec ->
-          EVM.Exec.exec >>= interpret fetcher . k
+          (State.state . runState) EVM.Exec.exec >>= interpret fetcher . k
         Run ->
-          EVM.Exec.run >>= interpret fetcher . k
+          (State.state . runState) EVM.Exec.run >>= interpret fetcher . k
         Wait q ->
           do m <- liftIO (fetcher q)
              State.state (runState m) >> interpret fetcher (k ())

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -232,9 +232,9 @@ interpret fetcher maxIter askSmtIters =
     eval (action Operational.:>>= k) =
       case action of
         Stepper.Exec ->
-          exec >>= interpret fetcher maxIter askSmtIters . k
+          (State.state . runState) exec >>= interpret fetcher maxIter askSmtIters . k
         Stepper.Run ->
-          run >>= interpret fetcher maxIter askSmtIters . k
+          (State.state . runState) run >>= interpret fetcher maxIter askSmtIters . k
         Stepper.IOAct q ->
           mapStateT liftIO q >>= interpret fetcher maxIter askSmtIters . k
         Stepper.Ask (EVM.PleaseChoosePath cond continue) -> do

--- a/test/BlockchainTests.hs
+++ b/test/BlockchainTests.hs
@@ -115,7 +115,23 @@ commonProblematicTests = Map.fromList
   ]
 
 ciProblematicTests :: Map String (TestTree -> TestTree)
-ciProblematicTests = Map.empty
+ciProblematicTests = Map.fromList
+  [ ("Return50000_d0g1v0_London", ignoreTest)
+  , ("Return50000_2_d0g1v0_London", ignoreTest)
+  , ("randomStatetest177_d0g0v0_London", ignoreTest)
+  , ("static_Call50000_d0g0v0_London", ignoreTest)
+  , ("static_Call50000_d1g0v0_London", ignoreTest)
+  , ("static_Call50000bytesContract50_1_d1g0v0_London", ignoreTest)
+  , ("static_Call50000bytesContract50_2_d1g0v0_London", ignoreTest)
+  , ("static_Return50000_2_d0g0v0_London", ignoreTest)
+  , ("loopExp_d10g0v0_London", ignoreTest)
+  , ("loopExp_d11g0v0_London", ignoreTest)
+  , ("loopExp_d12g0v0_London", ignoreTest)
+  , ("loopExp_d13g0v0_London", ignoreTest)
+  , ("loopExp_d14g0v0_London", ignoreTest)
+  , ("loopExp_d8g0v0_London", ignoreTest)
+  , ("loopExp_d9g0v0_London", ignoreTest)
+  ]
 
 runVMTest :: Bool -> (String, Case) -> IO ()
 runVMTest diffmode (_name, x) =

--- a/test/BlockchainTests.hs
+++ b/test/BlockchainTests.hs
@@ -119,23 +119,7 @@ commonProblematicTests = Map.fromList
   ]
 
 ciProblematicTests :: Map String (TestTree -> TestTree)
-ciProblematicTests = Map.fromList
-  [ ("Return50000_d0g1v0_London", ignoreTest)
-  , ("Return50000_2_d0g1v0_London", ignoreTest)
-  , ("randomStatetest177_d0g0v0_London", ignoreTest)
-  , ("static_Call50000_d0g0v0_London", ignoreTest)
-  , ("static_Call50000_d1g0v0_London", ignoreTest)
-  , ("static_Call50000bytesContract50_1_d1g0v0_London", ignoreTest)
-  , ("static_Call50000bytesContract50_2_d1g0v0_London", ignoreTest)
-  , ("static_Return50000_2_d0g0v0_London", ignoreTest)
-  , ("loopExp_d10g0v0_London", ignoreTest)
-  , ("loopExp_d11g0v0_London", ignoreTest)
-  , ("loopExp_d12g0v0_London", ignoreTest)
-  , ("loopExp_d13g0v0_London", ignoreTest)
-  , ("loopExp_d14g0v0_London", ignoreTest)
-  , ("loopExp_d8g0v0_London", ignoreTest)
-  , ("loopExp_d9g0v0_London", ignoreTest)
-  ]
+ciProblematicTests = Map.empty
 
 runVMTest :: Bool -> (String, Case) -> IO ()
 runVMTest diffmode (_name, x) =

--- a/test/BlockchainTests.hs
+++ b/test/BlockchainTests.hs
@@ -104,11 +104,7 @@ testsFromFile file problematicTests = do
 
 -- CI has issues with some heaver tests, disable in bulk
 ciIgnoredFiles :: [String]
-ciIgnoredFiles =
-  [ "BlockchainTests/GeneralStateTests/VMTests/vmPerformance"
-  , "BlockchainTests/GeneralStateTests/stQuadraticComplexityTest"
-  , "BlockchainTests/GeneralStateTests/stStaticCall"
-  ]
+ciIgnoredFiles = []
 
 commonProblematicTests :: Map String (TestTree -> TestTree)
 commonProblematicTests = Map.fromList


### PR DESCRIPTION
## Description
This fixes part of the space leak that happens inside State. For the test `loopMul_d2g0v0_London` the time went down from 98s to 73s (34% improvement) on my machine.

Before:
```
 181,446,033,696 bytes allocated in the heap
  50,253,045,752 bytes copied during GC
  14,248,185,032 bytes maximum residency (20 sample(s))
   1,510,627,312 bytes maximum slop
           30034 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     177075 colls, 177075 par   635.130s  24.324s     0.0001s    0.0221s
  Gen  1        20 colls,    19 par   2313.280s  100.571s     5.0285s    35.6827s

  Parallel GC work balance: 0.38% (serial 0%, perfect 100%)

  TASKS: 50 (1 bound, 49 peak workers (49 total), using -N24)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.004s  (  0.011s elapsed)
  MUT     time  221.051s  ( 75.926s elapsed)
  GC      time  2948.410s  (124.895s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    0.000s  (  0.000s elapsed)
  EXIT    time    0.007s  (  0.002s elapsed)
  Total   time  3169.472s  (200.833s elapsed)

  Alloc rate    820,831,648 bytes per MUT second

  Productivity   7.0% of total user, 37.8% of total elapsed
```

After:
```
 449,116,289,680 bytes allocated in the heap
   8,236,928,744 bytes copied during GC
     545,006,824 bytes maximum residency (19 sample(s))
   1,229,335,320 bytes maximum slop
            2949 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     441117 colls, 441117 par   691.961s  21.302s     0.0000s    0.0264s
  Gen  1        19 colls,    18 par   97.701s   4.374s     0.2302s    0.9794s

  Parallel GC work balance: 0.83% (serial 0%, perfect 100%)

  TASKS: 50 (1 bound, 49 peak workers (49 total), using -N24)

  SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

  INIT    time    0.004s  (  0.009s elapsed)
  MUT     time  417.787s  (155.933s elapsed)
  GC      time  789.661s  ( 25.676s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    0.000s  (  0.000s elapsed)
  EXIT    time    0.003s  (  0.001s elapsed)
  Total   time  1207.455s  (181.619s elapsed)

  Alloc rate    1,074,987,541 bytes per MUT second

  Productivity  34.6% of total user, 85.9% of total elapsed
```

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
