### PR TITLE
CSE: declare all extracted vars in dependency order

### DIFF
--- a/src/hevm/src/EVM/CSE.hs
+++ b/src/hevm/src/EVM/CSE.hs
@@ -12,16 +12,15 @@ import Prelude hiding (Word, LT, GT)
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Control.Monad.State
-import Data.Text (Text)
-import qualified Data.Text as T
 
 import EVM.Types
 import EVM.Traversals
 
 -- maps expressions to variable names
 data BuilderState = BuilderState
-  { bufs :: (Int, Map (Expr Buf) Int)
-  , stores :: (Int, Map (Expr Storage) Int)
+  { bufs :: Map (Expr Buf) Int
+  , stores :: Map (Expr Storage) Int
+  , count :: Int
   }
   deriving (Show)
 
@@ -30,8 +29,9 @@ type StoreEnv = Map Int (Expr Storage)
 
 initState :: BuilderState
 initState = BuilderState
-  { bufs = (0, Map.empty)
-  , stores = (0, Map.empty)
+  { bufs = mempty
+  , stores = mempty
+  , count = 0
   }
 
 
@@ -40,40 +40,44 @@ go = \case
   -- buffers
   e@(WriteWord {}) -> do
     s <- get
-    let (next, bs) = bufs s
-    case Map.lookup e bs of
+    case Map.lookup e (bufs s) of
       Just v -> pure $ GVar (BufVar v)
       Nothing -> do
-        let bs' = Map.insert e next bs
-        put $ s{bufs=(next + 1, bs')}
+        let
+          next = count s
+          bs' = Map.insert e next (bufs s)
+        put $ s{bufs=bs', count=next+1}
         pure $ GVar (BufVar next)
   e@(WriteByte {}) -> do
     s <- get
-    let (next, bs) = bufs s
-    case Map.lookup e bs of
+    case Map.lookup e (bufs s) of
       Just v -> pure $ GVar (BufVar v)
       Nothing -> do
-        let bs' = Map.insert e next bs
-        put $ s{bufs=(next + 1, bs')}
+        let
+          next = count s
+          bs' = Map.insert e next (bufs s)
+        put $ s{bufs=bs', count=next+1}
         pure $ GVar (BufVar next)
   e@(CopySlice {}) -> do
     s <- get
-    let (next, bs) = bufs s
-    case Map.lookup e bs of
+    case Map.lookup e (bufs s) of
       Just v -> pure $ GVar (BufVar v)
       Nothing -> do
-        let bs' = Map.insert e next bs
-        put $ s{bufs=(next + 1, bs')}
+        let
+          next = count s
+          bs' = Map.insert e next (bufs s)
+        put $ s{count=next+1, bufs=bs'}
         pure $ GVar (BufVar next)
   -- storage
   e@(SStore {}) -> do
     s <- get
-    let (next, ss) = stores s
-    case Map.lookup e ss of
+    case Map.lookup e (stores s) of
       Just v -> pure $ GVar (StoreVar v)
       Nothing -> do
-        let ss' = Map.insert e next ss
-        put $ s{stores=(next + 1, ss')}
+        let
+          next = count s
+          ss' = Map.insert e next (stores s)
+        put $ s{count=next+1, stores=ss'}
         pure $ GVar (StoreVar next)
   e -> pure e
 
@@ -87,7 +91,7 @@ eliminateExpr' e = mapExprM go e
 eliminateExpr :: Expr a -> (Expr a, BufEnv, StoreEnv)
 eliminateExpr e =
   let (e', st) = runState (eliminateExpr' e) initState in
-  (e', invertKeyVal (snd (bufs st)), invertKeyVal (snd (stores st)))
+  (e', invertKeyVal (bufs st), invertKeyVal (stores st))
 
 -- | Common subexpression elimination pass for Prop
 eliminateProp' :: Prop -> State BuilderState Prop
@@ -102,4 +106,4 @@ eliminateProps' props = mapM eliminateProp' props
 eliminateProps :: [Prop] -> ([Prop], BufEnv, StoreEnv)
 eliminateProps props =
   let (props', st) = runState (eliminateProps' props) initState in
-  (props',  invertKeyVal (snd (bufs st)),  invertKeyVal (snd (stores st)))
+  (props',  invertKeyVal (bufs st),  invertKeyVal (stores st))


### PR DESCRIPTION
Orders all intermediate buffers and stores by dependency order (i.e. if a store references a buffer that references a store, they will all be declared in the correct order in the resulting SMT query).

This is achieved by:

1. using a shared counter for both buffers and stores in CSE
2. conducting CSE from the leaves upwards (ensuring subexpressions have lower indentifiers)
3. using these identifiers to order the declaration of the intermediate bufs / stores in the produced SMT expressions