### PR TITLE
Group error cases in Expr

### DIFF
--- a/src/hevm/src/EVM.hs
+++ b/src/hevm/src/EVM.hs
@@ -11,7 +11,7 @@ import Prelude hiding (log, exponent, GT, LT)
 import Data.Text (unpack)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import EVM.ABI
-import EVM.Types hiding (IllegalOverflow)
+import EVM.Types hiding (IllegalOverflow, Error)
 import EVM.Solidity
 import EVM.Concrete (createAddress, create2Address)
 import EVM.Op

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -346,14 +346,14 @@ runExpr = do
     Nothing -> error "Internal Error: vm in intermediate state after call to runFully"
     Just (VMSuccess buf) -> Return asserts buf (view (env . EVM.storage) vm)
     Just (VMFailure e) -> case e of
-      UnrecognizedOpcode _ -> Invalid asserts
-      SelfDestruction -> SelfDestruct asserts
-      EVM.StackLimitExceeded -> EVM.Types.StackLimitExceeded asserts
-      EVM.IllegalOverflow -> EVM.Types.IllegalOverflow asserts
+      UnrecognizedOpcode _ -> Failure asserts Invalid
+      SelfDestruction -> Failure asserts SelfDestruct
+      EVM.StackLimitExceeded -> Failure asserts EVM.Types.StackLimitExceeded
+      EVM.IllegalOverflow -> Failure asserts EVM.Types.IllegalOverflow
       EVM.Revert buf -> EVM.Types.Revert asserts buf
-      EVM.InvalidMemoryAccess -> EVM.Types.InvalidMemoryAccess asserts
-      EVM.BadJumpDestination -> EVM.Types.BadJumpDestination asserts
-      e' -> EVM.Types.TmpErr asserts $ show e'
+      EVM.InvalidMemoryAccess -> Failure asserts EVM.Types.InvalidMemoryAccess
+      EVM.BadJumpDestination -> Failure asserts EVM.Types.BadJumpDestination
+      e' -> Failure asserts $ EVM.Types.TmpErr (show e')
 
 -- | Converts a given top level expr into a list of final states and the associated path conditions for each state
 flattenExpr :: Expr End -> [([Prop], Expr End)]
@@ -362,15 +362,10 @@ flattenExpr = go []
     go :: [Prop] -> Expr End -> [([Prop], Expr End)]
     go pcs = \case
       ITE c t f -> go (PNeg ((PEq c (Lit 0))) : pcs) t <> go (PEq c (Lit 0) : pcs) f
-      e@(Invalid _)  -> [(pcs, e)]
-      e@(SelfDestruct _) -> [(pcs, e)]
       e@(Revert _ _) -> [(pcs, e)]
       e@(Return _ _ _) -> [(pcs, e)]
-      e@(EVM.Types.IllegalOverflow _) -> [(pcs, e)]
-      e@(EVM.Types.StackLimitExceeded _ ) -> [(pcs, e)]
-      e@(EVM.Types.InvalidMemoryAccess _) -> [(pcs, e)]
-      e@(EVM.Types.BadJumpDestination _) -> [(pcs, e)]
-      TmpErr _ s -> error s
+      Failure _ (TmpErr s) -> error s
+      e@(Failure _ _) -> [(pcs, e)]
       GVar _ -> error "cannot flatten an Expr containing a GVar"
 
 -- | Strips unreachable branches from a given expr
@@ -413,6 +408,7 @@ reachable solvers e = do
           Unsat -> pure ([query], Nothing)
           r -> error $ "Invalid solver result: " <> show r
 
+
 -- | Evaluate the provided proposition down to its most concrete result
 evalProp :: Prop -> Prop
 evalProp = \case
@@ -450,15 +446,9 @@ evalProp = \case
 extractProps :: Expr End -> [Prop]
 extractProps = \case
   ITE _ _ _ -> []
-  Invalid asserts -> asserts
-  SelfDestruct asserts -> asserts
   Revert asserts _ -> asserts
   Return asserts _ _ -> asserts
-  EVM.Types.IllegalOverflow asserts -> asserts
-  EVM.Types.StackLimitExceeded asserts -> asserts
-  EVM.Types.InvalidMemoryAccess asserts -> asserts
-  EVM.Types.BadJumpDestination asserts -> asserts
-  TmpErr asserts _ -> asserts
+  Failure asserts _ -> asserts
   GVar _ -> error "cannot extract props from a GVar"
 
 
@@ -538,14 +528,9 @@ equivalenceCheck solvers bytecodeA bytecodeB opts signature' = do
             (Revert _ a, Revert _ b) -> if a==b then PBool False else a ./= b
             (Revert _ _, _) -> PBool True
             (_, Revert _ _) -> PBool True
-            (Invalid _, Invalid _) -> PBool False
-            (Invalid _, _ ) -> PBool True
-            (_, Invalid _) -> PBool True
-            (EVM.Types.StackLimitExceeded _, EVM.Types.StackLimitExceeded _ ) -> PBool False
-            (EVM.Types.StackLimitExceeded _, _) -> PBool True
-            (_, EVM.Types.StackLimitExceeded _) -> PBool True
-            (a, b) -> if a == b then PBool False
-                                else error $ "Unimplemented, see TODO about EVM failures and TmpExpr. Left: " <> show a <> " Right: " <> show b
+            (Failure erra _, Failure errb _) -> if erra==errb then PBool False else PBool True
+            (ITE _ _ _, _ ) -> error "Expressions must be flattened"
+            (_, ITE _ _ _) -> error "Expressions must be flattened"
 
         -- if the SMT solver can find a common input that satisfies BOTH sets of path conditions
         -- AND the output differs, then we are in trouble. We do this for _every_ pair of paths, which

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -366,6 +366,7 @@ flattenExpr = go []
       e@(Return _ _ _) -> [(pcs, e)]
       Failure _ (TmpErr s) -> error s
       e@(Failure _ _) -> [(pcs, e)]
+
       GVar _ -> error "cannot flatten an Expr containing a GVar"
 
 -- | Strips unreachable branches from a given expr

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -528,7 +528,9 @@ equivalenceCheck solvers bytecodeA bytecodeB opts signature' = do
             (Revert _ a, Revert _ b) -> if a==b then PBool False else a ./= b
             (Revert _ _, _) -> PBool True
             (_, Revert _ _) -> PBool True
-            (Failure erra _, Failure errb _) -> if erra==errb then PBool False else PBool True
+            (Failure _ (TmpErr s), _) -> error $ "Unhandled error: " <> s
+            (_, Failure _ (TmpErr s)) -> error $ "Unhandled error: " <> s
+            (Failure _ erra, Failure _ errb) -> if erra==errb then PBool False else PBool True
             (ITE _ _ _, _ ) -> error "Expressions must be flattened"
             (_, ITE _ _ _) -> error "Expressions must be flattened"
 

--- a/src/hevm/src/EVM/SymExec.hs
+++ b/src/hevm/src/EVM/SymExec.hs
@@ -366,7 +366,6 @@ flattenExpr = go []
       e@(Return _ _ _) -> [(pcs, e)]
       Failure _ (TmpErr s) -> error s
       e@(Failure _ _) -> [(pcs, e)]
-
       GVar _ -> error "cannot flatten an Expr containing a GVar"
 
 -- | Strips unreachable branches from a given expr

--- a/src/hevm/src/EVM/Traversals.hs
+++ b/src/hevm/src/EVM/Traversals.hs
@@ -66,16 +66,10 @@ foldExpr f acc expr = acc <> (go expr)
 
       -- control flow
 
-      e@(Invalid a) -> f e <> (foldl (foldProp f) mempty a)
-      e@(StackLimitExceeded a) -> f e <> (foldl (foldProp f) mempty a)
-      e@(InvalidMemoryAccess a) -> f e <> (foldl (foldProp f) mempty a)
-      e@(BadJumpDestination a) -> f e <> (foldl (foldProp f) mempty a)
-      e@(SelfDestruct a) -> f e <> (foldl (foldProp f) mempty a)
-      e@(IllegalOverflow a) -> f e <> (foldl (foldProp f) mempty a)
       e@(Revert a b) -> f e <> (foldl (foldProp f) mempty a) <> (go b)
       e@(Return a b c) -> f e <> (foldl (foldProp f) mempty a) <> (go b) <> (go c)
       e@(ITE a b c) -> f e <> (go a) <> (go b) <> (go c)
-      e@(TmpErr a _) -> f e <> (foldl (foldProp f) mempty a)
+      e@(Failure a _) -> f e <> (foldl (foldProp f) mempty a)
 
       -- integers
 
@@ -314,24 +308,9 @@ mapExprM f expr = case expr of
 
   -- control flow
 
-  Invalid a -> do
+  Failure a b -> do
     a' <- mapM (mapPropM f) a
-    f (Invalid a')
-  SelfDestruct a -> do
-    a' <- mapM (mapPropM f) a
-    f (SelfDestruct a')
-  IllegalOverflow a -> do
-    a' <- mapM (mapPropM f) a
-    f (IllegalOverflow a')
-  InvalidMemoryAccess a -> do
-    a' <- mapM (mapPropM f) a
-    f (InvalidMemoryAccess a')
-  StackLimitExceeded a -> do
-    a' <- mapM (mapPropM f) a
-    f (StackLimitExceeded a')
-  BadJumpDestination a -> do
-    a' <- mapM (mapPropM f) a
-    f (BadJumpDestination a')
+    f (Failure a' b)
   Revert a b -> do
     a' <- mapM (mapPropM f) a
     b' <- mapExprM f b
@@ -347,10 +326,6 @@ mapExprM f expr = case expr of
     b' <- mapExprM f b
     c' <- mapExprM f c
     f (ITE a' b' c')
-
-  TmpErr a b -> do
-    a' <- mapM (mapPropM f) a
-    f (TmpErr a' b)
 
   -- integers
 

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -115,6 +115,16 @@ data EType
   | End
   deriving (Typeable)
 
+data Error
+  = Invalid
+  | IllegalOverflow
+  | StackLimitExceeded
+  | InvalidMemoryAccess
+  | BadJumpDestination
+  | SelfDestruct
+  | TmpErr String
+  deriving (Show, Eq, Ord)
+
 -- Variables refering to a global environment
 data GVar (a :: EType) where
   BufVar :: Int -> GVar Buf
@@ -152,17 +162,11 @@ data Expr (a :: EType) where
                  -> Expr EWord
   -- control flow
 
-  Invalid             :: [Prop] -> Expr End
-  IllegalOverflow     :: [Prop] -> Expr End
-  SelfDestruct        :: [Prop] -> Expr End
-  StackLimitExceeded  :: [Prop] -> Expr End
-  InvalidMemoryAccess :: [Prop] -> Expr End
-  BadJumpDestination  :: [Prop] -> Expr End
   Revert              :: [Prop] -> Expr Buf -> Expr End
+  Failure             :: [Prop] -> Error -> Expr End
   Return              :: [Prop] -> Expr Buf -> Expr Storage -> Expr End
   ITE                 :: Expr EWord -> Expr End -> Expr End -> Expr End
-  TmpErr              :: [Prop] -> String -> Expr End -- TODO this is a crutch to help us not deal with all EVM failure modes in Expr
-                                                      --      should be removed once EVM failure modes are handled in Expr
+
   -- integers
 
   Add            :: Expr EWord -> Expr EWord -> Expr EWord

--- a/src/hevm/src/EVM/Types.hs
+++ b/src/hevm/src/EVM/Types.hs
@@ -115,6 +115,7 @@ data EType
   | End
   deriving (Typeable)
 
+-- EVM errors
 data Error
   = Invalid
   | IllegalOverflow

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -17,7 +17,7 @@ import EVM.Format
 import EVM.Solidity
 import qualified EVM.SymExec as SymExec
 import EVM.SymExec (defaultVeriOpts, symCalldata, verify, isQed, extractCex, runExpr, subModel, VeriOpts)
-import EVM.Types
+import EVM.Types hiding (Failure)
 import EVM.Transaction (initTx)
 import EVM.RLP
 import qualified EVM.Facts     as Facts

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -26,12 +26,12 @@ import Data.Typeable
 import Data.List (elemIndex)
 import Data.DoubleWord
 import Test.Tasty
-import Test.Tasty.QuickCheck
+import Test.Tasty.QuickCheck hiding (Failure)
 import Test.QuickCheck.Instances.Text()
 import Test.QuickCheck.Instances.Natural()
 import Test.QuickCheck.Instances.ByteString()
 import Test.Tasty.HUnit
-import Test.Tasty.Runners
+import Test.Tasty.Runners hiding (Failure)
 import Test.Tasty.ExpectedFailure
 
 import Control.Monad.State.Strict (execState, runState)
@@ -2275,9 +2275,9 @@ genName = fmap (T.pack . ("esc_" <> )) $ listOf1 (oneof . (fmap pure) $ ['a'..'z
 
 genEnd :: Int -> Gen (Expr End)
 genEnd 0 = oneof
- [ pure $ Invalid []
- , pure $ EVM.Types.IllegalOverflow []
- , pure $ SelfDestruct []
+ [ pure $ Failure [] Invalid
+ , pure $ Failure [] EVM.Types.IllegalOverflow
+ , pure $ Failure [] SelfDestruct
  ]
 genEnd sz = oneof
  [ fmap (EVM.Types.Revert []) subBuf


### PR DESCRIPTION
Instead of having an `Expr` constructor for each EVM failure case, this groups failures under the same constructor with the help of an auxiliary data type. This helps avoiding repetition when pattern matching against `Expr` and makes it easier to add new error cases. 

I'm not very attached to it, just thought it would be cleaner and wanted to try it out. 