### PR TITLE
Format: tweak oppurtunistic string formatting

### DIFF
--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -106,8 +106,9 @@ prettyIfConcreteWord = \case
   w -> T.pack $ show w
 
 showAbiValue :: (?context :: DappContext) => AbiValue -> Text
-showAbiValue (AbiBytes _ bs) =
-  formatBytes bs  -- opportunistically decodes recognisable strings
+showAbiValue (AbiString bs) = formatBytes bs
+showAbiValue (AbiBytesDynamic bs) = formatBytes bs
+showAbiValue (AbiBytes _ bs) = formatBinary bs
 showAbiValue (AbiAddress addr) =
   let dappinfo = view contextInfo ?context
       contracts = view contextEnv ?context


### PR DESCRIPTION
## Description

This changes `showAbiValue` so that it no longer attempts to decode fixed size `bytes` values (e.g. bytes32, bytes8, ...) into a human readable string, and instead only does this for dynamic byte arrays and solidity strings.

Closes #93.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
