### PR TITLE
Fix verify rpc

### DIFF
--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -267,10 +267,10 @@ unitTestOptions cmd solvers testFile = do
        else EVM.Fetch.BlockNumber testn
 
   pure EVM.UnitTest.UnitTestOptions
-    { EVM.UnitTest.oracle =
-        case rpc cmd of
-         Just url -> EVM.Fetch.oracle solvers (Just (block', url))
-         Nothing  -> EVM.Fetch.oracle solvers Nothing
+    { EVM.UnitTest.solvers = solvers
+    , EVM.UnitTest.rpcInfo = case rpc cmd of
+         Just url -> Just (block', url)
+         Nothing  -> Nothing
     , EVM.UnitTest.maxIter = maxIterations cmd
     , EVM.UnitTest.askSmtIters = askSmtIterations cmd
     , EVM.UnitTest.smtdebug = smtdebug cmd
@@ -311,7 +311,7 @@ main = do
           testOpts <- unitTestOptions cmd solvers testFile
           case (coverage cmd, optsMode cmd) of
             (False, Run) -> do
-              res <- dappTest testOpts solvers testFile (cache cmd)
+              res <- dappTest testOpts testFile (cache cmd)
               unless res exitFailure
             (False, Debug) -> liftIO $ TTY.main testOpts root testFile
             (False, JsonTrace) -> error "json traces not implemented for dappTest"
@@ -361,9 +361,10 @@ equivalence cmd = do
   let bytecodeA = hexByteString "--code" . strip0x $ codeA cmd
       bytecodeB = hexByteString "--code" . strip0x $ codeB cmd
       veriOpts = VeriOpts { simp = True
-                            , debug = False
-                            , maxIter = maxIterations cmd
-                            , askSmtIters = askSmtIterations cmd
+                          , debug = False
+                          , maxIter = maxIterations cmd
+                          , askSmtIters = askSmtIterations cmd
+                          , rpcInfo = Nothing
                           }
 
   withSolvers Z3 3 Nothing $ \s -> do
@@ -420,13 +421,14 @@ assert cmd = do
     if Main.debug cmd then do
       srcInfo <- getSrcInfo cmd
       void $ TTY.runFromVM
+        solvers
+        rpcinfo
         (maxIterations cmd)
         srcInfo
-        (EVM.Fetch.oracle solvers rpcinfo)
         preState
     else do
-      let opts = VeriOpts { simp = False, debug = False, maxIter = (maxIterations cmd), askSmtIters = (askSmtIterations cmd)}
-      res <- verify solvers opts preState rpcinfo (Just $ checkAssertions errCodes)
+      let opts = VeriOpts { simp = False, debug = False, maxIter = (maxIterations cmd), askSmtIters = (askSmtIterations cmd), rpcInfo = rpcinfo}
+      res <- verify solvers opts preState (Just $ checkAssertions errCodes)
       case res of
         [Qed _] -> putStrLn "QED: No reachable property violations discovered"
         cexs -> do
@@ -569,41 +571,42 @@ launchExec cmd = do
   dapp <- getSrcInfo cmd
   vm <- vmFromCommand cmd
   smtjobs <- fromIntegral <$> getNumProcessors
-  case optsMode cmd of
-    Run -> do
-      vm' <- execStateT (EVM.Stepper.interpret (fetcher smtjobs) . void $ EVM.Stepper.execFully) vm
-      --when (trace cmd) $ hPutStr stderr (showTraceTree dapp vm')
-      case view EVM.result vm' of
-        Nothing ->
-          error "internal error; no EVM result"
-        Just (EVM.VMFailure (EVM.Revert msg)) -> do
-          let res = case msg of
-                      ConcreteBuf bs -> bs
-                      _ -> "<symbolic>"
-          print $ ByteStringS res
-          exitWith (ExitFailure 2)
-        Just (EVM.VMFailure err) -> do
-          print err
-          exitWith (ExitFailure 2)
-        Just (EVM.VMSuccess buf) -> do
-          let msg = case buf of
-                ConcreteBuf msg' -> msg'
-                _ -> "<symbolic>"
-          print $ ByteStringS msg
-          case state cmd of
-            Nothing -> pure ()
-            Just path ->
-              Git.saveFacts (Git.RepoAt path) (Facts.vmFacts vm')
-          case cache cmd of
-            Nothing -> pure ()
-            Just path ->
-              Git.saveFacts (Git.RepoAt path) (Facts.cacheFacts (view EVM.cache vm'))
+  withSolvers Z3 smtjobs (smttimeout cmd) $ \solvers -> do
+    case optsMode cmd of
+      Run -> do
+        vm' <- execStateT (EVM.Stepper.interpret (EVM.Fetch.oracle solvers rpcinfo) . void $ EVM.Stepper.execFully) vm
+        --when (trace cmd) $ hPutStr stderr (showTraceTree dapp vm')
+        case view EVM.result vm' of
+          Nothing ->
+            error "internal error; no EVM result"
+          Just (EVM.VMFailure (EVM.Revert msg)) -> do
+            let res = case msg of
+                        ConcreteBuf bs -> bs
+                        _ -> "<symbolic>"
+            print $ ByteStringS res
+            exitWith (ExitFailure 2)
+          Just (EVM.VMFailure err) -> do
+            print err
+            exitWith (ExitFailure 2)
+          Just (EVM.VMSuccess buf) -> do
+            let msg = case buf of
+                  ConcreteBuf msg' -> msg'
+                  _ -> "<symbolic>"
+            print $ ByteStringS msg
+            case state cmd of
+              Nothing -> pure ()
+              Just path ->
+                Git.saveFacts (Git.RepoAt path) (Facts.vmFacts vm')
+            case cache cmd of
+              Nothing -> pure ()
+              Just path ->
+                Git.saveFacts (Git.RepoAt path) (Facts.cacheFacts (view EVM.cache vm'))
 
-    Debug -> void $ TTY.runFromVM Nothing dapp (fetcher smtjobs) vm
-    --JsonTrace -> void $ execStateT (interpretWithTrace fetcher EVM.Stepper.runFully) vm
-    _ -> error "TODO"
-   where fetcher smtjobs = maybe (EVM.Fetch.zero smtjobs (smttimeout cmd)) (EVM.Fetch.http smtjobs (smttimeout cmd) block') (rpc cmd)
-         block' = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
+      Debug -> void $ TTY.runFromVM solvers rpcinfo Nothing dapp vm
+      --JsonTrace -> void $ execStateT (interpretWithTrace fetcher EVM.Stepper.runFully) vm
+      _ -> error "TODO"
+     where block' = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
+           rpcinfo = (,) block' <$> rpc cmd
 
 data Testcase = Testcase {
   _entries :: [(Text, Maybe Text)],
@@ -892,7 +895,7 @@ runVMTest diffmode mode timelimit (name, x) =
           Timeout.timeout (1000000 * (fromMaybe 10 timelimit)) $
             execStateT (EVM.Stepper.interpret (EVM.Fetch.zero 0 (Just 0)) . void $ EVM.Stepper.execFully) vm0
         Debug ->
-          Just <$> TTY.runFromVM Nothing emptyDapp (EVM.Fetch.zero 0 (Just 0)) vm0
+          withSolvers Z3 0 Nothing $ \solvers -> Just <$> TTY.runFromVM solvers Nothing Nothing emptyDapp vm0
         JsonTrace ->
           error "JsonTrace: implement me"
           -- Just <$> execStateT (EVM.UnitTest.interpretWithCoverage EVM.Fetch.zero EVM.Stepper.runFully) vm0

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -691,15 +691,11 @@ vmFromCommand cmd = do
         Just contract' ->
           -- if both code and url is given,
           -- fetch the contract and overwrite the code
-          undefined
-            {-
           return $
-            EVM.initialContract  (codeType $ hexByteString "--code" $ strip0x c)
-              & set EVM.storage  (view EVM.storage  contract')
+            EVM.initialContract  (mkCode $ hexByteString "--code" $ strip0x c)
               & set EVM.balance  (view EVM.balance  contract')
               & set EVM.nonce    (view EVM.nonce    contract')
               & set EVM.external (view EVM.external contract')
-            -}
 
     (Just url, Just addr', Nothing) ->
       EVM.Fetch.fetchContractFrom block' url addr' >>= \case

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -239,10 +239,6 @@ common test-base
     test
   extra-libraries:
     secp256k1
-  if os(darwin)
-     extra-libraries: c++
-  else
-     extra-libraries: stdc++
   other-modules:
     Paths_hevm
   autogen-modules:
@@ -287,6 +283,10 @@ common test-common
     test-base
   build-depends:
     test-utils
+  if os(darwin)
+     extra-libraries: c++
+  else
+     extra-libraries: stdc++
 
 --- Test Suites ---
 

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -37,6 +37,7 @@ extra-source-files:
   test/contracts/pass/invariants.sol
   test/contracts/pass/libraries.so
   test/contracts/pass/loops.sol
+  test/contracts/pass/rpc.sol
   test/contracts/fail/trivial.sol
   test/contracts/fail/cheatCodes.sol
   test/contracts/fail/dsProveFail.sol
@@ -230,7 +231,7 @@ executable hevm
     vector,
     vty
 
-common test-common
+common test-base
   import: shared
   ghc-options:
     -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j
@@ -274,6 +275,20 @@ common test-common
     array,
     vector,
     smt2-parser >= 0.1.0.1
+
+library test-utils
+  import:
+    test-base
+  exposed-modules:
+    EVM.TestUtils
+
+common test-common
+  import:
+    test-base
+  build-depends:
+    test-utils
+
+--- Test Suites ---
 
 test-suite test
   import:

--- a/src/hevm/src/EVM/Dev.hs
+++ b/src/hevm/src/EVM/Dev.hs
@@ -48,7 +48,7 @@ runDappTest root =
     let testFile = root <> "/out/dapp.sol.json"
     withSolvers Z3 cores Nothing $ \solvers -> do
       opts <- testOpts solvers root testFile
-      res <- dappTest opts solvers testFile Nothing
+      res <- dappTest opts testFile Nothing
       unless res exitFailure
 
 testOpts :: SolverGroup -> FilePath -> FilePath -> IO UnitTestOptions
@@ -67,8 +67,10 @@ testOpts solvers root testFile = do
        else Fetch.BlockNumber testn
 
   pure EVM.UnitTest.UnitTestOptions
-    { EVM.UnitTest.oracle = Fetch.oracle solvers Nothing
+    { EVM.UnitTest.solvers = solvers
+    , EVM.UnitTest.rpcInfo = Nothing
     , EVM.UnitTest.maxIter = Nothing
+    , EVM.UnitTest.smtdebug = False
     , EVM.UnitTest.askSmtIters = Nothing
     , EVM.UnitTest.smtTimeout = Nothing
     , EVM.UnitTest.solver = Nothing

--- a/src/hevm/src/EVM/Fetch.hs
+++ b/src/hevm/src/EVM/Fetch.hs
@@ -46,6 +46,8 @@ data BlockNumber = Latest | BlockNumber W256
 
 deriving instance Show (RpcQuery a)
 
+type RpcInfo = Maybe (BlockNumber, Text)
+
 rpc :: String -> [Value] -> Value
 rpc method args = object
   [ "jsonrpc" .= ("2.0" :: String)
@@ -182,7 +184,7 @@ zero smtjobs smttimeout q =
     oracle s Nothing q
 
 -- smtsolving + (http or zero)
-oracle :: SolverGroup -> Maybe (BlockNumber, Text) -> Fetcher
+oracle :: SolverGroup -> RpcInfo -> Fetcher
 oracle solvers info q = do
   case q of
     EVM.PleaseDoFFI vals continue -> case vals of

--- a/src/hevm/src/EVM/SMT.hs
+++ b/src/hevm/src/EVM/SMT.hs
@@ -32,6 +32,7 @@ import qualified Data.List as List
 import qualified Data.List.NonEmpty as NE
 import Data.List.NonEmpty (NonEmpty, NonEmpty((:|)))
 import Data.String.Here
+import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Text.Lazy (Text)
@@ -77,6 +78,9 @@ data SMTCex = SMTCex
   , txContext :: Map (Expr EWord) W256
   }
   deriving (Eq, Show)
+
+getVar :: EVM.SMT.SMTCex -> TS.Text -> W256
+getVar cex name = fromJust $ Map.lookup (Var name) (vars cex)
 
 data SMT2 = SMT2 [Builder] CexVars
   deriving (Eq, Show)

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -130,6 +130,7 @@ makeVeriOpts opts =
    defaultVeriOpts { SymExec.debug = smtdebug opts
                    , SymExec.maxIter = maxIter opts
                    , SymExec.askSmtIters = askSmtIters opts
+                   , SymExec.rpcInfo = rpcInfo opts
                    }
 
 -- | Top level CLI endpoint for dapp-test

--- a/src/hevm/src/EVM/UnitTest.hs
+++ b/src/hevm/src/EVM/UnitTest.hs
@@ -22,7 +22,7 @@ import EVM.Transaction (initTx)
 import EVM.RLP
 import qualified EVM.Facts     as Facts
 import qualified EVM.Facts.Git as Git
-import qualified EVM.Fetch
+import qualified EVM.Fetch     as Fetch
 
 import qualified EVM.FeeSchedule as FeeSchedule
 
@@ -71,7 +71,8 @@ import qualified Data.Vector as Vector
 import Test.QuickCheck hiding (verbose)
 
 data UnitTestOptions = UnitTestOptions
-  { oracle      :: EVM.Query -> IO (EVM ())
+  { rpcInfo     :: Fetch.RpcInfo
+  , solvers     :: SolverGroup
   , verbose     :: Maybe Int
   , maxIter     :: Maybe Integer
   , askSmtIters :: Maybe Integer
@@ -132,13 +133,13 @@ makeVeriOpts opts =
                    }
 
 -- | Top level CLI endpoint for dapp-test
-dappTest :: UnitTestOptions -> SolverGroup -> String -> Maybe String -> IO Bool
-dappTest opts solvers solcFile cache = do
+dappTest :: UnitTestOptions -> String -> Maybe String -> IO Bool
+dappTest opts solcFile cache = do
   out <- liftIO $ readSolc solcFile
   case out of
     Just (contractMap, _) -> do
       let unitTests = findUnitTests (EVM.UnitTest.match opts) $ Map.elems contractMap
-      results <- concatMapM (runUnitTestContract opts solvers contractMap) unitTests
+      results <- concatMapM (runUnitTestContract opts contractMap) unitTests
       let (passing, vms) = unzip results
       case cache of
         Nothing ->
@@ -248,9 +249,9 @@ checkFailures UnitTestOptions { .. } method bailed = do
 
 -- | Randomly generates the calldata arguments and runs the test
 fuzzTest :: UnitTestOptions -> Text -> [AbiType] -> VM -> Property
-fuzzTest opts sig types vm = forAllShow (genAbiValue (AbiTupleType $ Vector.fromList types)) (show . ByteStringS . encodeAbiValue)
+fuzzTest opts@UnitTestOptions{..} sig types vm = forAllShow (genAbiValue (AbiTupleType $ Vector.fromList types)) (show . ByteStringS . encodeAbiValue)
   $ \args -> ioProperty $
-    fst <$> runStateT (EVM.Stepper.interpret (oracle opts) (runUnitTest opts sig args)) vm
+    fst <$> runStateT (EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo) (runUnitTest opts sig args)) vm
 
 tick :: Text -> IO ()
 tick x = Text.putStr x >> hFlush stdout
@@ -303,7 +304,7 @@ interpretWithCoverage
   :: UnitTestOptions
   -> Stepper a
   -> StateT CoverageState IO a
-interpretWithCoverage opts =
+interpretWithCoverage opts@UnitTestOptions{..} =
   eval . Operational.view
 
   where
@@ -321,7 +322,7 @@ interpretWithCoverage opts =
         Stepper.Run ->
           runWithCoverage >>= interpretWithCoverage opts . k
         Stepper.Wait q ->
-          do m <- liftIO (oracle opts q)
+          do m <- liftIO ((Fetch.oracle solvers rpcInfo) q)
              zoom _1 (State.state (runState m)) >> interpretWithCoverage opts (k ())
         Stepper.Ask _ ->
           error "cannot make choice in this interpreter"
@@ -417,12 +418,11 @@ coverageForUnitTestContract
 
 runUnitTestContract
   :: UnitTestOptions
-  -> SolverGroup
   -> Map Text SolcContract
   -> (Text, [(Test, [AbiType])])
   -> IO [(Bool, VM)]
 runUnitTestContract
-  opts@(UnitTestOptions {..}) solvers contractMap (name, testSigs) = do
+  opts@(UnitTestOptions {..}) contractMap (name, testSigs) = do
 
   -- Print a header
   liftIO $ putStrLn $ "Running " ++ show (length testSigs) ++ " tests for "
@@ -439,7 +439,7 @@ runUnitTestContract
       let vm0 = initialUnitTestVm opts theContract
       vm1 <-
         liftIO $ execStateT
-          (EVM.Stepper.interpret oracle
+          (EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo)
             (Stepper.enter name >> initializeUnitTest opts theContract))
           vm0
 
@@ -456,7 +456,7 @@ runUnitTestContract
             runCache :: ([(Either Text Text, VM)], VM) -> (Test, [AbiType])
                         -> IO ([(Either Text Text, VM)], VM)
             runCache (results, vm) (test, types) = do
-              (t, r, vm') <- runTest opts solvers vm (test, types)
+              (t, r, vm') <- runTest opts vm (test, types)
               liftIO $ Text.putStrLn t
               let vmCached = vm & set cache (view cache vm')
               pure (((r, vm'): results), vmCached)
@@ -476,9 +476,9 @@ runUnitTestContract
           pure [(isRight r, vm) | (r, vm) <- details]
 
 
-runTest :: UnitTestOptions -> SolverGroup -> VM -> (Test, [AbiType]) -> IO (Text, Either Text Text, VM)
-runTest opts@UnitTestOptions{} _ vm (ConcreteTest testName, []) = liftIO $ runOne opts vm testName emptyAbi
-runTest opts@UnitTestOptions{..} _ vm (ConcreteTest testName, types) = liftIO $ case replay of
+runTest :: UnitTestOptions -> VM -> (Test, [AbiType]) -> IO (Text, Either Text Text, VM)
+runTest opts@UnitTestOptions{} vm (ConcreteTest testName, []) = liftIO $ runOne opts vm testName emptyAbi
+runTest opts@UnitTestOptions{..} vm (ConcreteTest testName, types) = liftIO $ case replay of
   Nothing ->
     fuzzRun opts vm testName types
   Just (sig, callData) ->
@@ -486,14 +486,14 @@ runTest opts@UnitTestOptions{..} _ vm (ConcreteTest testName, types) = liftIO $ 
     then runOne opts vm testName $
       decodeAbiValue (AbiTupleType (Vector.fromList types)) callData
     else fuzzRun opts vm testName types
-runTest opts@UnitTestOptions{..} _ vm (InvariantTest testName, []) = liftIO $ case replay of
+runTest opts@UnitTestOptions{..} vm (InvariantTest testName, []) = liftIO $ case replay of
   Nothing -> exploreRun opts vm testName []
   Just (sig, cds) ->
     if sig == testName
     then exploreRun opts vm testName (decodeCalls cds)
     else exploreRun opts vm testName []
-runTest _ _ _ (InvariantTest _, types) = error $ "invariant testing with arguments: " <> show types <> " is not implemented (yet!)"
-runTest opts solvers vm (SymbolicTest testName, types) = symRun opts solvers vm testName types
+runTest _ _ (InvariantTest _, types) = error $ "invariant testing with arguments: " <> show types <> " is not implemented (yet!)"
+runTest opts vm (SymbolicTest testName, types) = symRun opts vm testName types
 
 type ExploreTx = (Addr, Addr, ByteString, W256)
 
@@ -601,6 +601,7 @@ getTargetContracts UnitTestOptions{..} = do
 
 exploreRun :: UnitTestOptions -> VM -> ABIMethod -> [ExploreTx] -> IO (Text, Either Text Text, VM)
 exploreRun opts@UnitTestOptions{..} initialVm testName replayTxs = do
+  let oracle = Fetch.oracle solvers rpcInfo
   (targets, _) <- runStateT (EVM.Stepper.interpret oracle (getTargetContracts opts)) initialVm
   let depth = fromMaybe 20 maxDepth
   ((x, counterex), vm') <-
@@ -624,7 +625,7 @@ exploreRun opts@UnitTestOptions{..} initialVm testName replayTxs = do
 execTest :: UnitTestOptions -> VM -> ABIMethod -> AbiValue -> IO (Bool, VM)
 execTest opts@UnitTestOptions{..} vm testName args =
   runStateT
-    (EVM.Stepper.interpret oracle (execTestStepper opts testName args))
+    (EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo) (execTestStepper opts testName args))
     vm
 
 -- | Define the thread spawner for normal test cases
@@ -634,7 +635,7 @@ runOne opts@UnitTestOptions{..} vm testName args = do
   (bailed, vm') <- execTest opts vm testName args
   (success, vm'') <-
     runStateT
-      (EVM.Stepper.interpret oracle (checkFailures opts testName bailed)) vm'
+      (EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo) (checkFailures opts testName bailed)) vm'
   if success
   then
      let gasSpent = num (testGasCall testParams) - view (state . gas) vm'
@@ -685,7 +686,7 @@ fuzzRun opts@UnitTestOptions{..} vm testName types = do
           ppOutput = pack $ show abiValue
       in do
         -- Run the failing test again to get a proper trace
-        vm' <- execStateT (EVM.Stepper.interpret oracle (runUnitTest opts testName abiValue)) vm
+        vm' <- execStateT (EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo) (runUnitTest opts testName abiValue)) vm
         pure ("\x1b[31m[FAIL]\x1b[0m "
                <> testName <> ". Counterexample: " <> ppOutput
                <> "\nRun:\n dapp test --replay '(\"" <> testName <> "\",\""
@@ -701,8 +702,8 @@ fuzzRun opts@UnitTestOptions{..} vm testName types = do
               )
 
 -- | Define the thread spawner for symbolic tests
-symRun :: UnitTestOptions -> SolverGroup -> VM -> Text -> [AbiType] -> IO (Text, Either Text Text, VM)
-symRun opts@UnitTestOptions{..} solvers vm testName types = do
+symRun :: UnitTestOptions -> VM -> Text -> [AbiType] -> IO (Text, Either Text Text, VM)
+symRun opts@UnitTestOptions{..} vm testName types = do
     let cd = symCalldata testName types [] (AbstractBuf "txdata")
         shouldFail = "proveFail" `isPrefixOf` testName
         testContract = view (state . contract) vm
@@ -722,13 +723,13 @@ symRun opts@UnitTestOptions{..} solvers vm testName types = do
                                    _ -> PBool False
 
     (_, vm') <- runStateT
-      (EVM.Stepper.interpret oracle (Stepper.evm $ do
+      (EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo) (Stepper.evm $ do
           popTrace
           makeTxCall testParams cd
         )) vm
 
     -- check postconditions against vm
-    results <- verify solvers (makeVeriOpts opts) vm' Nothing (Just postcondition)
+    results <- verify solvers (makeVeriOpts opts) vm' (Just postcondition)
 
     -- display results
     if all isQed results
@@ -962,12 +963,12 @@ initialUnitTestVm (UnitTestOptions {..}) theContract =
 
 getParametersFromEnvironmentVariables :: Maybe Text -> IO TestVMParams
 getParametersFromEnvironmentVariables rpc = do
-  block' <- maybe EVM.Fetch.Latest (EVM.Fetch.BlockNumber . read) <$> (lookupEnv "DAPP_TEST_NUMBER")
+  block' <- maybe Fetch.Latest (Fetch.BlockNumber . read) <$> (lookupEnv "DAPP_TEST_NUMBER")
 
   (miner,ts,blockNum,ran,limit,base) <-
     case rpc of
       Nothing  -> return (0,Lit 0,0,0,0,0)
-      Just url -> EVM.Fetch.fetchBlockFrom block' url >>= \case
+      Just url -> Fetch.fetchBlockFrom block' url >>= \case
         Nothing -> error "Could not fetch block"
         Just EVM.Block{..} -> return (  _coinbase
                                       , _timestamp

--- a/src/hevm/test/EVM/TestUtils.hs
+++ b/src/hevm/test/EVM/TestUtils.hs
@@ -1,0 +1,136 @@
+{-# Language QuasiQuotes #-}
+
+module EVM.TestUtils where
+
+import Data.Text
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Paths_hevm as Paths
+import Data.String.Here
+import System.Directory
+import System.IO.Temp
+import GHC.IO.Handle (hClose)
+import System.Process (readProcess)
+
+import EVM.Solidity
+import EVM.SMT
+import EVM.Dapp
+import EVM.UnitTest
+import EVM.Fetch (RpcInfo)
+import qualified EVM.TTY as TTY
+
+runDappTestCustom :: FilePath -> Text -> Maybe Integer -> Bool -> RpcInfo -> IO Bool
+runDappTestCustom testFile match maxIter ffiAllowed rpcinfo = do
+  root <- Paths.getDataDir
+  (json, _) <- compileWithDSTest testFile
+  T.writeFile "output.json" json
+  withCurrentDirectory root $ do
+    withSystemTempFile "output.json" $ \file handle -> do
+      hClose handle
+      T.writeFile file json
+      withSolvers Z3 1 Nothing $ \solvers -> do
+        opts <- testOpts solvers root json match maxIter ffiAllowed rpcinfo
+        dappTest opts file Nothing
+
+runDappTest :: FilePath -> Text -> IO Bool
+runDappTest testFile match = runDappTestCustom testFile match Nothing True Nothing
+
+debugDappTest :: FilePath -> RpcInfo -> IO ()
+debugDappTest testFile rpcinfo = do
+  root <- Paths.getDataDir
+  (json, _) <- compileWithDSTest testFile
+  --TIO.writeFile "output.json" json
+  withCurrentDirectory root $ do
+    withSystemTempFile "output.json" $ \file handle -> do
+      hClose handle
+      T.writeFile file json
+      withSolvers Z3 1 Nothing $ \solvers -> do
+        opts <- testOpts solvers root json ".*" Nothing True rpcinfo
+        TTY.main opts root file
+
+testOpts :: SolverGroup -> FilePath -> Text -> Text -> Maybe Integer -> Bool -> RpcInfo -> IO UnitTestOptions
+testOpts solvers root solcJson match maxIter allowFFI rpcinfo = do
+  srcInfo <- case readJSON solcJson of
+               Nothing -> error "Could not read solc json"
+               Just (contractMap, asts, sources) -> do
+                 sourceCache <- makeSourceCache sources asts
+                 pure $ dappInfo root contractMap sourceCache
+
+  params <- getParametersFromEnvironmentVariables Nothing
+
+  pure UnitTestOptions
+    { solvers = solvers
+    , rpcInfo = rpcinfo
+    , maxIter = maxIter
+    , askSmtIters = Nothing
+    , smtdebug = False
+    , smtTimeout = Nothing
+    , solver = Nothing
+    , covMatch = Nothing
+    , verbose = Just 1
+    , match = match
+    , maxDepth = Nothing
+    , fuzzRuns = 100
+    , replay = Nothing
+    , vmModifier = id
+    , testParams = params
+    , dapp = srcInfo
+    , ffiAllowed = allowFFI
+    }
+
+compileWithDSTest :: FilePath -> IO (Text, Text)
+compileWithDSTest src =
+  withSystemTempFile "input.json" $ \file handle -> do
+    hClose handle
+    dsTest <- readFile =<< Paths.getDataFileName "test/contracts/lib/test.sol"
+    erc20 <- readFile =<< Paths.getDataFileName "test/contracts/lib/erc20.sol"
+    testFilePath <- Paths.getDataFileName src
+    testFile <- readFile testFilePath
+    T.writeFile file
+      [i|
+      {
+        "language": "Solidity",
+        "sources": {
+          "ds-test/test.sol": {
+            "content": ${dsTest}
+          },
+          "lib/erc20.sol": {
+            "content": ${erc20}
+          },
+          "test.sol": {
+            "content": ${testFile}
+          }
+        },
+        "settings": {
+          "metadata": {
+            "useLiteralContent": true
+          },
+          "outputSelection": {
+            "*": {
+              "*": [
+                "metadata",
+                "evm.bytecode",
+                "evm.deployedBytecode",
+                "abi",
+                "storageLayout",
+                "evm.bytecode.sourceMap",
+                "evm.bytecode.linkReferences",
+                "evm.bytecode.generatedSources",
+                "evm.deployedBytecode.sourceMap",
+                "evm.deployedBytecode.linkReferences",
+                "evm.deployedBytecode.generatedSources"
+              ],
+              "": [
+                "ast"
+              ]
+            }
+          }
+        }
+      }
+      |]
+    x <- T.pack <$>
+      readProcess
+        "solc"
+        ["--allow-paths", file, "--standard-json", file]
+        ""
+    return (x, T.pack testFilePath)

--- a/src/hevm/test/contracts/pass/rpc.sol
+++ b/src/hevm/test/contracts/pass/rpc.sol
@@ -5,27 +5,12 @@ contract C is DSTest {
     // BAL: https://etherscan.io/address/0xba100000625a3754423978a60c9317c58a424e3D#code
     ERC20 bal = ERC20(0xba100000625a3754423978a60c9317c58a424e3D);
 
-    function prove_transfer(address dst, uint amt) public {
-        // ignore cases where we don't have enough tokens
-        if (amt > bal.balanceOf(address(this))) return;
-        if (dst == address(0x0)) return;
-
-        uint preBalThis = bal.balanceOf(address(this));
-        uint preBalDst  = bal.balanceOf(dst);
-
-        bal.transfer(dst, amt);
-
-        // no change for self-transfer
-        uint delta = dst == address(this) ? 0 : amt;
-
-        // balance of `this` has been reduced by `delta`
-        assertEq(preBalThis - delta, bal.balanceOf(address(this)));
-
-        // balance of `dst` has been increased by `delta`
-        assertEq(preBalDst + delta, bal.balanceOf(dst));
+    function test_trivial() public {
+        uint ub = bal.balanceOf(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
+        assertEq(ub, 27099516537379438397130892);
     }
 
-    function testCex() public {
-        prove_transfer(0x8000000000000000000000000000000000000000,0);
+    function prove_trivial() public {
+        test_trivial();
     }
 }

--- a/src/hevm/test/contracts/pass/rpc.sol
+++ b/src/hevm/test/contracts/pass/rpc.sol
@@ -1,0 +1,31 @@
+import {DSTest} from "ds-test/test.sol";
+import {ERC20} from "lib/erc20.sol";
+
+contract C is DSTest {
+    // BAL: https://etherscan.io/address/0xba100000625a3754423978a60c9317c58a424e3D#code
+    ERC20 bal = ERC20(0xba100000625a3754423978a60c9317c58a424e3D);
+
+    function prove_transfer(address dst, uint amt) public {
+        // ignore cases where we don't have enough tokens
+        if (amt > bal.balanceOf(address(this))) return;
+        if (dst == address(0x0)) return;
+
+        uint preBalThis = bal.balanceOf(address(this));
+        uint preBalDst  = bal.balanceOf(dst);
+
+        bal.transfer(dst, amt);
+
+        // no change for self-transfer
+        uint delta = dst == address(this) ? 0 : amt;
+
+        // balance of `this` has been reduced by `delta`
+        assertEq(preBalThis - delta, bal.balanceOf(address(this)));
+
+        // balance of `dst` has been increased by `delta`
+        assertEq(preBalDst + delta, bal.balanceOf(dst));
+    }
+
+    function testCex() public {
+        prove_transfer(0x8000000000000000000000000000000000000000,0);
+    }
+}

--- a/src/hevm/test/rpc.hs
+++ b/src/hevm/test/rpc.hs
@@ -59,11 +59,10 @@ tests = testGroup "rpc"
         assertEqual "prevRan" 0x2267531ab030ed32fd5f2ef51f81427332d0becbd74fe7f4cd5684ddf4b287e0 prevRan
     ]
   , testGroup "execution with remote state"
+    -- execute against remote state from a ds-test harness
     [ testCase "dapp-test" $ do
-        let
-          testFile = "test/contracts/pass/rpc.sol"
-          rpcInfo = Just (BlockNumber 16198552, testRpc)
-        runDappTestCustom testFile ".*" Nothing False rpcInfo >>= assertEqual "test result" True
+        let testFile = "test/contracts/pass/rpc.sol"
+        runDappTestCustom testFile ".*" Nothing False testRpcInfo >>= assertEqual "test result" True
 
     -- concretely exec "transfer" on WETH9 using remote rpc
     , testCase "weth-conc" $ do
@@ -143,3 +142,6 @@ vmFromRpc blockNum calldata' callvalue' caller' address' = do
 
 testRpc :: Text
 testRpc = "https://eth-mainnet.alchemyapi.io/v2/vpeKFsEF6PHifHzdtcwXSDbhV3ym5Ro4"
+
+testRpcInfo :: RpcInfo
+testRpcInfo = Just (BlockNumber 16198552, testRpc)

--- a/src/hevm/test/rpc.hs
+++ b/src/hevm/test/rpc.hs
@@ -65,6 +65,7 @@ tests = testGroup "rpc"
         runDappTestCustom testFile ".*" Nothing False testRpcInfo >>= assertEqual "test result" True
 
     -- concretely exec "transfer" on WETH9 using remote rpc
+    -- https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2#code
     , testCase "weth-conc" $ do
         let
           blockNum = 16198552
@@ -82,6 +83,7 @@ tests = testGroup "rpc"
         assertEqual "should revert" receiverBal (W256 $ 2595433725034301 + wad)
 
     -- symbolically exec "transfer" on WETH9 using remote rpc
+    -- https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2#code
     , testCase "weth-sym" $ do
         let
           blockNum = 16198552

--- a/src/hevm/test/rpc.hs
+++ b/src/hevm/test/rpc.hs
@@ -18,6 +18,7 @@ import EVM.ABI
 import EVM.SMT
 import EVM.Fetch
 import EVM.SymExec
+import EVM.TestUtils
 import qualified EVM.Stepper as Stepper
 import qualified EVM.Fetch as Fetch
 import EVM.Types hiding (BlockNumber)
@@ -58,7 +59,11 @@ tests = testGroup "rpc"
         assertEqual "prevRan" 0x2267531ab030ed32fd5f2ef51f81427332d0becbd74fe7f4cd5684ddf4b287e0 prevRan
     ]
   , testGroup "execution with remote state"
-    [ testCase "dapp-test" undefined
+    [ testCase "dapp-test" $ do
+        let
+          testFile = "test/contracts/pass/rpc.sol"
+          rpcInfo = Just (BlockNumber 16198552, testRpc)
+        runDappTestCustom testFile ".*" Nothing False rpcInfo >>= assertEqual "test result" True
 
     -- concretely exec "transfer" on WETH9 using remote rpc
     , testCase "weth-conc" $ do

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -2459,9 +2459,6 @@ data Invocation
   = SolidityCall Text [AbiValue]
   deriving Show
 
-getVar :: EVM.SMT.SMTCex -> Text -> W256
-getVar cex name = fromJust $ Map.lookup (Var name) (vars cex)
-
 assertSolidityComputation :: Invocation -> AbiValue -> IO ()
 assertSolidityComputation (SolidityCall s args) x =
   do y <- runStatements s args (abiValueType x)


### PR DESCRIPTION
## Description

This fixes symbolic execution against remote state (via rpc calls into an ethereum node) when executing via a `ds-test` harness. Prior to this change we didn't pass the required rpc info into `verify` in the `symRun` function in `UnitTest.hs`. To fix this I changed how we store the rpc info in `UnitTestOptions`. We used to store a fully constructed `Fetcher` in `UnitTestOptions`, but `verify` takes a raw `RpcInfo` and then constructs it's `Fetcher` internally. 

This meant we either had to change `verify` to take a fully constructed `Fetcher`, or change `UnitTestOptions` so it holds a raw `RpcInfo`. After playing around a bit the first seemed to produce a cleaner diff than the second so I went with that. 

I also added tests to `rpc.hs` that exercise this functionality, and modularised some of the test utils so that they can be shared between the `rpc-tests` binary, and the main `test` binary.

If you want to test around this change a bit, you can add tests to the `rpc.sol` file and run them from the rpc-tests repl (cabal  repl rpc-tests) with `:main -p "dapp-test"`.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
