### PR TITLE
Keccak injectivity assertions

### DIFF
--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -96,6 +96,7 @@ library
     EVM.SymExec,
     EVM.Traversals,
     EVM.CSE,
+    EVM.Keccak,
     EVM.Transaction,
     EVM.TTY,
     EVM.TTYCenteredList,

--- a/src/hevm/src/EVM/Keccak.hs
+++ b/src/hevm/src/EVM/Keccak.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DataKinds #-}
+{- |
+    Module: EVM.Keccak
+    Description: Expr passes to determine Keccak assumptions
+-}
+
+module EVM.Keccak (keccakInj) where
+
+import Prelude hiding (Word, LT, GT)
+
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Control.Monad.State
+
+import EVM.Types
+import EVM.Traversals
+
+
+data BuilderState = BuilderState
+  { keccaks :: Set (Expr EWord) }
+  deriving (Show)
+
+initState :: BuilderState
+initState = BuilderState { keccaks = Set.empty }
+
+go :: forall a. Expr a -> State BuilderState (Expr a)
+go = \case
+  e@(Keccak b) -> do
+    s <- get
+    put $ s{keccaks=Set.insert e (keccaks s)}
+    pure e
+  e -> pure e
+
+findKeccak :: forall a. Expr a -> State BuilderState (Expr a)
+findKeccak e = mapExprM go e
+
+findKeccakProp :: Prop -> State BuilderState Prop
+findKeccakProp p = mapPropM go p
+
+findKeccakProps :: [Prop] -> State BuilderState [Prop]
+findKeccakProps ps = mapM findKeccakProp ps
+
+combine :: [a] -> [(a,a)]
+combine lst = combine' lst []
+  where
+    combine' [] acc = concat acc
+    combine' (x:xs) acc =
+      let xcomb = [ (x, y) | y <- xs] in
+      combine' xs (xcomb:acc)
+
+
+-- | Takes a list of Props, finds all Keccak occurences and generates
+-- Keccak injectivity assumptions for all unique pairs of Keccak calls
+keccakInj :: [Prop] -> [Prop]
+keccakInj p =
+  let (_, st) = runState (findKeccakProps p) initState in
+  fmap injProp $ combine (Set.toList (keccaks st))
+  where
+    injProp :: (Expr EWord, Expr EWord) -> Prop
+    injProp (k1@(Keccak b1), k2@(Keccak b2)) =
+      POr (PEq b1 b2) (PNeg (PEq k1 k2))
+    injProp _ = error "Internal error: expected keccak expression"

--- a/src/hevm/src/EVM/Keccak.hs
+++ b/src/hevm/src/EVM/Keccak.hs
@@ -25,7 +25,7 @@ initState = BuilderState { keccaks = Set.empty }
 
 go :: forall a. Expr a -> State BuilderState (Expr a)
 go = \case
-  e@(Keccak b) -> do
+  e@(Keccak _) -> do
     s <- get
     put $ s{keccaks=Set.insert e (keccaks s)}
     pure e
@@ -37,12 +37,11 @@ findKeccakExpr e = mapExprM go e
 findKeccakProp :: Prop -> State BuilderState Prop
 findKeccakProp p = mapPropM go p
 
-findKeccakPropsExprs :: forall a. [Prop] -> [Expr Buf]  -> [Expr Storage]-> State BuilderState ()
+findKeccakPropsExprs :: [Prop] -> [Expr Buf]  -> [Expr Storage]-> State BuilderState ()
 findKeccakPropsExprs ps bufs stores = do
-  mapM findKeccakProp ps;
-  mapM findKeccakExpr bufs;
-  mapM findKeccakExpr stores;
-  pure ()
+  mapM_ findKeccakProp ps;
+  mapM_ findKeccakExpr bufs;
+  mapM_ findKeccakExpr stores
 
 
 combine :: [a] -> [(a,a)]
@@ -56,7 +55,7 @@ combine lst = combine' lst []
 
 -- | Takes a list of Props, finds all Keccak occurences and generates
 -- Keccak injectivity assumptions for all unique pairs of Keccak calls
-keccakInj :: forall a. [Prop] -> [Expr Buf]  -> [Expr Storage] -> [Prop]
+keccakInj :: [Prop] -> [Expr Buf]  -> [Expr Storage] -> [Prop]
 keccakInj ps bufs stores =
   let (_, st) = runState (findKeccakPropsExprs ps bufs stores) initState in
   fmap injProp $ combine (Set.toList (keccaks st))

--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -44,6 +44,7 @@ import System.Process (createProcess, cleanupProcess, proc, ProcessHandle, std_i
 import EVM.Types
 import EVM.Traversals
 import EVM.CSE
+import EVM.Keccak
 import EVM.Expr hiding (copySlice, writeWord, op1, op2, op3, drop)
 import qualified Language.SMT2.Syntax as Language.SMT2.Parser
 import Language.SMT2.Syntax (SpecConstant(SCHexadecimal))
@@ -105,6 +106,10 @@ declareIntermediates bufs stores =
     encodeStore n expr =
        "(define-const store" <> (T.pack . show $ n) <> " Storage " <> exprToSMT expr <> ")"
 
+keccakAssumptions :: [Prop] -> SMT2
+keccakAssumptions ps =
+  SMT2 (["; keccak assumptions"] <> fmap propToSMT (keccakInj ps)) mempty
+
 assertProps :: [Prop] -> SMT2
 assertProps ps =
   let encs = map propToSMT ps_elim
@@ -117,6 +122,7 @@ assertProps ps =
   <> (declareFrameContext . nubOrd $ foldl (<>) [] frameCtx)
   <> intermediates
   <> SMT2 [""] mempty
+  <> keccakAssumptions ps
   <> SMT2 (fmap (\p -> "(assert " <> p <> ")") encs) mempty
 
   where

--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -106,9 +106,10 @@ declareIntermediates bufs stores =
     encodeStore n expr =
        "(define-const store" <> (T.pack . show $ n) <> " Storage " <> exprToSMT expr <> ")"
 
-keccakAssumptions :: [Prop] -> SMT2
-keccakAssumptions ps =
-  SMT2 (["; keccak assumptions"] <> fmap propToSMT (keccakInj ps)) mempty
+keccakAssumptions :: [Prop] -> [Expr Buf] -> [Expr Storage] -> SMT2
+keccakAssumptions ps bufs stores =
+  let asserts = fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakInj ps bufs stores) in
+  SMT2 (["; keccak assumptions"] <> asserts) mempty
 
 assertProps :: [Prop] -> SMT2
 assertProps ps =
@@ -122,7 +123,7 @@ assertProps ps =
   <> (declareFrameContext . nubOrd $ foldl (<>) [] frameCtx)
   <> intermediates
   <> SMT2 [""] mempty
-  <> keccakAssumptions ps
+  <> keccakAssumptions ps_elim bufVals storeVals
   <> SMT2 (fmap (\p -> "(assert " <> p <> ")") encs) mempty
 
   where

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -1217,7 +1217,7 @@ tests = testGroup "hevm"
           [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLn "oob byte reads always return 0"
         ,
-        expectFail $ testCase "injectivity of keccak (32 bytes)" $ do
+        testCase "injectivity of keccak (32 bytes)" $ do
           Just c <- solcRuntime "A"
             [i|
             contract A {


### PR DESCRIPTION
Adds assumptions about injectivity of Keccak in the SMT encoding. It works by collecting all distinct occurrences Keccak calls in the Expr code and combining them pairwise to generate assertions of the form `(b1 = b2 \/ ~ Keccak b1 = Keccak b2)`.