### PR TITLE
Rewrites for `Read/WriteWord`, `Read/WriteByte`, and `CopySlice`

### DIFF
--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -392,8 +392,8 @@ instance Monoid (Expr Buf) where
 -- | Removes any irrelevant writes when reading from a buffer
 simplifyReads :: Expr a -> Expr a
 simplifyReads = \case
-  ReadWord (Lit idx) b -> ReadWord (Lit idx) (stripWrites idx (idx + 31) b)
-  ReadByte (Lit idx) b -> ReadByte (Lit idx) (stripWrites idx idx b)
+  ReadWord (Lit idx) b -> readWord (Lit idx) (stripWrites idx (idx + 31) b)
+  ReadByte (Lit idx) b -> readByte (Lit idx) (stripWrites idx idx b)
   a -> a
 
 -- | Strips writes from the buffer that can be statically determined to be out of range

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -369,6 +369,9 @@ simplify e = if (mapExpr go e == e)
       | otherwise = o
     go o@(ReadWord (Lit _) _) = Expr.simplifyReads o
     go o@(ReadByte (Lit _) _) = Expr.simplifyReads o
+    go (WriteWord a b c) = Expr.writeWord a b c
+    go (WriteByte a b c) = Expr.writeByte a b c
+    go (CopySlice a b c d f) = Expr.copySlice a b c d f
 
     -- function selector checks
     go (SHR (Lit 0xe0) (ReadWord (Lit 0x0) (WriteByte (Lit 0x0) (LitByte sel0) (WriteByte (Lit 0x1) (LitByte sel1) (WriteByte (Lit 0x2) (LitByte sel2) (WriteByte (Lit 0x3) (LitByte sel3) _))))))


### PR DESCRIPTION
## Description
Rewrites for `Read/WriteWord`, `Read/WriteByte`, and `CopySlice`. Also, I moved `octet*` to `Types.hs`, it belongs there  more, I think, plus I need it :)

I am not attached to this PR, I'd just like get some feedback :)

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
