### PR TITLE
Fix nix-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
       - uses: cachix/install-nix-action@v18
         with:
           # https://discourse.nixos.org/t/understanding-binutils-darwin-wrapper-nix-support-bad-substitution/11475/2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/hevm/solidity"]
-	path = src/hevm/solidity
-	url = https://github.com/ethereum/solidity

--- a/flake.lock
+++ b/flake.lock
@@ -50,7 +50,25 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "solidity": "solidity"
+      }
+    },
+    "solidity": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670421565,
+        "narHash": "sha256-VCZDKQHnMsXu+ucsT5BLPYQoZ2FYjpyGbDVoDYjr1W8=",
+        "owner": "ethereum",
+        "repo": "solidity",
+        "rev": "1c8745c54a239d20b6fb0f79a8bd2628d779b27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ethereum",
+        "repo": "solidity",
+        "rev": "1c8745c54a239d20b6fb0f79a8bd2628d779b27e",
+        "type": "github"
       }
     }
   },

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -17,6 +17,7 @@ import Control.Monad
 import Text.RE.TDFA.String
 import Text.RE.Replace
 import Data.Time
+import System.Environment
 
 import Prelude hiding (fail, LT, GT)
 
@@ -2015,10 +2016,11 @@ tests = testGroup "hevm"
                     , "reasoningBasedSimplifier/signed_division.yul" -- ACTUAL bug, SDIV I think?
                     ]
 
-        let dir = "solidity/test/libyul/yulOptimizerTests"
-        dircontents <- System.Directory.listDirectory dir
+        solcRepo <- fromMaybe (error "cannot find solidity repo") <$> (lookupEnv "HEVM_SOLIDITY_REPO")
+        let testDir = solcRepo <> "/test/libyul/yulOptimizerTests"
+        dircontents <- System.Directory.listDirectory testDir
         let
-          fullpaths = map ((dir ++ "/") ++) dircontents
+          fullpaths = map ((testDir ++ "/") ++) dircontents
           recursiveList :: [FilePath] -> [FilePath] -> IO [FilePath]
           recursiveList (a:ax) b =  do
               isdir <- doesDirectoryExist a


### PR DESCRIPTION
## Description

nix-build was failing if the solidity submodule was not checked out. This removes the solidity submodule, checks it out via nix and passes it to the tests using an environment variable that is set in the flake.nix.

Closes #128.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
