### PR TITLE
Expr: perform function selector simplification during exploration

### DIFF
--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -351,6 +351,7 @@ flattenExpr = go []
       Return  buf store -> [(pcs, Return buf store)]
       EVM.Types.IllegalOverflow -> [(pcs, EVM.Types.IllegalOverflow)]
       TmpErr s -> error s
+      GVar _ -> error "cannot flatten an Expr containing a GVar"
 
 -- | Simple recursive match based AST simplification
 -- Note: may not terminate!
@@ -369,10 +370,6 @@ simplify e = if (mapExpr go e == e)
       | otherwise = o
     go o@(ReadWord (Lit _) _) = Expr.simplifyReads o
     go o@(ReadByte (Lit _) _) = Expr.simplifyReads o
-
-    -- function selector checks
-    go (SHR (Lit 0xe0) (ReadWord (Lit 0x0) (WriteByte (Lit 0x0) (LitByte sel0) (WriteByte (Lit 0x1) (LitByte sel1) (WriteByte (Lit 0x2) (LitByte sel2) (WriteByte (Lit 0x3) (LitByte sel3) _))))))
-      = Lit $ word $ padLeft 32 $ BS.singleton sel0 <> BS.singleton sel1 <> BS.singleton sel2 <> BS.singleton sel3
 
     -- concrete LT / GT
     go (EVM.Types.LT (Lit a) (Lit b))


### PR DESCRIPTION
This generalizes function selector simplification, and moves it earlier in the pipeline, so it runs during the exploration phase. This can significantly cut down on the number of branches that need to be explored for more complex tests (e.g. for `prove_balance` in `dsProvePass.sol`, this reduced the number of explored branches from ~6000 to 14).