### PR TITLE
Test div, sdiv, mod, smod by zero when doing it on constants

### DIFF
--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -1476,7 +1476,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (_, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
+          [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn "div/mod/sdiv/smod by zero works as expected during constant propagation"
         ,
         testCase "check-asm-byte-oob" $ do

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -1449,7 +1449,7 @@ tests = testGroup "hevm"
           [Qed _] <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLn "in bounds byte reads return the expected value"
         ,
-        testCase "check-div-mod-sdiv-by-zero-constant-prop" $ do
+        testCase "check-div-mod-sdiv-smod-by-zero-constant-prop" $ do
           Just c <- solcRuntime "C"
             [i|
             contract C {
@@ -1469,11 +1469,15 @@ tests = testGroup "hevm"
                 assert(z == 0);
                 assembly { z := mod(x,y) }
                 assert(z == 0);
+                assembly { z := smod(y,x) }
+                assert(z == 0);
+                assembly { z := smod(x,y) }
+                assert(z == 0);
               }
             }
             |]
           (_, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("foo(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
-          putStrLn "div/mod/sdiv by zero works as expected during constant propagation"
+          putStrLn "div/mod/sdiv/smod by zero works as expected during constant propagation"
         ,
         testCase "check-asm-byte-oob" $ do
           Just c <- solcRuntime "C"


### PR DESCRIPTION
## Description
This was inspired by our discussion on the chat. Tests that when working with constants, we indeed get 0 for all div/sdiv/mod/smod-by-zero.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
