### PR TITLE
Format: cleaner formatting for end buffers in formatExpr

### DIFF
--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -33,6 +33,7 @@ import qualified Data.ByteString as BS
 import Data.Bifunctor (first, second)
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import Data.List (find)
 import Data.Maybe (isJust, fromJust)
 import EVM.Format (formatExpr)
@@ -600,9 +601,9 @@ verify :: SolverGroup -> VeriOpts -> VM -> Maybe (Fetch.BlockNumber, Text) -> Ma
 verify solvers opts preState rpcinfo maybepost = do
   putStrLn "Exploring contract"
   exprInter <- evalStateT (interpret (Fetch.oracle solvers Nothing) Nothing Nothing runExpr) preState
-  when (debug opts) $ putStrLn $ " --- expr pre-simplify BEGIN ---\n" <> (formatExpr exprInter) <> "--- expr pre-simplify END ---\n"
+  when (debug opts) $ T.putStrLn $ " --- expr pre-simplify BEGIN ---\n" <> (formatExpr exprInter) <> "--- expr pre-simplify END ---\n"
   expr <- if (simp opts) then (pure $ simplify exprInter) else pure exprInter
-  when (debug opts) $ putStrLn $ " --- expr BEGIN ---\n" <> (formatExpr expr) <> "\n--- expr END ---\n"
+  when (debug opts) $ T.putStrLn $ " --- expr BEGIN ---\n" <> (formatExpr expr) <> "\n--- expr END ---\n"
   when (debug opts) $ putStrLn $ "Explored contract (" <> show (Expr.numBranches expr) <> " branches)"
   let leaves = flattenExpr expr
   when (debug opts) $ putStrLn $ " --- leaves BEGIN ---\n" <> (show leaves) <> "\n--- leaves END ---\n"


### PR DESCRIPTION
## Description

Makes `formatExpr` a little nicer, and formats the end state buffers as a vertically aligned stack of writes. Also adds nice formatting for concrete buffers in the end state.

As an example this contract:

```
          contract SafeAdd {
            function add(uint x, uint y) public pure returns (uint z) {
                 require((z = x + y) >= x);
            }
          }
```

Used to be formatted as:

```
(ITE (IsZero (CallValue 0))
  (ITE (LT (BufLength (AbstractBuf "txdata")) (Lit 0x4))
    (Revert ConcreteBuf "")
    (ITE (Eq (Lit 0x771602f7) (JoinBytes (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (ReadByte (Lit 0x0) (AbstractBuf "txdata")) (ReadByte (Lit 0x1) (AbstractBuf "txdata")) (ReadByte (Lit 0x2) (AbstractBuf "txdata")) (ReadByte (Lit 0x3) (AbstractBuf "txdata"))))
      (ITE (IsZero (SLT (Sub (Add (Lit 0x4) (Sub (BufLength (AbstractBuf "txdata")) (Lit 0x4))) (Lit 0x4)) (Lit 0x40)))
        (ITE (Eq (ReadWord (Lit 0x4) (AbstractBuf "txdata")) (ReadWord (Lit 0x4) (AbstractBuf "txdata")))
          (ITE (Eq (ReadWord (Lit 0x24) (AbstractBuf "txdata")) (ReadWord (Lit 0x24) (AbstractBuf "txdata")))
            (ITE (IsZero (GT (ReadWord (Lit 0x4) (AbstractBuf "txdata")) (Sub (Lit 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) (ReadWord (Lit 0x24) (AbstractBuf "txdata")))))
              (ITE (IsZero (LT (Add (ReadWord (Lit 0x4) (AbstractBuf "txdata")) (ReadWord (Lit 0x24) (AbstractBuf "txdata"))) (ReadWord (Lit 0x4) (AbstractBuf "txdata"))))
                (Return
                  Data: CopySlice (Lit 0x80) (Lit 0x0) (Lit 0x20) (WriteWord (Lit 0x80) (Add (ReadWord (Lit 0x4) (AbstractBuf "txdata")) (ReadWord (Lit 0x24) (AbstractBuf "txdata"))) (ConcreteBuf "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\128")) (ConcreteBuf "")
                  Store: AbstractStore
                )
                (Revert ConcreteBuf "")
              )
              (Revert ConcreteBuf "NH{q\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\DC1")
            )
            (Revert ConcreteBuf "")
          )
          (Revert ConcreteBuf "")
        )
        (Revert ConcreteBuf "")
      )
      (Revert ConcreteBuf "")
    )
  )
  (Revert ConcreteBuf "")
)
```

And now looks like:

```
(ITE (IsZero (CallValue 0))
  (ITE (LT (BufLength (AbstractBuf "txdata")) (Lit 0x4))
    (Revert (ConcreteBuf ""))
    (ITE (Eq (Lit 0x771602f7) (JoinBytes (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (LitByte 0) (ReadByte (Lit 0x0) (AbstractBuf "txdata")) (ReadByte (Lit 0x1) (AbstractBuf "txdata")) (ReadByte (Lit 0x2) (AbstractBuf "txdata")) (ReadByte (Lit 0x3) (AbstractBuf "txdata"))))
      (ITE (IsZero (SLT (Sub (BufLength (AbstractBuf "txdata")) (Lit 0x4)) (Lit 0x40)))
        (ITE (IsZero (LT (Sub (Lit 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) (ReadWord (Lit 0x24) (AbstractBuf "txdata"))) (ReadWord (Lit 0x4) (AbstractBuf "txdata"))))
          (ITE (IsZero (LT (Add (ReadWord (Lit 0x4) (AbstractBuf "txdata")) (ReadWord (Lit 0x24) (AbstractBuf "txdata"))) (ReadWord (Lit 0x4) (AbstractBuf "txdata"))))
            (Return
              Data:
                (CopySlice
                  srcOffset: 0x80
                  dstOffset: 0x0
                  size:      0x20
                  src:
                    (WriteWord
                      idx: 0x80
                      val: Add (ReadWord (Lit 0x4) (AbstractBuf "txdata")) (ReadWord (Lit 0x24) (AbstractBuf "txdata"))
                    )
                    (ConcreteBuf
                      Length: 96 (0x60) bytes
                      0000:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                      0010:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                      0020:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                      0030:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                      0040:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                      0050:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 80                 ................
                    )

                )
                (ConcreteBuf "")

              Store:
                AbstractStore
            )
            (Revert (ConcreteBuf ""))
          )
          (Revert
            (ConcreteBuf
              Length: 36 (0x24) bytes
              0000:   4e 48 7b 71  00 00 00 00  00 00 00 00  00 00 00 00   NH{q............
              0010:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
              0020:   00 00 00 11                                                        ....
            )
          )
        )
        (Revert (ConcreteBuf ""))
      )
      (Revert (ConcreteBuf ""))
    )
  )
  (Revert (ConcreteBuf ""))
)
```
## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
