### PR TITLE
Simplifier fuzzing

### DIFF
--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -249,6 +249,7 @@ test-suite test
   build-depends:
     HUnit >= 1.6,
     QuickCheck,
+    quickcheck-instances,
     base,
     base16-bytestring,
     binary,
@@ -259,6 +260,7 @@ test-suite test
     hevm,
     lens,
     mtl,
+    data-dword,
     process,
     tasty >= 1.0,
     tasty-hunit >= 0.10,

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -35,7 +35,7 @@ runDappTest root =
   withCurrentDirectory root $ do
     cores <- num <$> getNumProcessors
     let testFile = root <> "/out/dapp.sol.json"
-    withSolvers Z3 cores $ \solvers -> do
+    withSolvers Z3 cores Nothing $ \solvers -> do
       opts <- testOpts solvers root testFile
       res <- dappTest opts solvers testFile Nothing
       unless res exitFailure
@@ -77,7 +77,7 @@ dumpQueries :: FilePath -> IO ()
 dumpQueries root = withCurrentDirectory root $ do
   d <- dai
   putStrLn "building expression"
-  withSolvers Z3 1 $ \s -> do
+  withSolvers Z3 1 Nothing $ \s -> do
     e <- buildExpr s d
     putStrLn "built expression"
     putStrLn "generating queries"
@@ -103,13 +103,13 @@ analyzeDai = do
 daiExpr :: IO (Expr End)
 daiExpr = do
   d <- dai
-  withSolvers Z3 1 $ \s -> buildExpr s d
+  withSolvers Z3 1 Nothing $ \s -> buildExpr s d
 
 analyzeVat :: IO ()
 analyzeVat = do
   putStrLn "starting"
   v <- vat
-  withSolvers Z3 1 $ \s -> do
+  withSolvers Z3 1 Nothing $ \s -> do
     e <- buildExpr s v
     putStrLn $ "done (" <> show (numBranches e) <> " branches)"
     reachable' False v
@@ -134,7 +134,7 @@ analyzeDeposit = do
       }
      }
     |]
-  withSolvers Z3 1 $ \s -> do
+  withSolvers Z3 1 Nothing $ \s -> do
     putStrLn "Exploring Contract"
     e <- simplify <$> buildExpr s c
     putStrLn "Writing AST"
@@ -144,7 +144,7 @@ analyzeDeposit = do
 reachable' :: Bool -> ByteString -> IO ()
 reachable' smtdebug c = do
   putStrLn "Exploring contract"
-  withSolvers Z3 4 $ \s -> do
+  withSolvers Z3 4 Nothing $ \s -> do
     full <- simplify <$> buildExpr s c
     putStrLn $ "Explored contract (" <> (show $ numBranches full) <> " branches)"
     --putStrLn $ formatExpr full
@@ -166,7 +166,7 @@ reachable' smtdebug c = do
 summaryExpr :: IO ()
 summaryExpr = do
   c <- summaryStore
-  withSolvers Z3 1 $ \s -> do
+  withSolvers Z3 1 Nothing $ \s -> do
     e <- buildExpr s c
     putStrLn $ formatExpr e
 

--- a/src/hevm/src/EVM/Expr.hs
+++ b/src/hevm/src/EVM/Expr.hs
@@ -281,20 +281,24 @@ copySlice srcOffset dstOffset size src dst = CopySlice srcOffset dstOffset size 
 writeByte :: Expr EWord -> Expr Byte -> Expr Buf -> Expr Buf
 writeByte (Lit offset) (LitByte val) (ConcreteBuf "")
   = ConcreteBuf $ BS.replicate (num offset) 0 <> BS.singleton val
-writeByte (Lit offset) (LitByte byte) (ConcreteBuf src)
-  = ConcreteBuf $ (padRight (num offset) $ BS.take (num offset) src)
-               <> BS.pack [byte]
-               <> BS.drop (num offset + 1) src
+writeByte o@(Lit offset) b@(LitByte byte) buf@(ConcreteBuf src)
+  | offset < num (maxBound :: Int)
+    = ConcreteBuf $ (padRight (num offset) $ BS.take (num offset) src)
+                 <> BS.pack [byte]
+                 <> BS.drop (num offset + 1) src
+  | otherwise = WriteByte o b buf
 writeByte offset byte src = WriteByte offset byte src
 
 
 writeWord :: Expr EWord -> Expr EWord -> Expr Buf -> Expr Buf
 writeWord (Lit offset) (Lit val) (ConcreteBuf "")
   = ConcreteBuf $ BS.replicate (num offset) 0 <> word256Bytes val
-writeWord (Lit offset) (Lit val) (ConcreteBuf src)
-  = ConcreteBuf $ (padRight (num offset) $ BS.take (num offset) src)
-               <> word256Bytes val
-               <> BS.drop ((num offset) + 32) src
+writeWord o@(Lit offset) v@(Lit val) buf@(ConcreteBuf src)
+  | offset + 32 < num (maxBound :: Int)
+    = ConcreteBuf $ (padRight (num offset) $ BS.take (num offset) src)
+                 <> word256Bytes val
+                 <> BS.drop ((num offset) + 32) src
+  | otherwise = WriteWord o v buf
 writeWord offset val src = WriteWord offset val src
 
 

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -159,14 +159,14 @@ fetchSlotFrom n url addr slot =
   Session.withAPISession
     (\s -> fetchSlotWithSession n url s addr slot)
 
-http :: Natural -> BlockNumber -> Text -> Fetcher
-http smtjobs n url q =
-  withSolvers Z3 smtjobs $ \s ->
+http :: Natural -> Maybe Natural -> BlockNumber -> Text -> Fetcher
+http smtjobs smttimeout n url q =
+  withSolvers Z3 smtjobs smttimeout $ \s ->
     oracle s (Just (n, url)) q
 
-zero :: Natural -> Fetcher
-zero smtjobs q =
-  withSolvers Z3 smtjobs $ \s ->
+zero :: Natural -> Maybe Natural -> Fetcher
+zero smtjobs smttimeout q =
+  withSolvers Z3 smtjobs smttimeout $ \s ->
     oracle s Nothing q
 
 -- smtsolving + (http or zero)

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -230,13 +230,13 @@ type Fetcher = EVM.Query -> IO (EVM ())
 -- will be pruned anyway.
 checkBranch :: SolverGroup -> Prop -> Prop -> IO EVM.BranchCondition
 checkBranch solvers branchcondition pathconditions = do
-  checkSat' solvers (assertProps [(branchcondition .&& pathconditions)]) >>= \case
+  checkSat solvers (assertProps [(branchcondition .&& pathconditions)]) >>= \case
      -- the condition is unsatisfiable
      Unsat -> -- if pathconditions are consistent then the condition must be false
             return $ EVM.Case False
      -- Sat means its possible for condition to hold
      Sat _ -> -- is its negation also possible?
-            checkSat' solvers (assertProps [(pathconditions .&& (PNeg branchcondition))]) >>= \case
+            checkSat solvers (assertProps [(pathconditions .&& (PNeg branchcondition))]) >>= \case
                -- No. The condition must hold
                Unsat -> return $ EVM.Case True
                -- Yes. Both branches possible

--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -651,7 +651,7 @@ data CheckSatResult
   | Unsat
   | Unknown
   | Error Text
-  deriving (Show)
+  deriving (Show, Eq)
 
 isSat :: CheckSatResult -> Bool
 isSat (Sat _) = True

--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -465,7 +465,7 @@ exprToSMT = \case
   Min a b ->
     let aenc = exprToSMT a
         benc = exprToSMT b in
-    "(ite (<= " <> aenc `sp` benc <> ") " <> aenc `sp` benc <> ")"
+    "(ite (bvule " <> aenc `sp` benc <> ") " <> aenc `sp` benc <> ")"
   LT a b ->
     let cond = op2 "bvult" a b in
     "(ite " <> cond `sp` one `sp` zero <> ")"

--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -68,9 +68,9 @@ instance Monoid CexVars where
 
 data SMTCex = SMTCex
   { calldata :: Map Text Language.SMT2.Parser.SpecConstant
-  , storage :: SpecConstant
-  , blockContext :: SpecConstant
-  , txContext :: SpecConstant
+  , storage :: Text
+  , blockContext :: Text
+  , txContext :: Text
   }
   deriving (Eq, Show)
 
@@ -740,6 +740,9 @@ withSolvers solver count cont = do
                   mempty (calldataV cexvars)
               pure $ Sat $ SMTCex
                 { calldata = calldatamodels
+                , storage = mempty
+                , blockContext = mempty
+                , txContext = mempty
                 }
             "unsat" -> pure Unsat
             "timeout" -> pure Unknown

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -377,7 +377,7 @@ simplify e = if (mapExpr go e == e)
       | otherwise = Lit 0
     go (EVM.Types.GT a b) = EVM.Types.LT b a
     go (EVM.Types.GEq a b) = EVM.Types.LEq b a
-    go (EVM.Types.LEq a b) = EVM.Types.Not (EVM.Types.GT a b)
+    go (EVM.Types.LEq a b) = EVM.Types.IsZero (EVM.Types.GT a b)
 
     -- syntactic Eq reduction
     go (Eq (Lit a) (Lit b))

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -503,7 +503,7 @@ reachable2 solvers e = do
         pure (fst tres <> fst fres, subexpr)
       leaf -> do
         let query = assertProps pcs
-        res <- checkSat' solvers query
+        res <- checkSat solvers query
         case res of
           Sat _ -> pure ([query], Just leaf)
           Unsat -> pure ([query], Nothing)
@@ -527,8 +527,8 @@ reachable solvers = go []
         let
           tquery = assertProps (PEq c (Lit 1) : pcs)
           fquery = assertProps (PEq c (Lit 0) : pcs)
-        tres <- (checkSat' solvers tquery)
-        fres <- (checkSat' solvers fquery)
+        tres <- (checkSat solvers tquery)
+        fres <- (checkSat solvers fquery)
         print (tres, fres)
         case (tres, fres) of
           (Error tm, Error fm) -> do
@@ -620,7 +620,7 @@ verify solvers opts preState rpcinfo maybepost = do
       when (debug opts) $ putStrLn $ "Checking for reachability of " <> show (length withQueries) <> "\n potential property violations"
       results <- flip mapConcurrently withQueries $ \(query, leaf) -> do
         when (debug opts) $ putStrLn $ "--- query BEGIN ---\n" <> (show query) <> "\n--- query END ---\n"
-        res <- checkSat' solvers query
+        res <- checkSat solvers query
         when (debug opts) $ putStrLn $ "--- res BEGIN ---\n" <> (show res) <> "\n--- res END ---\n"
         pure (res, leaf)
       let cexs = filter (\(res, _) -> not . isUnsat $ res) results

--- a/src/hevm/src/EVM/Traversals.hs
+++ b/src/hevm/src/EVM/Traversals.hs
@@ -128,7 +128,7 @@ foldExpr f acc expr = acc <> (go expr)
       e@(GasLimit) -> f e
       e@(ChainId) -> f e
       e@(BaseFee) -> f e
-      e@(BlockHash _) -> f e
+      e@(BlockHash a) -> f e <> (go a)
 
       -- frame context
 

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -49,6 +49,7 @@ import Data.Word          (Word8, Word32)
 import Data.Text.Encoding (encodeUtf8)
 import System.Environment (lookupEnv)
 import System.IO          (hFlush, stdout)
+import GHC.Natural
 
 import qualified Control.Monad.Par.Class as Par
 import qualified Data.ByteString as BS
@@ -74,7 +75,7 @@ data UnitTestOptions = UnitTestOptions
   , maxIter     :: Maybe Integer
   , askSmtIters :: Maybe Integer
   , maxDepth    :: Maybe Int
-  , smtTimeout  :: Maybe Integer
+  , smtTimeout  :: Maybe Natural
   , solver      :: Maybe Text
   , covMatch    :: Maybe Text
   , match       :: Text

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -80,7 +80,7 @@ tests = testGroup "hevm"
   [ testGroup "StorageTests"
     [ testProperty "readStorage-equivalance" $ \(store, addr, slot) ->
         -- we use the SMT solver to compare the result of readStorage, to the unsimplified result
-        ioProperty $ withSolvers Z3 1 (Just 100) $ \solvers -> do
+        ioProperty $ withSolvers Z3 1 (Just 250) $ \solvers -> do
           let simplified = Expr.readStorage' addr slot store
               full = SLoad addr slot store
           res <- checkSat solvers (assertProps [simplified ./= full])
@@ -1386,7 +1386,7 @@ tests = testGroup "hevm"
 
 
 runSimplifyTest :: (Typeable a) => Expr a -> Property
-runSimplifyTest expr = ioProperty $ withSolvers Z3 1 (Just 100) $ \solvers -> do
+runSimplifyTest expr = ioProperty $ withSolvers Z3 1 (Just 250) $ \solvers -> do
   let simplified = simplify expr
   if simplified == expr
      then pure True

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -1393,6 +1393,7 @@ runSimplifyTest expr = ioProperty $ withSolvers Z3 1 (Just 250) $ \solvers -> do
      else do
        let smt = assertProps [simplified ./= expr]
        res <- checkSat solvers smt
+       print res
        pure $ case res of
          Unsat -> True
          EVM.SMT.Unknown -> True

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -83,7 +83,7 @@ tests = testGroup "hevm"
         ioProperty $ withSolvers Z3 1 $ \solvers -> do
           let simplified = Expr.readStorage' addr slot store
               full = SLoad addr slot store
-          res <- checkSat' solvers (assertProps [simplified ./= full])
+          res <- checkSat solvers (assertProps [simplified ./= full])
           pure $ res == Unsat
     ]
   , testGroup "SimplifierTests"
@@ -1389,7 +1389,7 @@ runSimplifyTest expr = ioProperty $ withSolvers Z3 1 $ \solvers -> do
      then pure True
      else do
        let smt = assertProps [simplified ./= expr]
-       res <- checkSat' solvers smt
+       res <- checkSat solvers smt
        pure $ res == Unsat
 
 

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -80,7 +80,7 @@ tests = testGroup "hevm"
   [ testGroup "StorageTests"
     [ testProperty "readStorage-equivalance" $ \(store, addr, slot) ->
         -- we use the SMT solver to compare the result of readStorage, to the unsimplified result
-        ioProperty $ withSolvers Z3 1 $ \solvers -> do
+        ioProperty $ withSolvers Z3 1 (Just 1000) $ \solvers -> do
           let simplified = Expr.readStorage' addr slot store
               full = SLoad addr slot store
           res <- checkSat solvers (assertProps [simplified ./= full])
@@ -314,7 +314,7 @@ tests = testGroup "hevm"
              }
             }
            |]
-       [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+       [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
        assertEqual "Must be 0" 0 $ getArgInteger ctr "arg1"
        putStrLn  $ "expected counterexample found, and it's correct: " <> (show $ getArgInteger ctr "arg1")
      ,
@@ -327,7 +327,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s [0x11] c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x11] c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         let x = getArgInteger ctr "arg1"
         let y = getArgInteger ctr "arg2"
         assertBool "Overflow must occur" (x+y > 2^256)
@@ -342,7 +342,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s [0x12] c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x12] c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         assertEqual "Division by 0 needs b=0" (getArgInteger ctr "arg2") 0
         putStrLn "expected counterexample found"
      ,
@@ -356,7 +356,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s [0x21] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+        [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x21] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
         assertBool "Enum is only defined for 0 and 1" $ (getArgInteger ctr "arg1") > 1
         putStrLn "expected counterexample found"
      ,
@@ -377,7 +377,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        a <- withSolvers Z3 1 $ \s -> checkAssert s [0x31] c (Just ("fun(uint8)", [AbiUIntType 8])) [] defaultVeriOpts
+        a <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x31] c (Just ("fun(uint8)", [AbiUIntType 8])) [] defaultVeriOpts
         print $ length a
         print $ show a
         putStrLn "expected counterexample found"
@@ -394,7 +394,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s [0x32] c (Just ("fun(uint8)", [AbiUIntType 8])) [] defaultVeriOpts
+        [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x32] c (Just ("fun(uint8)", [AbiUIntType 8])) [] defaultVeriOpts
         assertBool "Access must be beyond element 2" $ (getArgInteger ctr "arg1") > 1
         putStrLn "expected counterexample found"
       ,
@@ -408,7 +408,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s [0x41] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+        [Cex _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x41] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "expected counterexample found"
       ,
       -- TODO the system currently does not allow for symbolic JUMP
@@ -428,7 +428,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s [0x51] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+        [Cex _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x51] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "expected counterexample found"
  ]
 
@@ -483,7 +483,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256)", [AbiIntType 256])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256)", [AbiIntType 256])) [] defaultVeriOpts
         putStrLn "Require works as expected"
      ,
      testCase "ITE-with-bitwise-AND" $ do
@@ -504,7 +504,7 @@ tests = testGroup "hevm"
          }
          |]
        -- should find a counterexample
-       [Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+       [Cex _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
        putStrLn "expected counterexample found"
      ,
      testCase "ITE-with-bitwise-OR" $ do
@@ -523,7 +523,7 @@ tests = testGroup "hevm"
            }
          }
          |]
-       [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+       [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
        putStrLn "this should always be true, due to bitwise OR with positive value"
     ,
     -- CopySlice check
@@ -549,7 +549,7 @@ tests = testGroup "hevm"
           }
         }
         |]
-      [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("checkval(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] VeriOpts {simp = False, debug = False, maxIter = Nothing, askSmtIters = Nothing}
+      [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("checkval(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] VeriOpts {simp = False, debug = False, maxIter = Nothing, askSmtIters = Nothing}
       putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
      ,
      -- TODO look at tests here for SAR: https://github.com/dapphub/dapptools/blob/01ef8ea418c3fe49089a44d56013d8fcc34a1ec2/src/dapp-tests/pass/constantinople.sol#L250
@@ -567,7 +567,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLn "SAR works as expected"
      ,
      testCase "opcode-sar-pos" $ do
@@ -584,7 +584,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLn "SAR works as expected"
      ,
      testCase "opcode-sar-fixedval-pos" $ do
@@ -601,7 +601,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLn "SAR works as expected"
      ,
      testCase "opcode-sar-fixedval-neg" $ do
@@ -618,7 +618,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLn "SAR works as expected"
      ,
      testCase "opcode-signextend-neg" $ do
@@ -640,7 +640,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        [Qed _]  <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+        [Qed _]  <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "signextend works as expected"
       ,
      testCase "opcode-signextend-pos-nochop" $ do
@@ -658,7 +658,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint8)", [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint8)", [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
         putStrLn "signextend works as expected"
       ,
       testCase "opcode-signextend-pos-chopped" $ do
@@ -676,7 +676,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint8)", [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint8)", [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
         putStrLn "signextend works as expected"
       ,
       -- when b is too large, value is unchanged
@@ -694,7 +694,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint8)", [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint8)", [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
         putStrLn "signextend works as expected"
      ,
      testCase "opcode-shl" $ do
@@ -712,7 +712,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "SAR works as expected"
      ,
      testCase "opcode-xor-cancel" $ do
@@ -729,7 +729,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "XOR works as expected"
       ,
       testCase "opcode-xor-reimplement" $ do
@@ -745,7 +745,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "XOR works as expected"
       ,
       -- Somewhat tautological since we are asserting the precondition
@@ -767,7 +767,7 @@ tests = testGroup "hevm"
               in case leaf of
                    Return b _ -> (ReadWord (Lit 0) b) .== (Add x y)
                    _ -> PBool True
-        [Qed res] <- withSolvers Z3 1 $ \s -> verifyContract s safeAdd (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
+        [Qed res] <- withSolvers Z3 1 Nothing $ \s -> verifyContract s safeAdd (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
         putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
      ,
 
@@ -789,7 +789,7 @@ tests = testGroup "hevm"
               in case leaf of
                    Return b _ -> (ReadWord (Lit 0) b) .== (Mul (Lit 2) y)
                    _ -> PBool True
-        [Qed res] <- withSolvers Z3 1 $ \s ->
+        [Qed res] <- withSolvers Z3 1 Nothing $ \s ->
           verifyContract s safeAdd (Just ("add(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
         putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
       ,
@@ -814,7 +814,7 @@ tests = testGroup "hevm"
               in case leaf of
                 Return _ postStore -> Expr.add prex (Expr.mul (Lit 2) y) .== (Expr.readStorage' this (Lit 0) postStore)
                 _ -> PBool True
-        [Qed res] <- withSolvers Z3 1 $ \s -> verifyContract s c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
+        [Qed res] <- withSolvers Z3 1 Nothing $ \s -> verifyContract s c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
         putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         -- tests how whiffValue handles Neg via application of the triple IsZero simplification rule
@@ -839,7 +839,7 @@ tests = testGroup "hevm"
                     }
                     |]
             Just c <- yulRuntime "Neg" src
-            [Qed res] <- withSolvers Z3 4 $ \s -> checkAssert s defaultPanicCodes c (Just ("hello(address)", [AbiAddressType])) [] defaultVeriOpts
+            [Qed res] <- withSolvers Z3 4 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("hello(address)", [AbiAddressType])) [] defaultVeriOpts
             putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "catch-storage-collisions-noproblem" $ do
@@ -871,7 +871,7 @@ tests = testGroup "hevm"
                            posty = Expr.readStorage' this y poststore
                        in Expr.add prex prey .== Expr.add postx posty
                      _ -> PBool True
-          [Qed _] <- withSolvers Z3 1 $ \s -> verifyContract s c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
+          [Qed _] <- withSolvers Z3 1 Nothing $ \s -> verifyContract s c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
           putStrLn "Correct, this can never fail"
         ,
         -- Inspired by these `msg.sender == to` token bugs
@@ -903,7 +903,7 @@ tests = testGroup "hevm"
                            posty = Expr.readStorage' this y poststore
                        in Expr.add prex prey .== Expr.add postx posty
                      _ -> PBool True
-          [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> verifyContract s c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
+          [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> verifyContract s c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
           let x = getArgInteger ctr "arg1"
           let y = getArgInteger ctr "arg2"
           putStrLn $ "y:" <> show y
@@ -920,7 +920,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Cex (l, _)] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo()", [])) [] defaultVeriOpts
+          [Cex (l, _)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo()", [])) [] defaultVeriOpts
           assertEqual "incorrect revert msg" l (EVM.Types.Revert (ConcreteBuf $ panicMsg 0x01))
         ,
         testCase "simple-assert-2" $ do
@@ -932,7 +932,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [(Cex (_, ctr))] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [(Cex (_, ctr))] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           assertEqual "Must be 10" 10 $ getArgInteger ctr "arg1"
           putStrLn "Got 10 Cex, as expected"
         ,
@@ -946,7 +946,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Cex (_, a), Cex (_, b)] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Cex (_, a), Cex (_, b)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           let ints = map (flip getArgInteger "arg1") [a,b]
           assertBool "0 must be one of the Cex-es" $ isJust $ elemIndex 0 ints
           putStrLn "expected 2 counterexamples found, one Cex is the 0 value"
@@ -961,7 +961,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Cex (_, a), Cex (_, b)] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Cex (_, a), Cex (_, b)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           let x = getArgInteger a "arg1"
           let y = getArgInteger b "arg1"
           assertBool "At least one has to be 0, to go through the first assert" (x == 0 || y == 0)
@@ -977,7 +977,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Cex _, Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          [Cex _, Cex _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLn "expected 2 counterexamples found"
         ,
         testCase "assert-2nd-arg" $ do
@@ -989,7 +989,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           assertEqual "Must be 666" 666 $ getArgInteger ctr "arg2"
           putStrLn "Found arg2 Ctx to be 666"
         ,
@@ -1006,7 +1006,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         -- We zero out everything but the LSB byte. However, byte(31,x) takes the LSB byte
@@ -1023,7 +1023,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           assertBool "last byte must be non-zero" $ ((Data.Bits..&.) (getArgInteger ctr "arg1") 0xff) > 0
           putStrLn $ "Expected counterexample found"
         ,
@@ -1041,7 +1041,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           assertBool "second to last byte must be non-zero" $ ((Data.Bits..&.) (getArgInteger ctr "arg1") 0xff00) > 0
           putStrLn $ "Expected counterexample found"
         ,
@@ -1060,7 +1060,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         -- Bitwise OR operation test
@@ -1076,7 +1076,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn "When OR-ing with full 1's we should get back full 1's"
         ,
         -- Bitwise OR operation test
@@ -1093,7 +1093,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn "When OR-ing with a byte of 1's, we should get 1's back there"
         ,
         testCase "Deposit contract loop (z3)" $ do
@@ -1115,7 +1115,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("deposit(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "Deposit-contract-loop-error-version" $ do
@@ -1137,7 +1137,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) [] defaultVeriOpts
+          [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s allPanicCodes c (Just ("deposit(uint8)", [AbiUIntType 8])) [] defaultVeriOpts
           assertEqual "Must be 255" 255 $ getArgInteger ctr "arg1"
           putStrLn  $ "expected counterexample found, and it's correct: " <> (show $ getArgInteger ctr "arg1")
         ,
@@ -1150,7 +1150,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "check-asm-byte-in-bounds" $ do
@@ -1169,7 +1169,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLn "in bounds byte reads return the expected value"
         ,
         testCase "check-asm-byte-oob" $ do
@@ -1184,7 +1184,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLn "oob byte reads always return 0"
         ,
         expectFail $ testCase "injectivity of keccak (32 bytes)" $ do
@@ -1196,7 +1196,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "injectivity of keccak (64 bytes)" $ do
@@ -1208,7 +1208,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Cex (_, ctr)] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256,uint256,uint256,uint256)", replicate 4 (AbiUIntType 256))) [] defaultVeriOpts
+          [Cex (_, ctr)] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256,uint256,uint256,uint256)", replicate 4 (AbiUIntType 256))) [] defaultVeriOpts
           let x = getArgInteger ctr "arg1"
           let y = getArgInteger ctr "arg2"
           let w = getArgInteger ctr "arg3"
@@ -1231,7 +1231,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         ignoreTest $ testCase "keccak soundness" $ do
@@ -1248,7 +1248,7 @@ tests = testGroup "hevm"
             |]
 
           -- should find a counterexample
-          [Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          [Cex _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256,uint256)", [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLn "expected counterexample found"
         ,
         testCase "multiple-contracts" $ do
@@ -1270,7 +1270,7 @@ tests = testGroup "hevm"
               aAddr = Addr 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B
           Just c <- solcRuntime "C" code'
           Just a <- solcRuntime "A" code'
-          [Cex _] <- withSolvers Z3 1 $ \s -> do
+          [Cex _] <- withSolvers Z3 1 Nothing $ \s -> do
             let vm0 = abstractVM (Just ("call_A()", [])) [] c Nothing SymbolicS
             let vm = vm0
                   & set (state . callvalue) (Lit 0)
@@ -1299,7 +1299,7 @@ tests = testGroup "hevm"
                 uint public x;
               }
             |]
-          [Cex _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("call_A()", [])) [] defaultVeriOpts
+          [Cex _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("call_A()", [])) [] defaultVeriOpts
           putStrLn "expected counterexample found"
         ,
         expectFail $ testCase "keccak concrete and sym agree" $ do
@@ -1313,13 +1313,13 @@ tests = testGroup "hevm"
                 }
               }
             |]
-          [Qed res] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("kecc(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Qed res] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("kecc(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         ignoreTest $ testCase "safemath distributivity (yul)" $ do
           let yulsafeDistributivity = hex "6355a79a6260003560e01c14156016576015601f565b5b60006000fd60a1565b603d602d604435600435607c565b6039602435600435607c565b605d565b6052604b604435602435605d565b600435607c565b141515605a57fe5b5b565b6000828201821115151560705760006000fd5b82820190505b92915050565b6000818384048302146000841417151560955760006000fd5b82820290505b92915050565b"
           let vm =  abstractVM (Just ("distributivity(uint256,uint256,uint256)", [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] yulsafeDistributivity Nothing SymbolicS
-          [Qed _] <-  withSolvers Z3 1 $ \s -> verify s defaultVeriOpts vm Nothing (Just $ checkAssertions defaultPanicCodes)
+          [Qed _] <-  withSolvers Z3 1 Nothing $ \s -> verify s defaultVeriOpts vm Nothing (Just $ checkAssertions defaultPanicCodes)
           putStrLn "Proven"
         ,
         testCase "safemath distributivity (sol)" $ do
@@ -1344,7 +1344,7 @@ tests = testGroup "hevm"
               }
             |]
 
-          [Qed _] <- withSolvers Z3 1 $ \s -> checkAssert s defaultPanicCodes c (Just ("distributivity(uint256,uint256,uint256)", [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("distributivity(uint256,uint256,uint256)", [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLn "Proven"
  {- ]
   , testGroup "Equivalence checking"
@@ -1383,14 +1383,18 @@ tests = testGroup "hevm"
 
 
 runSimplifyTest :: (Typeable a) => Expr a -> Property
-runSimplifyTest expr = ioProperty $ withSolvers Z3 1 $ \solvers -> do
+runSimplifyTest expr = ioProperty $ withSolvers Z3 1 (Just 1000) $ \solvers -> do
   let simplified = simplify expr
   if simplified == expr
      then pure True
      else do
        let smt = assertProps [simplified ./= expr]
        res <- checkSat solvers smt
-       pure $ res == Unsat
+       pure $ case res of
+         Unsat -> True
+         EVM.SMT.Unknown -> True
+         Sat _ -> False
+         Error _ -> False
 
 
 runSimpleVM :: ByteString -> ByteString -> Maybe ByteString
@@ -1666,7 +1670,7 @@ genStorage :: Int -> Gen (Expr Storage)
 genStorage 0 = oneof
   [ pure AbstractStore
   , pure EmptyStore
-  , fmap ConcreteStore arbitrary
+  --, fmap ConcreteStore arbitrary
   ]
 genStorage sz = liftM4 SStore subWord subWord subWord subStore
   where
@@ -1710,7 +1714,7 @@ runDappTest testFile match = do
     withSystemTempFile "output.json" $ \file handle -> do
       hClose handle
       TIO.writeFile file json
-      withSolvers Z3 1 $ \solvers -> do
+      withSolvers Z3 1 Nothing $ \solvers -> do
         opts <- testOpts solvers root json match
         dappTest opts solvers file Nothing
 
@@ -1723,7 +1727,7 @@ debugDappTest testFile = do
     withSystemTempFile "output.json" $ \file handle -> do
       hClose handle
       TIO.writeFile file json
-      withSolvers Z3 1 $ \solvers -> do
+      withSolvers Z3 1 Nothing $ \solvers -> do
         opts <- testOpts solvers root json ".*"
         TTY.main opts root file
 

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -1529,8 +1529,8 @@ genByte sz = oneof
   , liftM2 ReadByte subWord subBuf
   ]
   where
-    subWord = genWord (sz `div` 2)
-    subBuf = genBuf (sz `div` 2)
+    subWord = genWord (sz `div` 10)
+    subBuf = genBuf (sz `div` 10)
 
 genNat :: Gen Int
 genNat = fmap fromIntegral (arbitrary :: Gen Natural)
@@ -1642,10 +1642,10 @@ genWord sz = frequency
     ])
   ]
  where
-   subWord = genWord (sz `div` 2)
-   subBuf = genBuf (sz `div` 2)
-   subStore = genStorage (sz `div` 2)
-   subByte = genByte (sz `div` 2)
+   subWord = genWord (sz `div` 5)
+   subBuf = genBuf (sz `div` 10)
+   subStore = genStorage (sz `div` 10)
+   subByte = genByte (sz `div` 10)
 
 genBuf :: Int -> Gen (Expr Buf)
 genBuf 0 = oneof
@@ -1662,9 +1662,9 @@ genBuf sz = oneof
     smolLitWord = do
       w <- arbitrary
       pure $ Lit (w `mod` 100)
-    subWord = genWord (sz `div` 2)
-    subByte = genByte (sz `div` 2)
-    subBuf = genBuf (sz `div` 2)
+    subWord = genWord (sz `div` 5)
+    subByte = genByte (sz `div` 10)
+    subBuf = genBuf (sz `div` 10)
 
 genStorage :: Int -> Gen (Expr Storage)
 genStorage 0 = oneof
@@ -1674,8 +1674,8 @@ genStorage 0 = oneof
   ]
 genStorage sz = liftM4 SStore subWord subWord subWord subStore
   where
-    subStore = genStorage (sz `div` 2)
-    subWord = genWord (sz `div` 2)
+    subStore = genStorage (sz `div` 10)
+    subWord = genWord (sz `div` 5)
 
 data Invocation
   = SolidityCall Text [AbiValue]

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -80,7 +80,7 @@ tests = testGroup "hevm"
   [ testGroup "StorageTests"
     [ testProperty "readStorage-equivalance" $ \(store, addr, slot) ->
         -- we use the SMT solver to compare the result of readStorage, to the unsimplified result
-        ioProperty $ withSolvers Z3 1 (Just 250) $ \solvers -> do
+        ioProperty $ withSolvers Z3 1 (Just 100) $ \solvers -> do
           let simplified = Expr.readStorage' addr slot store
               full = SLoad addr slot store
           res <- checkSat solvers (assertProps [simplified ./= full])
@@ -1386,7 +1386,7 @@ tests = testGroup "hevm"
 
 
 runSimplifyTest :: (Typeable a) => Expr a -> Property
-runSimplifyTest expr = ioProperty $ withSolvers Z3 1 (Just 250) $ \solvers -> do
+runSimplifyTest expr = ioProperty $ withSolvers Z3 1 (Just 100) $ \solvers -> do
   let simplified = simplify expr
   if simplified == expr
      then pure True

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -80,7 +80,7 @@ tests = testGroup "hevm"
   [ testGroup "StorageTests"
     [ testProperty "readStorage-equivalance" $ \(store, addr, slot) ->
         -- we use the SMT solver to compare the result of readStorage, to the unsimplified result
-        ioProperty $ withSolvers Z3 1 (Just 1000) $ \solvers -> do
+        ioProperty $ withSolvers Z3 1 (Just 100) $ \solvers -> do
           let simplified = Expr.readStorage' addr slot store
               full = SLoad addr slot store
           res <- checkSat solvers (assertProps [simplified ./= full])
@@ -1383,7 +1383,7 @@ tests = testGroup "hevm"
 
 
 runSimplifyTest :: (Typeable a) => Expr a -> Property
-runSimplifyTest expr = ioProperty $ withSolvers Z3 1 (Just 1000) $ \solvers -> do
+runSimplifyTest expr = ioProperty $ withSolvers Z3 1 (Just 100) $ \solvers -> do
   let simplified = simplify expr
   if simplified == expr
      then pure True


### PR DESCRIPTION
## Description

Adds some small fuzzing pipelines for the simplification engine. This works as follows:

1. generate a random Expr
2. run the simplifier on this Expr
3. compare the two for equivalence using an SMT solver

This is a draft for now because we need to add some solver timeouts before we can actually start to run this in CI. Still the pipelines seem pretty useful, I already found quite a few small bugs with them...

## Checklist

- [ ] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
