### PR TITLE
Require newer cabal

### DIFF
--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 name:
   hevm
 version:
@@ -80,7 +80,7 @@ library
     EVM.Solidity,
     EVM.Stepper,
     EVM.StorageLayout,
-    EVM.SymExec
+    EVM.SymExec,
     EVM.Transaction,
     EVM.TTY,
     EVM.TTYCenteredList,


### PR DESCRIPTION
This catches a typo
This newer cabal is also quite old. It means we can now catch a typo in our cabal file.

## Description

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
