### PR TITLE
Fixing QuickCheck generation so it doesn't generate SMT2 syntax errors

### DIFF
--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -2239,6 +2239,7 @@ genNat :: Gen Int
 genNat = fmap fromIntegral (arbitrary :: Gen Natural)
 
 genName :: Gen Text
+-- In order not to generate SMT reserved words, we prepend with "esc_"
 genName = fmap (T.pack . ("esc_" <> )) $ listOf1 (oneof . (fmap pure) $ ['a'..'z'] <> ['A'..'Z'])
 
 genEnd :: Int -> Gen (Expr End)

--- a/src/hevm/test/test.hs
+++ b/src/hevm/test/test.hs
@@ -2239,7 +2239,7 @@ genNat :: Gen Int
 genNat = fmap fromIntegral (arbitrary :: Gen Natural)
 
 genName :: Gen Text
-genName = fmap T.pack $ listOf1 (oneof . (fmap pure) $ ['a'..'z'] <> ['A'..'Z'])
+genName = fmap (T.pack . ("esc_" <> )) $ listOf1 (oneof . (fmap pure) $ ['a'..'z'] <> ['A'..'Z'])
 
 genEnd :: Int -> Gen (Expr End)
 genEnd 0 = oneof


### PR DESCRIPTION
## Description
Fixes name generation for quickcheck fuzzer

Closes https://github.com/ethereum/hevm/issues/139

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
