### PR TITLE
Minor fixes: missing `next`, `mulmod`, `BaseFee`, etc.

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -58,7 +58,7 @@ common shared
   if flag(ci)
     ghc-options: -Werror
   if flag(devel)
-    ghc-options: -j --disable-optimization
+    ghc-options: -j -O0
   default-language: GHC2021
   default-extensions:
     LambdaCase
@@ -107,7 +107,7 @@ library
   autogen-modules:
     Paths_hevm
   if flag(devel)
-    ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j --disable-optimization
+    ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
   else
     ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans
   extra-libraries:
@@ -183,7 +183,7 @@ executable hevm
   main-is:
     hevm-cli.hs
   if flag(devel)
-    ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j --disable-optimization
+    ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
   else
     ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans
   other-modules:
@@ -229,7 +229,7 @@ executable hevm
 common test-base
   import: shared
   if flag (devel)
-    ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j --disable-optimization
+    ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
   else
     ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans
   hs-source-dirs:

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -45,13 +45,20 @@ flag ci
   default:     False
   manual:      True
 
+flag devel
+  description: Sets flag for compilation during development
+  default:     False
+  manual:      True
+
 source-repository head
   type:     git
   location: https://github.com/ethereum/hevm.git
 
 common shared
   if flag(ci)
-    ghc-options: -Werror -j
+    ghc-options: -Werror
+  if flag(devel)
+    ghc-options: -j -O0
   default-language: GHC2021
   default-extensions:
     LambdaCase
@@ -99,8 +106,10 @@ library
     Paths_hevm
   autogen-modules:
     Paths_hevm
-  ghc-options:
-    -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j
+  if flag(devel)
+    ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+  else
+    ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans
   extra-libraries:
     secp256k1, ff
   if os(linux)
@@ -173,8 +182,10 @@ executable hevm
     hevm-cli
   main-is:
     hevm-cli.hs
-  ghc-options:
-    -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j
+  if flag(devel)
+    ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+  else
+    ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans
   other-modules:
     Paths_hevm
   if os(darwin)
@@ -217,8 +228,10 @@ executable hevm
 
 common test-base
   import: shared
-  ghc-options:
-    -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j
+  if flag (devel)
+    ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+  else
+    ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans
   hs-source-dirs:
     test
   extra-libraries:

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -58,7 +58,7 @@ common shared
   if flag(ci)
     ghc-options: -Werror
   if flag(devel)
-    ghc-options: -j -O0
+    ghc-options: -j --disable-optimization
   default-language: GHC2021
   default-extensions:
     LambdaCase
@@ -107,7 +107,7 @@ library
   autogen-modules:
     Paths_hevm
   if flag(devel)
-    ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+    ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j --disable-optimization
   else
     ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans
   extra-libraries:
@@ -183,7 +183,7 @@ executable hevm
   main-is:
     hevm-cli.hs
   if flag(devel)
-    ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+    ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j --disable-optimization
   else
     ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans
   other-modules:
@@ -229,7 +229,7 @@ executable hevm
 common test-base
   import: shared
   if flag (devel)
-    ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+    ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j --disable-optimization
   else
     ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans
   hs-source-dirs:

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -58,7 +58,7 @@ common shared
   if flag(ci)
     ghc-options: -Werror
   if flag(devel)
-    ghc-options: -j -O0
+    ghc-options: -j
   default-language: GHC2021
   default-extensions:
     LambdaCase
@@ -107,7 +107,7 @@ library
   autogen-modules:
     Paths_hevm
   if flag(devel)
-    ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+    ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j
   else
     ghc-options: -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans
   extra-libraries:
@@ -183,7 +183,7 @@ executable hevm
   main-is:
     hevm-cli.hs
   if flag(devel)
-    ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+    ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j
   else
     ghc-options: -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans
   other-modules:
@@ -229,7 +229,7 @@ executable hevm
 common test-base
   import: shared
   if flag (devel)
-    ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j -O0
+    ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j
   else
     ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-orphans
   hs-source-dirs:

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -51,7 +51,7 @@ source-repository head
 
 common shared
   if flag(ci)
-    ghc-options: -Werror
+    ghc-options: -Werror -j
   default-language: GHC2021
   default-extensions:
     LambdaCase
@@ -100,7 +100,7 @@ library
   autogen-modules:
     Paths_hevm
   ghc-options:
-    -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans
+    -Wall -Wno-deprecations -Wno-unticked-promoted-constructors -Wno-orphans -j
   extra-libraries:
     secp256k1, ff
   if os(linux)
@@ -174,7 +174,7 @@ executable hevm
   main-is:
     hevm-cli.hs
   ghc-options:
-    -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans
+    -Wall -threaded -with-rtsopts=-N -Wno-unticked-promoted-constructors -Wno-orphans -j
   other-modules:
     Paths_hevm
   if os(darwin)
@@ -218,7 +218,7 @@ executable hevm
 common test-base
   import: shared
   ghc-options:
-    -Wall -Wno-unticked-promoted-constructors -Wno-orphans
+    -Wall -Wno-unticked-promoted-constructors -Wno-orphans -j
   hs-source-dirs:
     test
   extra-libraries:

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -857,6 +857,7 @@ exec1 = do
               _ -> do
                 assign (state . stack) xs
                 pushSym (CodeSize x')
+                next
             [] ->
               underrun
 
@@ -2270,7 +2271,7 @@ vmError :: Error -> EVM ()
 vmError e = finishFrame (FrameErrored e)
 
 underrun :: EVM ()
-underrun = vmError StackUnderrun
+underrun = vmError EVM.StackUnderrun
 
 -- | A stack frame can be popped in three ways.
 data FrameResult

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -379,6 +379,7 @@ prettyError= \case
   EVM.Types.StackLimitExceeded -> "Stack limit exceeded"
   EVM.Types.InvalidMemoryAccess -> "Invalid memory access"
   EVM.Types.BadJumpDestination -> "Bad jump destination"
+  EVM.Types.StackUnderrun -> "Stack underrun"
   TmpErr err -> "Temp error: " <> err
 
 

--- a/src/EVM/Op.hs
+++ b/src/EVM/Op.hs
@@ -62,6 +62,7 @@ data Op
   | OpGaslimit
   | OpChainid
   | OpSelfbalance
+  | OpBaseFee
   | OpPop
   | OpMload
   | OpMstore
@@ -145,6 +146,7 @@ opString (i, o) = let showPc x | x < 0x10 = '0' : showHex x ""
   OpGaslimit -> "GASLIMIT"
   OpChainid -> "CHAINID"
   OpSelfbalance -> "SELFBALANCE"
+  OpBaseFee -> "BASEFEE"
   OpPop -> "POP"
   OpMload -> "MLOAD"
   OpMstore -> "MSTORE"

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -565,6 +565,14 @@ exprToSMT = \case
         bLift = "(concat (_ bv0 256) " <> bExp <> ")"
         cLift = "(concat (_ bv0 256) " <> cExp <> ")"
     in  "((_ extract 255 0) (ite (= " <> cExp <> " (_ bv0 256)) (_ bv0 512) (bvurem (bvmul " <> aLift `sp` bLift <> ")" <> cLift <> ")))"
+  AddMod a b c ->
+    let aExp = exprToSMT a
+        bExp = exprToSMT b
+        cExp = exprToSMT c
+        aLift = "(concat (_ bv0 256) " <> aExp <> ")"
+        bLift = "(concat (_ bv0 256) " <> bExp <> ")"
+        cLift = "(concat (_ bv0 256) " <> cExp <> ")"
+    in  "((_ extract 255 0) (ite (= " <> cExp <> " (_ bv0 256)) (_ bv0 512) (bvurem (bvadd " <> aLift `sp` bLift <> ")" <> cLift <> ")))"
   EqByte a b ->
     let cond = op2 "=" a b in
     "(ite " <> cond `sp` one `sp` zero <> ")"

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -353,6 +353,7 @@ runExpr = do
       EVM.Revert buf -> EVM.Types.Revert asserts buf
       EVM.InvalidMemoryAccess -> Failure asserts EVM.Types.InvalidMemoryAccess
       EVM.BadJumpDestination -> Failure asserts EVM.Types.BadJumpDestination
+      EVM.StackUnderrun -> Failure asserts EVM.Types.StackUnderrun
       e' -> Failure asserts $ EVM.Types.TmpErr (show e')
 
 -- | Converts a given top level expr into a list of final states and the associated path conditions for each state

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -124,6 +124,7 @@ data Error
   | StackLimitExceeded
   | InvalidMemoryAccess
   | BadJumpDestination
+  | StackUnderrun
   | SelfDestruct
   | TmpErr String
   deriving (Show, Eq, Ord)

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -152,9 +152,7 @@ dappTest opts solcFile cache' = do
           in
             liftIO $ Git.saveFacts (Git.RepoAt path) (Facts.cacheFacts evmcache)
 
-      if and passing
-         then return True
-         else return False
+      return $ and passing
     Nothing ->
       error ("Failed to read Solidity JSON for `" ++ solcFile ++ "'")
 


### PR DESCRIPTION
## Description
This is a set of things I have found to be missing/incorrect with my fuzzing adventures. In particular, it:
* Adds `-j -O0` option in case you pass ` -f devel` to your `cabal repl test`. This will _significantly_ improve your compile times. Note that you can't do performance debugging with that. I personally plan on using `-f devel` but you can skip this change by not passing `-f devel` and never notice the difference.
* Adds missing `OpBaseFee`
* Adds `StackUnderrun`
* Test for `addmod`
* Simplify a test `return`
* Missing `next` at the end of `EXTCODESIZE`

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
