### PR TITLE
Adding SAR instruction

### DIFF
--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -413,7 +413,8 @@ exprToSMT = \case
   Xor a b -> exprToSMT $ And (Or a b) (Not (And a b))
   Not a -> op1 "bvnot" a
   SHL a b -> op2 "bvshl" a b
-  SHR a b -> op2 "bvlshr" b a -- TODO: is lshr the same as shr?
+  SHR a b -> op2 "bvlshr" b a
+  SAR a b -> op2 "bvashr" b a
   EqByte a b -> do
     cond <- op2 "=" a b
     pure $ "(ite " <> cond `sp` one `sp` zero <> ")"

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -404,6 +404,88 @@ tests = testGroup "hevm"
 
   , testGroup "Symbolic execution"
       [
+     testCase "require-test" $ do
+        Just c <- solcRuntime "MyContract"
+            [i|
+            contract MyContract {
+              function fun(int256 a) external pure {
+              require(a <= 0);
+              assert (a <= 0);
+              }
+             }
+            |]
+        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256)", [AbiIntType 256])) []
+        putStrLn "Require works as expected"
+     ,
+     -- TODO look at tests here for SAR: https://github.com/dapphub/dapptools/blob/01ef8ea418c3fe49089a44d56013d8fcc34a1ec2/src/dapp-tests/pass/constantinople.sol#L250
+     testCase "opcode-sar-neg" $ do
+        Just c <- solcRuntime "MyContract"
+            [i|
+            contract MyContract {
+              function fun(int256 shift_by, int256 val) external pure returns (int256 out) {
+              require(shift_by >= 0);
+              require(val <= 0);
+              assembly {
+                out := sar(shift_by,val)
+              }
+              assert (out <= 0);
+              }
+             }
+            |]
+        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) []
+        putStrLn "SAR works as expected"
+     ,
+     testCase "opcode-sar-pos" $ do
+        Just c <- solcRuntime "MyContract"
+            [i|
+            contract MyContract {
+              function fun(int256 shift_by, int256 val) external pure returns (int256 out) {
+              require(shift_by >= 0);
+              require(val >= 0);
+              assembly {
+                out := sar(shift_by,val)
+              }
+              assert (out >= 0);
+              }
+             }
+            |]
+        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) []
+        putStrLn "SAR works as expected"
+     ,
+     testCase "opcode-sar-fixedval-pos" $ do
+        Just c <- solcRuntime "MyContract"
+            [i|
+            contract MyContract {
+              function fun(int256 shift_by, int256 val) external pure returns (int256 out) {
+              require(shift_by == 1);
+              require(val == 64);
+              assembly {
+                out := sar(shift_by,val)
+              }
+              assert (out == 32);
+              }
+             }
+            |]
+        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) []
+        putStrLn "SAR works as expected"
+     ,
+     testCase "opcode-sar-fixedval-neg" $ do
+        Just c <- solcRuntime "MyContract"
+            [i|
+            contract MyContract {
+              function fun(int256 shift_by, int256 val) external pure returns (int256 out) {
+              require(shift_by == 1);
+              require(val == -64);
+              assembly {
+                out := sar(shift_by,val)
+              }
+              assert (out == -32);
+              }
+             }
+            |]
+        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) []
+        putStrLn "SAR works as expected"
+
       -- Somewhat tautological since we are asserting the precondition
       -- on the same form as the actual "requires" clause.
       testCase "SafeAdd success case" $ do

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -485,7 +485,7 @@ tests = testGroup "hevm"
             |]
         [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) []
         putStrLn "SAR works as expected"
-
+      ,
       -- Somewhat tautological since we are asserting the precondition
       -- on the same form as the actual "requires" clause.
       testCase "SafeAdd success case" $ do


### PR DESCRIPTION
## Description

Adds SAR instruction definition using `bvashr`. It also removes the TODO using `bvlshr` -- there is no `bvshr`, weirdly enough. Neither the theory:

https://smtlib.cs.uiowa.edu/theories-FixedSizeBitVectors.shtml

nor the logic contains `bvshr`:

https://smtlib.cs.uiowa.edu/logics-all.shtml#QF_BV

There is only `bvlshr`.


Also, now I know there is both a theory and a logic...

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
