### PR TITLE
Optimize concrete readWordFromBytes

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -58,7 +58,6 @@ import Crypto.Hash (Digest, SHA256, RIPEMD160, digestFromByteString)
 import Crypto.PubKey.ECC.ECDSA (signDigestWith, PrivateKey(..), Signature(..))
 import Crypto.PubKey.ECC.Types (getCurveByName, CurveName(..), Point(..))
 import Crypto.PubKey.ECC.Generate (generateQ)
-import Data.DoubleWord (Word256(Word256), Word128 (Word128))
 
 -- * Data types
 
@@ -2948,18 +2947,6 @@ codeloc = do
   let self = view (state . contract) vm
       loc = view (state . pc) vm
   pure (self, loc)
-
-toWord64 :: W256 -> Maybe Word64
-toWord64 n =
-  if n <= num (maxBound :: Word64)
-    then let (W256 (Word256 _ (Word128 _ n'))) = n in Just n'
-    else Nothing
-
-toInt :: W256 -> Maybe Int
-toInt n =
-  if n <= num (maxBound :: Int)
-    then let (W256 (Word256 _ (Word128 _ n'))) = n in Just (fromIntegral n')
-    else Nothing
 
 -- * Emacs setup
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -266,13 +266,16 @@ readWord i b = readWordFromBytes i b
 -- Attempts to read a concrete word from a buffer by reading 32 individual bytes and joining them together
 -- returns an abstract ReadWord expression if a concrete word cannot be constructed
 readWordFromBytes :: Expr EWord -> Expr Buf -> Expr EWord
+readWordFromBytes (Lit idx) (ConcreteBuf bs) =
+  case toInt idx of
+    Nothing -> Lit 0
+    Just i -> Lit $ word $ padRight 32 $ BS.take 32 $ BS.drop i bs
 readWordFromBytes i@(Lit idx) buf = let
     bytes = [readByte (Lit i') buf | i' <- [idx .. idx + 31]]
   in if Prelude.and . (fmap isLitByte) $ bytes
      then Lit (bytesToW256 . mapMaybe unlitByte $ bytes)
      else ReadWord i buf
 readWordFromBytes idx buf = ReadWord idx buf
-
 
 {- | Copies a slice of src into dst.
 

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -663,6 +663,18 @@ packNibbles [] = mempty
 packNibbles (n1:n2:ns) = BS.singleton (toByte n1 n2) <> packNibbles ns
 packNibbles _ = error "can't pack odd number of nibbles"
 
+toWord64 :: W256 -> Maybe Word64
+toWord64 n =
+  if n <= num (maxBound :: Word64)
+    then let (W256 (Word256 _ (Word128 _ n'))) = n in Just n'
+    else Nothing
+
+toInt :: W256 -> Maybe Int
+toInt n =
+  if n <= num (maxBound :: Int)
+    then let (W256 (Word256 _ (Word128 _ n'))) = n in Just (fromIntegral n')
+    else Nothing
+
 -- Keccak hashing
 
 keccakBytes :: ByteString -> ByteString


### PR DESCRIPTION
## Description
This yields another 10% time cut on `ethereum-tests`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
