### PR TITLE
ConcreteStore encoding & readStorage fix

### DIFF
--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -447,9 +447,14 @@ readStorage addr loc store@(ConcreteStore s) = case (addr, loc) of
     pure $ Lit val
   _ -> Just $ SLoad addr loc store
 readStorage addr' loc s@AbstractStore = Just $ SLoad addr' loc s
-readStorage addr' loc s@(SStore addr slot val prev) = case (addr, slot, addr', loc) of
-  (Lit _, Lit _, Lit _, Lit _) -> if loc == slot && addr == addr' then Just val else readStorage addr' loc prev
+readStorage addr' loc s@(SStore addr slot val prev) = case addr of
+  Lit _ -> if addr == addr'
+           then case slot of
+                  Lit _ -> if slot == loc then (Just val) else readStorage addr' loc prev
+                  _ -> Just $ SLoad addr' loc s
+           else readStorage addr' loc prev
   _ -> Just $ SLoad addr' loc s
+readStorage _ _ (GVar _) = error "Can't read from a GVar"
 
 readStorage' :: Expr EWord -> Expr EWord -> Expr Storage -> Expr EWord
 readStorage' addr loc store = case readStorage addr loc store of

--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -447,12 +447,13 @@ readStorage addr loc store@(ConcreteStore s) = case (addr, loc) of
     pure $ Lit val
   _ -> Just $ SLoad addr loc store
 readStorage addr' loc s@AbstractStore = Just $ SLoad addr' loc s
-readStorage addr' loc s@(SStore addr slot val prev) = case addr of
-  Lit _ -> if addr == addr'
-           then case slot of
-                  Lit _ -> if slot == loc then (Just val) else readStorage addr' loc prev
-                  _ -> Just $ SLoad addr' loc s
-           else readStorage addr' loc prev
+readStorage addr' loc s@(SStore addr slot val prev) = case (addr, addr') of
+  (Lit _, Lit _) ->
+    if addr == addr'
+    then case (loc, slot) of
+      (Lit _, Lit _) -> if slot == loc then (Just val) else readStorage addr' loc prev
+      _ -> Just $ SLoad addr' loc s
+    else readStorage addr' loc prev
   _ -> Just $ SLoad addr' loc s
 readStorage _ _ (GVar _) = error "Can't read from a GVar"
 


### PR DESCRIPTION
Just a few small fixes:

1. Adds an SMT encoding for `ConcreteStore`
2. Makes `readStorage` a little smarter so that it can handle more kinds of fully concrete reads from semi abstract stores