### PR TITLE
Fix cli gas

### DIFF
--- a/src/hevm/CHANGELOG.md
+++ b/src/hevm/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+
+- `hevm exec` no longer fails with `hevm: No match in record selector smttimeout`
+- the `gas`, `gaslimit`, `priorityfee`, and `gasprice` cli options are now respected
+- cleaner formatting for the gas value in the visual debugger
+
 ## [0.50.0] - 2022-12-19
 
 ### Changed

--- a/src/hevm/hevm-cli/hevm-cli.hs
+++ b/src/hevm/hevm-cli/hevm-cli.hs
@@ -537,8 +537,8 @@ launchExec :: Command Options.Unwrapped -> IO ()
 launchExec cmd = do
   dapp <- getSrcInfo cmd
   vm <- vmFromCommand cmd
-  smtjobs <- fromIntegral <$> getNumProcessors
-  withSolvers Z3 smtjobs (smttimeout cmd) $ \solvers -> do
+  -- TODO: we shouldn't need solvers to execute this code
+  withSolvers Z3 0 Nothing $ \solvers -> do
     case optsMode cmd of
       Run -> do
         vm' <- execStateT (EVM.Stepper.interpret (EVM.Fetch.oracle solvers rpcinfo) . void $ EVM.Stepper.execFully) vm

--- a/src/hevm/src/EVM/Format.hs
+++ b/src/hevm/src/EVM/Format.hs
@@ -68,20 +68,17 @@ data Signedness = Signed | Unsigned
   deriving (Show)
 
 showDec :: Signedness -> W256 -> Text
-showDec signed (W256 w) =
-  let
+showDec signed (W256 w)
+  | i == num cheatCode = "<hevm cheat address>"
+  | (i :: Integer) == 2 ^ (256 :: Integer) - 1 = "MAX_UINT256"
+  | otherwise = Text.pack (show (i :: Integer))
+  where
     i = case signed of
           Signed   -> num (signedWord w)
           Unsigned -> num w
-  in
-    if i == num cheatCode
-    then "<hevm cheat address>"
-    else if (i :: Integer) == 2 ^ (256 :: Integer) - 1
-    then "MAX_UINT256"
-    else Text.pack (show (i :: Integer))
 
 showWordExact :: W256 -> Text
-showWordExact w = humanizeInteger w
+showWordExact w = humanizeInteger (toInteger w)
 
 showWordExplanation :: W256 -> DappInfo -> Text
 showWordExplanation w _ | w > 0xffffffff = showDec Unsigned w


### PR DESCRIPTION
## Description

Fixes a few silly errors in the cli:

- exec was trying to parse `smttimeout` from `cmd`, where is was not defined
- `gas`, `gaslimit`, `priorityfee`, `gasprice` args were not being respected

It also makes a small change in `TTY.hs` to fix the display of gas in the debugger:

**before**
![image](https://user-images.githubusercontent.com/6689924/208657756-1d070915-36b6-4aa2-ad25-0bd759abae43.png)

**after**
![image](https://user-images.githubusercontent.com/6689924/208657433-6e3394a8-9c76-46e3-a6a7-41232481831a.png)

Fixes #144 

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
