### PR TITLE
ci: release: build docs for correct component

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: prepare hackage artifacts
         run: |
           nix-shell --command "cabal sdist --builddir=${{ runner.temp }}/packages"
-          nix-shell --command "cabal haddock --builddir=${{ runner.temp }}/docs --haddock-for-hackage --haddock-option=--hyperlinked-source"
+          nix-shell --command "cabal haddock lib:hevm --builddir=${{ runner.temp }}/docs --haddock-for-hackage --haddock-option=--hyperlinked-source"
       - name: publish to hackage
         uses: haskell-actions/hackage-publish@v1
         with:


### PR DESCRIPTION
## Description

updates the release pipeline to build docs for the library component (previously seemed to be producing docs for `TestUtils`).

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
