### PR TITLE
ci: add release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: "Release"
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  linuxRelease:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v18
+      - name: build hevm
+        run: nix-build -A hevmUnwrapped --out-link hevmLinux
+      - name: rename linux binary
+        run: cp ./hevmLinux/bin/hevm ./hevm-x86_64-linux
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          files: |
+            ./hevm-x86_64-linux
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,23 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v18
       - name: build hevm
-        run: nix-build -A hevmUnwrapped --out-link hevmLinux
-      - name: rename linux binary
-        run: cp ./hevmLinux/bin/hevm ./hevm-x86_64-linux
-      - name: Release
+        run: |
+          nix-build -A hevmUnwrapped --out-link hevmLinux
+          cp ./hevmLinux/bin/hevm ./hevm-x86_64-linux
+      - name: upload linux binary
         uses: softprops/action-gh-release@v0.1.15
         with:
           files: |
             ./hevm-x86_64-linux
+      - name: prepare hackage artifacts
+        run: |
+          nix-shell --command "cabal haddock --builddir=${{ runner.temp }}/docs --haddock-for-hackage --haddock-option=--hyperlinked-source"
+          nix-shell --command "cabal sdist --builddir=${{ runner.temp }}/packages"
+      - name: publish to hackage
+        uses: haskell-actions/hackage-publish@v1
+        with:
+          hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
+          packagesPath: ${{ runner.temp }}/packages
+          docsPath: ${{ runner.temp }}/docs
+          publish: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,14 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: build hevm
         run: |
-          nix-build -A hevmUnwrapped --out-link hevmLinux
+          nix build .#hevmUnwrapped --out-link hevmLinux
           cp ./hevmLinux/bin/hevm ./hevm-x86_64-linux
       - name: upload linux binary
         uses: softprops/action-gh-release@v0.1.15
@@ -22,13 +25,13 @@ jobs:
             ./hevm-x86_64-linux
       - name: prepare hackage artifacts
         run: |
-          nix-shell --command "cabal haddock --builddir=${{ runner.temp }}/docs --haddock-for-hackage --haddock-option=--hyperlinked-source"
-          nix-shell --command "cabal sdist --builddir=${{ runner.temp }}/packages"
+          nix-shell --command "cd src/hevm && cabal sdist --builddir=${{ runner.temp }}/packages"
+          nix-shell --command "cd src/hevm && cabal haddock --builddir=${{ runner.temp }}/docs --haddock-for-hackage --haddock-option=--hyperlinked-source"
       - name: publish to hackage
         uses: haskell-actions/hackage-publish@v1
         with:
           hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
-          packagesPath: ${{ runner.temp }}/packages
+          packagesPath: ${{ runner.temp }}/packages/sdist
           docsPath: ${{ runner.temp }}/docs
           publish: true
 

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -27,7 +27,7 @@ data-files:
   run-consensus-tests
 extra-source-files:
   CHANGELOG.md
-  test/contracts/lib/ds-test.sol
+  test/contracts/lib/test.sol
   test/contracts/lib/erc20.sol
   test/contracts/pass/trivial.sol
   test/contracts/pass/abstract.sol
@@ -35,7 +35,7 @@ extra-source-files:
   test/contracts/pass/constantinople.sol
   test/contracts/pass/dsProvePass.sol
   test/contracts/pass/invariants.sol
-  test/contracts/pass/libraries.so
+  test/contracts/pass/libraries.sol
   test/contracts/pass/loops.sol
   test/contracts/fail/trivial.sol
   test/contracts/fail/cheatCodes.sol

--- a/src/hevm/hevm.cabal
+++ b/src/hevm/hevm.cabal
@@ -178,7 +178,7 @@ library
     smt2-parser                       >= 0.1.0.1,
     word-wrap                         >= 0.5 && < 0.6,
     spool                             >= 0.1 && < 0.2,
-    parsec
+    parsec                            >= 3.1.14.0 && < 3.1.15
   hs-source-dirs:
     src
 


### PR DESCRIPTION
## Description

Adds a release pipeline that automatically uploads the static linux binary to the github release page, and also uploads the release to hackage.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
