### PR TITLE
Fix non-exhaustive pattern match in evalProp

### DIFF
--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -529,6 +529,7 @@ evalProp = \case
                    (PBool False, PBool False) -> PBool False
                    (PBool _, PBool _) -> PBool True
                    _ -> o
+  o -> o
 
 
 -- | Symbolically execute the VM and check all endstates against the postcondition, if available.


### PR DESCRIPTION
After a recent fix, `evalProp` ended up with a non-exhaustive pattern match against `Prop` expressions. The `Props` that where not pattern matched were binary operators with non-literal operands: 

```
ghci> evalProp (PLEq (ReadWord (Lit 0x24) (WriteWord (Lit 0x24) (Lit 0x0) (ConcreteBuf ""))) (ReadWord (Lit 0x24) (WriteWord (Lit 0x24) (Lit 0x1) (ConcreteBuf ""))))
*** Exception: src/EVM/SymExec.hs:(504,12)-(531,25): Non-exhaustive patterns in case
```

This adds an extra case so that every `Prop` is matched.

```
ghci> evalProp (PLEq (ReadWord (Lit 0x24) (WriteWord (Lit 0x24) (Lit 0x0) (ConcreteBuf ""))) (ReadWord (Lit 0x24) (WriteWord (Lit 0x24) (Lit 0x1) (ConcreteBuf ""))))
PLEq (ReadWord (Lit 0x24) (WriteWord (Lit 0x24) (Lit 0x0) (ConcreteBuf ""))) (ReadWord (Lit 0x24) (WriteWord (Lit 0x24) (Lit 0x1) (ConcreteBuf "")))
```
