### PR TITLE
ci: bump install-nix-action to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: cachix/install-nix-action@v14.1
+      - uses: cachix/install-nix-action@v18
         with:
           # https://discourse.nixos.org/t/understanding-binutils-darwin-wrapper-nix-support-bad-substitution/11475/2
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: cachix/install-nix-action@v14.1
+      - uses: cachix/install-nix-action@v18
 
       - name: build docs
         run: nix-shell --pure --command "cd doc && mdbook build"


### PR DESCRIPTION
Bumps `install-nix-action` to latest, squashing a warning regarding outdated nodejs versions in ci