### PR TITLE
[WIP] Better error handling

### DIFF
--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -313,13 +313,13 @@ equivalence cmd = do
       Left err -> do
         putStrLn $ "Error occurred while generating internal expression" <> (show err) <> "cannot determine equivalence"
         exitFailure
-      Right a -> case (containsA (Cex()) a) of
+      Right a -> case (containsA (Cex ()) a) of
         False -> do
           putStrLn "No discrepancies found"
-          when (containsA (SMTTimeout()) a) $ do
+          when (containsA (SMTTimeout ()) a) $ do
             putStrLn "But timeout(s) occurred"
             exitFailure
-          when (containsA (SMTError {}) a) $ do
+          when (containsA (SMTError () "") a) $ do
             putStrLn "But SMT error(s) occurred"
             exitFailure
         True -> do

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -319,6 +319,7 @@ equivalence cmd = do
           when (containsA (SMTTimeout ()) a) $ do
             putStrLn "But timeout(s) occurred"
             exitFailure
+          -- TODO wrong. String may not be empty!!
           when (containsA (SMTError () "") a) $ do
             putStrLn "But SMT error(s) occurred"
             exitFailure

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -35,7 +35,7 @@ import Control.Lens hiding (pre, passing)
 import Control.Monad              (void, when, forM_, unless)
 import Control.Monad.State.Strict (execStateT, liftIO)
 import Data.ByteString            (ByteString)
-import Data.List                  (intercalate, isSuffixOf)
+import Data.List                  (intercalate, isSuffixOf, find)
 import Data.Text                  (unpack, pack)
 import Data.Maybe                 (fromMaybe, mapMaybe)
 import Data.Version               (showVersion)
@@ -316,11 +316,10 @@ equivalence cmd = do
       Right a -> case (containsA (Cex ()) a) of
         False -> do
           putStrLn "No discrepancies found"
-          when (containsA (SMTTimeout ()) a) $ do
+          when (isJust $ Data.List.find (sameCnstr (SMTTimeout ()))) $ do
             putStrLn "But timeout(s) occurred"
             exitFailure
-          -- TODO wrong. String may not be empty!!
-          when (containsA (SMTError () "") a) $ do
+          when (isJust $ Data.List.find (sameCnstr (SMTError () ""))) $ do
             putStrLn "But SMT error(s) occurred"
             exitFailure
         True -> do

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -310,8 +310,8 @@ equivalence cmd = do
   withSolvers Z3 3 Nothing $ \s -> do
     res <- equivalenceCheck s bytecodeA bytecodeB veriOpts Nothing
     case res of
-      Left _ -> do
-        print "Error occurred while generating expression, cannot determine equivalence"
+      Left err -> do
+        putStrLn $ "Error occurred while generating internal expression" <> (show err) <> "cannot determine equivalence"
         exitFailure
       Right a -> case (containsA (Cex()) a) of
         False -> do

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -310,15 +310,16 @@ equivalence cmd = do
 
   withSolvers Z3 3 Nothing $ \s -> do
     res <- equivalenceCheck s bytecodeA bytecodeB veriOpts Nothing
-    when (all ((== True) . (qedOrTimeout)) res) $ putStrLn "all OK"
-    mapM_ proc res
+    when (all ((== True) . (qedOrTimeout)) res) $ putStrLn "All OK"
+    mapM_ checkIssues res
+    unless (all ((== True) . (qedOrTimeout)) res) exitFailure
       where
         qedOrTimeout :: Either ExprError EquivResult -> Bool
         qedOrTimeout (Right (Qed _)) = True
         qedOrTimeout (Right (SMTTimeout _)) = True
         qedOrTimeout _ = False
-        proc :: Either ExprError EquivResult -> IO ()
-        proc r = case r of
+        checkIssues :: Either ExprError EquivResult -> IO ()
+        checkIssues r = case r of
                 Left err -> do
                    putStrLn $ "Error occurred while generating internal expression" <> (show err) <> " -- cannot determine equivalence"
                 Right val -> case val of

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -37,7 +37,7 @@ import Control.Monad.State.Strict (execStateT, liftIO)
 import Data.ByteString            (ByteString)
 import Data.List                  (intercalate, isSuffixOf, find)
 import Data.Text                  (unpack, pack)
-import Data.Maybe                 (fromMaybe, mapMaybe)
+import Data.Maybe                 (fromMaybe, mapMaybe, isJust)
 import Data.Version               (showVersion)
 import Data.DoubleWord            (Word256)
 import System.IO                  (stderr)
@@ -313,13 +313,13 @@ equivalence cmd = do
       Left err -> do
         putStrLn $ "Error occurred while generating internal expression" <> (show err) <> "cannot determine equivalence"
         exitFailure
-      Right a -> case (containsA (Cex ()) a) of
+      Right a -> case (isJust $ Data.List.find (sameCnstr (Cex ())) a) of
         False -> do
           putStrLn "No discrepancies found"
-          when (isJust $ Data.List.find (sameCnstr (SMTTimeout ()))) $ do
+          when (isJust $ Data.List.find (sameCnstr (SMTTimeout ())) a) $ do
             putStrLn "But timeout(s) occurred"
             exitFailure
-          when (isJust $ Data.List.find (sameCnstr (SMTError () ""))) $ do
+          when (isJust $ Data.List.find (sameCnstr (SMTError () "")) a) $ do
             putStrLn "But SMT error(s) occurred"
             exitFailure
         True -> do

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -316,8 +316,11 @@ equivalence cmd = do
       Right a -> case (containsA (Cex()) a) of
         False -> do
           putStrLn "No discrepancies found"
-          when (containsA (EVM.SymExec.Timeout()) a) $ do
+          when (containsA (SMTTimeout()) a) $ do
             putStrLn "But timeout(s) occurred"
+            exitFailure
+          when (containsA (SMTError {}) a) $ do
+            putStrLn "But SMT error(s) occurred"
             exitFailure
         True -> do
           putStrLn $ "Not equivalent. Counterexample(s):" <> show res
@@ -428,7 +431,7 @@ getCexs = mapMaybe go
 getTimeouts :: [VerifyResult] -> [Expr End]
 getTimeouts = mapMaybe go
   where
-    go (Timeout leaf) = Just leaf
+    go (SMTTimeout leaf) = Just leaf
     go _ = Nothing
 
 dappCoverage :: UnitTestOptions -> Mode -> String -> IO ()

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -72,6 +72,7 @@ library
   exposed-modules:
     EVM,
     EVM.ABI,
+    EVM.Assembler,
     EVM.Concrete,
     EVM.Dapp,
     EVM.Debug,

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -64,8 +64,8 @@ import Crypto.PubKey.ECC.Generate (generateQ)
 -- | EVM failure modes
 data EVMError
   = BalanceTooLow W256 W256
-  | UnrecognizedOpcode Word8
-  | SelfDestruction
+  | InvalidOpcode Word8
+  | SelfDestruct
   | StackUnderrun
   | BadJumpDestination
   | Revert (Expr Buf)
@@ -1334,7 +1334,7 @@ exec1 = do
             _ -> underrun
 
         xxx ->
-          vmError (UnrecognizedOpcode xxx)
+          vmError (EVM.InvalidOpcode xxx)
 
 transfer :: Addr -> Addr -> W256 -> EVM ()
 transfer xFrom xTo xValue =

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -62,7 +62,7 @@ import Crypto.PubKey.ECC.Generate (generateQ)
 -- * Data types
 
 -- | EVM failure modes
-data Error
+data EVMError
   = BalanceTooLow W256 W256
   | UnrecognizedOpcode Word8
   | SelfDestruction
@@ -84,14 +84,13 @@ data Error
   | forall a . UnexpectedSymbolicArg Int String [Expr a]
   | DeadPath
   | NotUnique (Expr EWord)
-  | SMTTimeout
   | FFI [AbiValue]
   | NonceOverflow
-deriving instance Show Error
+deriving instance Show EVMError
 
 -- | The possible result states of a VM
 data VMResult
-  = VMFailure Error -- ^ An operation failed
+  = VMFailure EVMError -- ^ An operation failed
   | VMSuccess (Expr Buf) -- ^ Reached STOP, RETURN, or end-of-code
 
 deriving instance Show VMResult
@@ -126,7 +125,7 @@ data TraceData
   = EventTrace (Expr EWord) (Expr Buf) [Expr EWord]
   | FrameTrace FrameContext
   | QueryTrace Query
-  | ErrorTrace Error
+  | ErrorTrace EVMError
   | EntryTrace Text
   | ReturnTrace (Expr Buf) FrameContext
   deriving (Show)
@@ -2267,7 +2266,7 @@ resetState = do
 
 -- * VM error implementation
 
-vmError :: Error -> EVM ()
+vmError :: EVMError -> EVM ()
 vmError e = finishFrame (FrameErrored e)
 
 underrun :: EVM ()
@@ -2277,7 +2276,7 @@ underrun = vmError EVM.StackUnderrun
 data FrameResult
   = FrameReturned (Expr Buf) -- ^ STOP, RETURN, or no more code
   | FrameReverted (Expr Buf) -- ^ REVERT
-  | FrameErrored Error -- ^ Any other error
+  | FrameErrored EVMError -- ^ Any other error
   deriving Show
 
 -- | This function defines how to pop the current stack frame in either of

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -11,7 +11,7 @@ import Prelude hiding (log, exponent, GT, LT)
 import Data.Text (unpack)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import EVM.ABI
-import EVM.Types hiding (IllegalOverflow, Error)
+import EVM.Types hiding (IllegalOverflow, ExprError)
 import EVM.Solidity
 import EVM.Concrete (createAddress, create2Address)
 import EVM.Op

--- a/src/EVM/Assembler.hs
+++ b/src/EVM/Assembler.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE DataKinds #-}
+
+module EVM.Assembler where
+
+import EVM.Op
+import EVM.Types
+import qualified EVM.Expr as Expr
+
+import qualified Data.Vector as V
+import Data.Vector (Vector)
+
+assemble :: [Op] -> Vector (Expr Byte)
+assemble os = V.concatMap go (V.fromList os)
+  where
+    go :: Op -> Vector (Expr Byte)
+    go = \case
+      OpStop -> V.singleton (LitByte 0x00)
+      OpAdd -> V.singleton (LitByte 0x01)
+      OpMul -> V.singleton (LitByte 0x02)
+      OpSub -> V.singleton (LitByte 0x03)
+      OpDiv -> V.singleton (LitByte 0x04)
+      OpSdiv -> V.singleton (LitByte 0x05)
+      OpMod -> V.singleton (LitByte 0x06)
+      OpSmod -> V.singleton (LitByte 0x07)
+      OpAddmod -> V.singleton (LitByte 0x08)
+      OpMulmod -> V.singleton (LitByte 0x09)
+      OpExp -> V.singleton (LitByte 0x0A)
+      OpSignextend -> V.singleton (LitByte 0x0B)
+      OpLt -> V.singleton (LitByte 0x10)
+      OpGt -> V.singleton (LitByte 0x11)
+      OpSlt -> V.singleton (LitByte 0x12)
+      OpSgt -> V.singleton (LitByte 0x13)
+      OpEq -> V.singleton (LitByte 0x14)
+      OpIszero -> V.singleton (LitByte 0x15)
+      OpAnd -> V.singleton (LitByte 0x16)
+      OpOr -> V.singleton (LitByte 0x17)
+      OpXor -> V.singleton (LitByte 0x18)
+      OpNot -> V.singleton (LitByte 0x19)
+      OpByte -> V.singleton (LitByte 0x1A)
+      OpShl -> V.singleton (LitByte 0x1B)
+      OpShr -> V.singleton (LitByte 0x1C)
+      OpSar -> V.singleton (LitByte 0x1D)
+      OpSha3 -> V.singleton (LitByte 0x20)
+      OpAddress -> V.singleton (LitByte 0x30)
+      OpBalance -> V.singleton (LitByte 0x31)
+      OpOrigin -> V.singleton (LitByte 0x32)
+      OpCaller -> V.singleton (LitByte 0x33)
+      OpCallvalue -> V.singleton (LitByte 0x34)
+      OpCalldataload -> V.singleton (LitByte 0x35)
+      OpCalldatasize -> V.singleton (LitByte 0x36)
+      OpCalldatacopy -> V.singleton (LitByte 0x37)
+      OpCodesize -> V.singleton (LitByte 0x38)
+      OpCodecopy -> V.singleton (LitByte 0x39)
+      OpGasprice -> V.singleton (LitByte 0x3A)
+      OpExtcodesize -> V.singleton (LitByte 0x3B)
+      OpExtcodecopy -> V.singleton (LitByte 0x3C)
+      OpReturndatasize -> V.singleton (LitByte 0x3D)
+      OpReturndatacopy -> V.singleton (LitByte 0x3E)
+      OpExtcodehash -> V.singleton (LitByte 0x3F)
+      OpBlockhash -> V.singleton (LitByte 0x40)
+      OpCoinbase -> V.singleton (LitByte 0x41)
+      OpTimestamp -> V.singleton (LitByte 0x42)
+      OpNumber -> V.singleton (LitByte 0x43)
+      OpPrevRandao -> V.singleton (LitByte 0x44)
+      OpGaslimit -> V.singleton (LitByte 0x45)
+      OpChainid -> V.singleton (LitByte 0x46)
+      OpSelfbalance -> V.singleton (LitByte 0x47)
+      OpBaseFee -> V.singleton (LitByte 0x48)
+      OpPop -> V.singleton (LitByte 0x50)
+      OpMload -> V.singleton (LitByte 0x51)
+      OpMstore -> V.singleton (LitByte 0x52)
+      OpMstore8 -> V.singleton (LitByte 0x53)
+      OpSload -> V.singleton (LitByte 0x54)
+      OpSstore -> V.singleton (LitByte 0x55)
+      OpJump -> V.singleton (LitByte 0x56)
+      OpJumpi -> V.singleton (LitByte 0x57)
+      OpPc -> V.singleton (LitByte 0x58)
+      OpMsize -> V.singleton (LitByte 0x59)
+      OpGas -> V.singleton (LitByte 0x5A)
+      OpJumpdest -> V.singleton (LitByte 0x5B)
+      OpCreate -> V.singleton (LitByte 0xF0)
+      OpCall -> V.singleton (LitByte 0xF1)
+      OpStaticcall -> V.singleton (LitByte 0xFA)
+      OpCallcode -> V.singleton (LitByte 0xF2)
+      OpReturn -> V.singleton (LitByte 0xF3)
+      OpDelegatecall -> V.singleton (LitByte 0xF4)
+      OpCreate2 -> V.singleton (LitByte 0xF5)
+      OpRevert -> V.singleton (LitByte 0xFD)
+      OpSelfdestruct -> V.singleton (LitByte 0xFF)
+      OpDup n ->
+        if 1 <= n && n <= 16
+        then V.singleton (LitByte (0x80 + (n - 1)))
+        else error $ "Internal Error: invalid argument to OpDup: " <> show n
+      OpSwap n ->
+        if 1 <= n && n <= 16
+        then V.singleton (LitByte (0x90 + (n - 1)))
+        else error $ "Internal Error: invalid argument to OpSwap: " <> show n
+      OpLog n ->
+        if 0 <= n && n <= 4
+        then V.singleton (LitByte (0xA0 + n))
+        else error $ "Internal Error: invalid argument to OpLog: " <> show n
+      -- we just always assemble OpPush into PUSH32
+      OpPush wrd -> V.cons (LitByte 0x7f) (V.fromList [Expr.indexWord (Lit i) wrd | i <- [0..31]])
+      OpUnknown o -> V.singleton (LitByte o)

--- a/src/EVM/Dapp.hs
+++ b/src/EVM/Dapp.hs
@@ -4,7 +4,6 @@ module EVM.Dapp where
 
 import EVM (Trace, traceContract, traceOpIx, ContractCode(..), Contract(..), codehash, contractcode, RuntimeCode (..))
 import EVM.ABI (Event, AbiType, SolError)
-import EVM.Debug (srcMapCodePos)
 import EVM.Solidity
 import EVM.Types (W256, abiKeccak, keccak', Addr, regexMatches, unlit, unlitByte)
 
@@ -20,7 +19,7 @@ import Data.Maybe (isJust, fromJust, mapMaybe)
 import Data.Word (Word32)
 import EVM.Concrete
 
-import Control.Arrow ((>>>))
+import Control.Arrow ((>>>), second)
 import Control.Lens
 
 import Data.List (find)
@@ -202,3 +201,9 @@ showTraceLocation dapp trace =
         Nothing -> Left "<source not found>"
         Just (fileName, lineIx) ->
           Right (fileName <> ":" <> pack (show lineIx))
+
+srcMapCodePos :: SourceCache -> SrcMap -> Maybe (Text, Int)
+srcMapCodePos cache sm =
+  fmap (second f) $ cache ^? sourceFiles . ix (srcMapFile sm)
+  where
+    f v = BS.count 0xa (BS.take (srcMapOffset sm - 1) v) + 1

--- a/src/EVM/Debug.hs
+++ b/src/EVM/Debug.hs
@@ -1,13 +1,10 @@
 {-# Language DataKinds #-}
-{-# Language NumericUnderscores #-}
-{-# Language QuasiQuotes #-}
-{-# Language DataKinds #-}
 
 module EVM.Debug where
 
 import EVM          (Contract, nonce, balance, bytecode, codehash)
 import EVM.Solidity (SrcMap, srcMapFile, srcMapOffset, srcMapLength, SourceCache, sourceFiles)
-import EVM.Types    (Addr, Expr, Expr (Lit), Expr(LitByte), EType (Byte))
+import EVM.Types    (Addr, Expr, Expr(LitByte), EType (Byte))
 import EVM.Expr     (bufLength)
 import EVM.Op
 import Data.Word (Word8)
@@ -17,7 +14,6 @@ import Control.Lens
 import Data.ByteString (ByteString)
 import Data.Map        (Map)
 import Data.Text       (Text)
-import EVM.SymExec (VeriOpts, defaultVeriOpts, noLoopVeriOpts)
 
 import qualified Data.ByteString       as ByteString
 import qualified Data.Map              as Map

--- a/src/EVM/Debug.hs
+++ b/src/EVM/Debug.hs
@@ -4,10 +4,9 @@ module EVM.Debug where
 
 import EVM          (Contract, nonce, balance, bytecode, codehash)
 import EVM.Solidity (SrcMap, srcMapFile, srcMapOffset, srcMapLength, SourceCache, sourceFiles)
-import EVM.Types    (Addr, Expr, Expr(LitByte), EType (Byte))
+import EVM.Types    (Addr)
 import EVM.Expr     (bufLength)
 import EVM.Op
-import Data.Word (Word8)
 
 import Control.Arrow   (second)
 import Control.Lens
@@ -56,10 +55,6 @@ srcMapCode cache sm =
   fmap f $ cache ^? sourceFiles . ix (srcMapFile sm)
   where
     f (_, v) = ByteString.take (min 80 (srcMapLength sm)) (ByteString.drop (srcMapOffset sm) v)
-
-toW8fromLitB :: Expr 'Byte -> Data.Word.Word8
-toW8fromLitB (LitByte a) = a
-toW8fromLitB _ = error "nope"
 
 data OpContract = OpContract [Op]
   deriving (Show)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -181,8 +181,12 @@ shr = op2
 
 sar :: Expr EWord -> Expr EWord -> Expr EWord
 sar = op2 SAR (\x y ->
-  let asSigned = (fromIntegral y) :: Int256
-  in fromIntegral $ shiftR asSigned (fromIntegral x))
+  let msb = testBit y 255
+      asSigned = fromIntegral y :: Int256
+  in if x > 256 then
+       if msb then maxBound else 0
+     else
+       fromIntegral $ shiftR asSigned (fromIntegral x))
 
 -- ** Bufs ** --------------------------------------------------------------------------------------
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -401,7 +401,7 @@ writeWord offset val src = WriteWord offset val src
 -- | Returns the length of a given buffer
 --
 -- If there are any writes to abstract locations, or CopySlices with an
--- abstract size or dstOffset, an abstract expresion will be returned.
+-- abstract size or dstOffset, an abstract expression will be returned.
 bufLength :: Expr Buf -> Expr EWord
 bufLength buf = case go 0 buf of
                   Just len -> len
@@ -414,7 +414,7 @@ bufLength buf = case go 0 buf of
     go l (CopySlice _ (Lit dstOffset) (Lit size) _ dst) = go (max (dstOffset + size) l) dst
     go _ _ = Nothing
 
--- | If a buffer has a concrete prefix, we return it's length here
+-- | If a buffer has a concrete prefix, we return its length here
 concPrefix :: Expr Buf -> Maybe Integer
 concPrefix (CopySlice (Lit srcOff) (Lit _) (Lit _) src (ConcreteBuf "")) = do
   sz <- go 0 src
@@ -473,7 +473,7 @@ toList buf = case bufLength buf of
 fromList :: V.Vector (Expr Byte) -> Expr Buf
 fromList bs = case Prelude.and (fmap isLitByte bs) of
   True -> ConcreteBuf . BS.pack . V.toList . V.mapMaybe unlitByte $ bs
-  -- we want to minimize the size of the resulting expresion, so we do two passes:
+  -- we want to minimize the size of the resulting expression, so we do two passes:
   --   1. write all concrete bytes to some base buffer
   --   2. write all symbolic writes on top of this buffer
   -- this is safe because each write in the input vec is to a single byte at a distinct location

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -181,12 +181,8 @@ shr = op2
 
 sar :: Expr EWord -> Expr EWord -> Expr EWord
 sar = op2 SAR (\x y ->
-  let msb = testBit y 255
-      asSigned = fromIntegral y :: Int256
-  in if x > 256 then
-       if msb then maxBound else 0
-     else
-       fromIntegral $ shiftR asSigned (fromIntegral x))
+  let asSigned = (fromIntegral y) :: Int256
+  in fromIntegral $ shiftR asSigned (fromIntegral x))
 
 -- ** Bufs ** --------------------------------------------------------------------------------------
 

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -373,14 +373,14 @@ contractPathPart x = Text.split (== ':') x !! 0
 
 prettyError :: ExprError -> String
 prettyError= \case
-  InvalidOpcode -> "Invalid Opcode"
+  EVM.Types.InvalidOpcode -> "Invalid Opcode"
   EVM.Types.IllegalOverflow -> "Illegal Overflow"
   SelfDestruct -> "Self Destruct"
   EVM.Types.StackLimitExceeded -> "Stack limit exceeded"
   EVM.Types.InvalidMemoryAccess -> "Invalid memory access"
   EVM.Types.BadJumpDestination -> "Bad jump destination"
   EVM.Types.StackUnderrun -> "Stack underrun"
-  TmpErr err -> "Temp error: " <> err
+  WrappedEVMError err -> "Temp error: " <> err
 
 
 prettyvmresult :: (?context :: DappContext) => Expr End -> String

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -30,7 +30,7 @@ import Prelude hiding (Word)
 import qualified EVM
 import EVM.Dapp (DappInfo (..), dappSolcByHash, dappAbiMap, showTraceLocation, dappEventMap, dappErrorMap)
 import EVM.Dapp (DappContext (..), contextInfo, contextEnv)
-import EVM (VM, cheatCode, traceForest, traceData, Error (..))
+import EVM (VM, cheatCode, traceForest, traceData, EVMError (..))
 import EVM (Trace, TraceData (..), Query (..), FrameContext (..))
 import EVM.Types (maybeLitWord, W256 (..), num, word, Expr(..), EType(..))
 import EVM.Types (Addr, ByteStringS(..), Error(..))
@@ -373,7 +373,7 @@ contractPathPart x = Text.split (== ':') x !! 0
 
 prettyError :: EVM.Types.Error -> String
 prettyError= \case
-  Invalid -> "Invalid Opcode"
+  InvalidOpcode -> "Invalid Opcode"
   EVM.Types.IllegalOverflow -> "Illegal Overflow"
   SelfDestruct -> "Self Destruct"
   EVM.Types.StackLimitExceeded -> "Stack limit exceeded"

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -379,7 +379,6 @@ prettyError= \case
   EVM.Types.StackLimitExceeded -> "Stack limit exceeded"
   EVM.Types.InvalidMemoryAccess -> "Invalid memory access"
   EVM.Types.BadJumpDestination -> "Bad jump destination"
-  EVM.Types.StackUnderrun -> "Stack underrun"
   TmpErr err -> "Temp error: " <> err
 
 

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -375,12 +375,12 @@ prettyError :: ExprError -> String
 prettyError= \case
   EVM.Types.InvalidOpcode -> "Invalid Opcode"
   EVM.Types.IllegalOverflow -> "Illegal Overflow"
-  SelfDestruct -> "Self Destruct"
+  EVM.Types.SelfDestruct -> "Self Destruct"
   EVM.Types.StackLimitExceeded -> "Stack limit exceeded"
   EVM.Types.InvalidMemoryAccess -> "Invalid memory access"
   EVM.Types.BadJumpDestination -> "Bad jump destination"
   EVM.Types.StackUnderrun -> "Stack underrun"
-  WrappedEVMError err -> "Temp error: " <> err
+  EVM.Types.WrappedEVMError err -> "Wrapped EVM Error: " <> err
 
 
 prettyvmresult :: (?context :: DappContext) => Expr End -> String

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -379,6 +379,7 @@ prettyError= \case
   EVM.Types.StackLimitExceeded -> "Stack limit exceeded"
   EVM.Types.InvalidMemoryAccess -> "Invalid memory access"
   EVM.Types.BadJumpDestination -> "Bad jump destination"
+  EVM.Types.StackUnderrun -> "Stack underrun"
   TmpErr err -> "Temp error: " <> err
 
 

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -33,7 +33,7 @@ import EVM.Dapp (DappContext (..), contextInfo, contextEnv)
 import EVM (VM, cheatCode, traceForest, traceData, EVMError (..))
 import EVM (Trace, TraceData (..), Query (..), FrameContext (..))
 import EVM.Types (maybeLitWord, W256 (..), num, word, Expr(..), EType(..))
-import EVM.Types (Addr, ByteStringS(..), Error(..))
+import EVM.Types (Addr, ByteStringS(..), ExprError(..))
 import EVM.ABI (AbiValue (..), Event (..), AbiType (..), SolError (..))
 import EVM.ABI (Indexed (NotIndexed), getAbiSeq)
 import EVM.ABI (parseTypeName, formatString)
@@ -371,7 +371,7 @@ contractNamePart x = Text.split (== ':') x !! 1
 contractPathPart :: Text -> Text
 contractPathPart x = Text.split (== ':') x !! 0
 
-prettyError :: EVM.Types.Error -> String
+prettyError :: ExprError -> String
 prettyError= \case
   InvalidOpcode -> "Invalid Opcode"
   EVM.Types.IllegalOverflow -> "Illegal Overflow"

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -495,7 +495,7 @@ referencedBlockContext expr = nubOrd (foldExpr go [] expr)
       BaseFee -> ["basefee"]
       _ -> []
 
-
+-- TODO we should have an option to return Error here
 exprToSMT :: Expr a -> Builder
 exprToSMT = \case
   Lit w -> fromLazyText $ "(_ bv" <> (T.pack $ show (num w :: Integer)) <> " 256)"
@@ -1049,7 +1049,8 @@ readSExpr h = go 0 0 []
 
 -- | Stores a region of src into dst
 copySlice :: Expr EWord -> Expr EWord -> Expr EWord -> Builder -> Builder -> Builder
-copySlice srcOffset dstOffset size@(Lit _) src dst
+copySlice srcOffset dstOffset size@(Lit sz) src dst
+  | sz > (1024*16) = error "Too large copySlice size"
   | size == (Lit 0) = dst
   | otherwise =
     let size' = (sub size (Lit 1))

--- a/src/EVM/Stepper.hs
+++ b/src/EVM/Stepper.hs
@@ -33,7 +33,7 @@ import qualified EVM.Exec
 import Data.Text (Text)
 import EVM.Types (Expr, EType(..))
 
-import EVM (EVM, VM, VMResult (VMFailure, VMSuccess), Error (Query, Choose), Query, Choose)
+import EVM (EVM, VM, VMResult (VMFailure, VMSuccess), EVMError (Query, Choose), Query, Choose)
 import qualified EVM
 
 import qualified EVM.Fetch as Fetch
@@ -83,7 +83,7 @@ evmIO :: StateT VM IO a -> Stepper a
 evmIO = singleton . IOAct
 
 -- | Run the VM until final result, resolving all queries
-execFully :: Stepper (Either Error (Expr Buf))
+execFully :: Stepper (Either EVMError (Expr Buf))
 execFully =
   exec >>= \case
     VMFailure (Query q) ->

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -23,10 +23,9 @@ import qualified EVM.FeeSchedule as FeeSchedule
 import Data.DoubleWord (Word256)
 import Control.Concurrent.Async
 import Data.Maybe
-import Data.List (foldl')
+import Data.List (foldl', find)
 import Data.Tuple (swap)
 import Data.ByteString (ByteString)
-import Data.List (find)
 import Data.ByteString (null, pack)
 import qualified Control.Monad.State.Class as State
 import Data.Bifunctor (first, second)
@@ -50,6 +49,26 @@ isQed _ = False
 
 containsA :: Eq a => Eq b => Eq c => ProofResult a b c -> [(d , e, ProofResult a b c)] -> Bool
 containsA a lst = isJust $ Data.List.find (\(_, _, c) -> c == a) lst
+
+getCexes :: Eq a => Eq b => Eq c => [(d , e, ProofResult a b c)] -> [(d , e, ProofResult a b c)]
+getCexes lst = filter cexCheck lst
+  where
+    cexCheck (_, _, c) = case c of
+                         Cex {} -> True
+                         _ -> False
+
+getSMTTimeouts :: Eq a => Eq b => Eq c => [(d , e, ProofResult a b c)] -> [(d , e, ProofResult a b c)]
+getSMTTimeouts lst = filter timeoutCheck lst
+  where
+    timeoutCheck (_, _, c) = case c of
+                         SMTTimeout {} -> True
+                         _ -> False
+getSMTErrors :: Eq a => Eq b => Eq c => [(d , e, ProofResult a b c)] -> [(d , e, ProofResult a b c)]
+getSMTErrors lst = filter timeoutCheck lst
+  where
+    timeoutCheck (_, _, c) = case c of
+                         SMTError {} -> True
+                         _ -> False
 
 data VeriOpts = VeriOpts
   { simp :: Bool

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -582,10 +582,6 @@ equivalenceCheck solvers bytecodeA bytecodeB opts signature' = do
            else (foldl PAnd (PBool True) aProps) .&& (foldl PAnd (PBool True) bProps)  .&& differingResults
   -- If there exists a pair of end states where this is not the case,
   -- the following constraint is satisfiable
-
-  -- if isLeft flattenedA || isLeft flattenedB then do
-    -- pure $ Left $ getLeft flattenedA -- TODO fix to be better, it's only checking flattenedA
-  -- else do
   do
     let diffEndStFilt = filter (/= PBool False) differingEndStates
     putStrLn $ "Equivalence checking " <> (show $ length diffEndStFilt) <> " combinations"

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -60,15 +60,6 @@ data VeriOpts = VeriOpts
   }
   deriving (Eq, Show)
 
-noLoopVeriOpts :: VeriOpts
-noLoopVeriOpts = VeriOpts
-  { simp = True
-  , debug = False
-  , maxIter = Just 0
-  , askSmtIters = Just 0
-  , rpcInfo = Nothing
-  }
-
 defaultVeriOpts :: VeriOpts
 defaultVeriOpts = VeriOpts
   { simp = True

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -38,7 +38,6 @@ import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
 import EVM.Format (formatExpr, indent, formatBinary)
-import Data.Either (isLeft, isRight)
 
 data ProofResult a b c = Qed a | Cex b | Timeout c
   deriving (Show, Eq)

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -56,26 +56,12 @@ isCex :: ProofResult a b c -> Bool
 isCex (Cex _) = True
 isCex _ = False
 
-isCex2 :: EquivResult -> Bool
-isCex2 (Cex _) = True
-isCex2 _ = False
-
 isQed :: ProofResult a b c -> Bool
 isQed (Qed _) = True
 isQed _ = False
 
-sameCnstr :: ProofResult a b c -> (d , e, ProofResult a b c) -> Bool
-sameCnstr a e = (\(_, _, c) -> checkCnstr c a) e
-  where
-    checkCnstr x y = case (x, y) of
-      (Qed _, Qed _) -> True
-      (Cex _, Cex _) -> True
-      (SMTTimeout _, SMTTimeout _) -> True
-      (SMTError {}, SMTError {}) -> True
-      _ -> False
-
-sameCnstr2 :: ProofResult a b c -> ProofResult a b c -> Bool
-sameCnstr2 a e = checkCnstr a e
+sameCnstr :: ProofResult a b c -> ProofResult a b c -> Bool
+sameCnstr a e = checkCnstr a e
   where
     checkCnstr x y = case (x, y) of
       (Qed _, Qed _) -> True

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -50,25 +50,15 @@ isQed _ = False
 containsA :: Eq a => Eq b => Eq c => ProofResult a b c -> [(d , e, ProofResult a b c)] -> Bool
 containsA a lst = isJust $ Data.List.find (\(_, _, c) -> c == a) lst
 
-getCexes :: Eq a => Eq b => Eq c => [(d , e, ProofResult a b c)] -> [(d , e, ProofResult a b c)]
-getCexes lst = filter cexCheck lst
+sameCnstr :: ProofResult a b c -> (d , e, ProofResult a b c) -> Bool
+sameCnstr a e = (\(_, _, c) -> checkCnstr c a) e
   where
-    cexCheck (_, _, c) = case c of
-                         Cex {} -> True
-                         _ -> False
-
-getSMTTimeouts :: Eq a => Eq b => Eq c => [(d , e, ProofResult a b c)] -> [(d , e, ProofResult a b c)]
-getSMTTimeouts lst = filter timeoutCheck lst
-  where
-    timeoutCheck (_, _, c) = case c of
-                         SMTTimeout {} -> True
-                         _ -> False
-getSMTErrors :: Eq a => Eq b => Eq c => [(d , e, ProofResult a b c)] -> [(d , e, ProofResult a b c)]
-getSMTErrors lst = filter timeoutCheck lst
-  where
-    timeoutCheck (_, _, c) = case c of
-                         SMTError {} -> True
-                         _ -> False
+    checkCnstr x y = case (x, y) of
+      (Qed _, Qed _) -> True
+      (Cex _, Cex _) -> True
+      (SMTTimeout _, SMTTimeout _) -> True
+      (SMTError {}, SMTError {}) -> True
+      _ -> False
 
 data VeriOpts = VeriOpts
   { simp :: Bool

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -347,13 +347,13 @@ runExpr = do
     Just (VMSuccess buf) -> Return asserts buf (view (env . EVM.storage) vm)
     Just (VMFailure e) -> case e of
       EVM.InvalidOpcode _ -> Failure asserts EVM.Types.InvalidOpcode
-      EVM.SelfDestruct -> Failure asserts EVM.Types.SelfDestruct
-      EVM.StackLimitExceeded -> Failure asserts EVM.Types.StackLimitExceeded
       EVM.IllegalOverflow -> Failure asserts EVM.Types.IllegalOverflow
-      EVM.Revert buf -> EVM.Types.Revert asserts buf
+      EVM.StackLimitExceeded -> Failure asserts EVM.Types.StackLimitExceeded
       EVM.InvalidMemoryAccess -> Failure asserts EVM.Types.InvalidMemoryAccess
       EVM.BadJumpDestination -> Failure asserts EVM.Types.BadJumpDestination
       EVM.StackUnderrun -> Failure asserts EVM.Types.StackUnderrun
+      EVM.SelfDestruct -> Failure asserts EVM.Types.SelfDestruct
+      EVM.Revert buf -> EVM.Types.Revert asserts buf
       -- Many other types of EVMError-s are allowed, all captured below as Failure + ExprError's WrappedEVMError
       e' -> Failure asserts $ EVM.Types.WrappedEVMError (show e')
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -297,10 +297,7 @@ type Precondition = VM -> Prop
 type Postcondition = VM -> Expr End -> Prop
 
 
-checkAssert ::
-  SolverGroup -> [Word256] -> ByteString ->
-  Maybe (Text, [AbiType]) -> [String] -> VeriOpts ->
-  IO (Either EVM.Types.Error (Expr End, [VerifyResult]))
+checkAssert :: SolverGroup -> [Word256] -> ByteString -> Maybe (Text, [AbiType]) -> [String] -> VeriOpts -> IO (Either EVM.Types.Error (Expr End, [VerifyResult]))
 checkAssert solvers errs c signature' concreteArgs opts = verifyContract solvers c signature' concreteArgs opts SymbolicS Nothing (Just $ checkAssertions errs)
 
 {- |Checks if an assertion violation has been encountered
@@ -339,10 +336,7 @@ allPanicCodes = [ 0x00, 0x01, 0x11, 0x12, 0x21, 0x22, 0x31, 0x32, 0x41, 0x51 ]
 panicMsg :: Word256 -> ByteString
 panicMsg err = (selector "Panic(uint256)") <> (encodeAbiValue $ AbiUInt 256 err)
 
-verifyContract ::
-  SolverGroup ->ByteString -> Maybe (Text, [AbiType]) -> [String] ->
-  VeriOpts -> StorageModel -> Maybe Precondition -> Maybe Postcondition ->
-  IO (Either EVM.Types.Error (Expr End, [VerifyResult]))
+verifyContract :: SolverGroup ->ByteString -> Maybe (Text, [AbiType]) -> [String] -> VeriOpts -> StorageModel -> Maybe Precondition -> Maybe Postcondition -> IO (Either EVM.Types.Error (Expr End, [VerifyResult]))
 verifyContract solvers theCode signature' concreteArgs opts storagemodel maybepre maybepost = do
   let preState = abstractVM signature' concreteArgs theCode maybepre storagemodel
   verify solvers opts preState maybepost

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -126,7 +126,7 @@ data ExprError
   | BadJumpDestination
   | StackUnderrun
   | SelfDestruct
-  | TmpErr String
+  | WrappedEVMError String
   deriving (Show, Eq, Ord)
 
 -- Variables refering to a global environment

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -118,7 +118,7 @@ data EType
   deriving (Typeable)
 
 -- Failure states of the Expr AST
-data Error
+data ExprError
   = InvalidOpcode
   | IllegalOverflow
   | StackLimitExceeded
@@ -167,7 +167,7 @@ data Expr (a :: EType) where
   -- control flow
 
   Revert              :: [Prop] -> Expr Buf -> Expr End
-  Failure             :: [Prop] -> Error -> Expr End
+  Failure             :: [Prop] -> ExprError -> Expr End
   Return              :: [Prop] -> Expr Buf -> Expr Storage -> Expr End
   ITE                 :: Expr EWord -> Expr End -> Expr End -> Expr End
 

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -117,9 +117,9 @@ data EType
   | End
   deriving (Typeable)
 
--- EVM errors
+-- Failure states of the Expr AST
 data Error
-  = Invalid
+  = InvalidOpcode
   | IllegalOverflow
   | StackLimitExceeded
   | InvalidMemoryAccess

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -344,7 +344,7 @@ coverageReport dapp cov =
     allPositions :: Set (Text, Int)
     allPositions =
       ( Set.fromList
-      . mapMaybe (srcMapCodePos sources)
+      . mapMaybe (EVM.Debug.srcMapCodePos sources)
       . toList
       $ mconcat
         ( view dappSolcByName dapp
@@ -354,7 +354,7 @@ coverageReport dapp cov =
       )
 
     srcMapCov :: MultiSet (Text, Int)
-    srcMapCov = MultiSet.mapMaybe (srcMapCodePos sources) cov
+    srcMapCov = MultiSet.mapMaybe (EVM.Debug.srcMapCodePos sources) cov
 
     linesByName :: Map Text (Vector ByteString)
     linesByName =
@@ -742,16 +742,19 @@ symRun opts@UnitTestOptions{..} vm testName types = do
         )) vm
 
     -- check postconditions against vm
-    (_, results) <- verify solvers (makeVeriOpts opts) vm' (Just postcondition)
+    checked <- verify solvers (makeVeriOpts opts) vm' (Just postcondition)
+    -- (_, results) <- verify solvers (makeVeriOpts opts) vm' (Just postcondition)
 
     -- display results
-    if all isQed results
-    then do
-      return ("\x1b[32m[PASS]\x1b[0m " <> testName, Right "", vm)
-    else do
-      let x = mapMaybe extractCex results
-      let y = symFailure opts testName (fst cd) types x
-      return ("\x1b[31m[FAIL]\x1b[0m " <> testName, Left y, vm)
+    if isRight checked then do
+       let (_, results) = SymExec.getRight checked
+       if all isQed results then do
+         return ("\x1b[32m[PASS]\x1b[0m " <> testName, Right "", vm)
+       else do
+        let x = mapMaybe extractCex results
+        let y = symFailure opts testName (fst cd) types x
+        return ("\x1b[31m[FAIL]\x1b[0m " <> testName, Left y, vm)
+    else return ("\x1b[31m[FAIL]\x1b[0m  OTHER ERROR " <> testName, Left "whatever", vm)
 
 symFailure :: UnitTestOptions -> Text -> Expr Buf -> [AbiType] -> [(Expr End, SMTCex)] -> Text
 symFailure UnitTestOptions {..} testName cd types failures' =

--- a/test/test.hs
+++ b/test/test.hs
@@ -43,7 +43,7 @@ import Data.String.Here
 import qualified Data.Map.Strict as Map
 
 import Data.Binary.Put (runPut)
-import Data.Binary.Get (runGetOrFail, isEmpty)
+import Data.Binary.Get (runGetOrFail)
 
 import EVM hiding (Query, allowFFI)
 import EVM.SymExec

--- a/test/test.hs
+++ b/test/test.hs
@@ -2120,9 +2120,9 @@ tests = testGroup "hevm"
             res <- equivalenceCheck s aPrgm bPrgm myVeriOpts Nothing
             end <- getCurrentTime
             let rightRes = map getRight (filter isRight res)
-                timeouts = filter (sameCnstr2 (SMTTimeout ())) rightRes
-                smtErrors = filter (sameCnstr2 (SMTError () "")) rightRes
-                cexs = filter (sameCnstr2 (Cex {})) rightRes
+                timeouts = filter (sameCnstr (SMTTimeout ())) rightRes
+                smtErrors = filter (sameCnstr (SMTError () "")) rightRes
+                cexs = filter (sameCnstr (Cex {})) rightRes
                 exprErrors = filter isLeft res
             case (null exprErrors) of
               True -> case (null cexs) of

--- a/test/test.hs
+++ b/test/test.hs
@@ -765,7 +765,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        Right (_, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        Right (_, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] debugVeriOpts
         putStrLn "SAR works as expected"
      ,
      testCase "opcode-sar-pos" $ do
@@ -782,7 +782,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        Right (_, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        Right (_, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("fun(int256,int256)", [AbiIntType 256, AbiIntType 256])) [] debugVeriOpts
         putStrLn "SAR works as expected"
      ,
      testCase "opcode-sar-fixedval-pos" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -107,14 +107,13 @@ tests = testGroup "hevm"
   -- unsimplified one
   , testGroup "contractQuickCheck"
     [ testProperty "random-contract-with-symbolic-call" $ \(expr :: OpContract) -> ioProperty $ do
-      let noLoopVeriOpts :: VeriOpts
-        noLoopVeriOpts = VeriOpts
-          { simp = True
-          , debug = False
-          , maxIter = Just 0
-          , askSmtIters = Just 0
-          , rpcInfo = Nothing
-          }
+        let noLoopVeriOpts = VeriOpts {
+            simp = True
+            , debug = False
+            , maxIter = Just 0
+            , askSmtIters = Just 0
+            , rpcInfo = Nothing
+            }
         expr2 <- fixContractJumps expr
         putStrLn $ "Contract: " <> (show expr2)
         let lits = assemble . getOpData $ expr2

--- a/test/test.hs
+++ b/test/test.hs
@@ -2152,9 +2152,9 @@ tests = testGroup "hevm"
           withSolvers CVC5 6 (Just 3) $ \s -> do
             Right res <- equivalenceCheck s aPrgm bPrgm myVeriOpts Nothing
             end <- getCurrentTime
-            let cexs = getCexes res
-                timeouts = getSMTTimeouts res
-                smtErrors = getSMTErrors res
+            let cexs = filter (sameCnstr (Cex())) res
+                timeouts = filter (sameCnstr (SMTTimeout ())) res
+                smtErrors = filter (sameCnstr (SMTError () "")) res
             case (null cexs) of
               False -> do
                 print $ "OK. Took " <> (show $ diffUTCTime end start) <> " seconds"

--- a/test/test.hs
+++ b/test/test.hs
@@ -2148,7 +2148,7 @@ tests = testGroup "hevm"
             case containsA (Cex()) res of
               False -> do
                 print $ "OK. Took " <> (show $ diffUTCTime end start) <> " seconds"
-                let timeouts = filter (\(_, _, c) -> c == EVM.SymExec.Timeout()) res
+                let timeouts = filter (\(_, _, c) -> c == SMTTimeout()) res
                 unless (null timeouts) $ putStrLn $ "But " <> (show $ length timeouts) <> " timeout(s) occurred"
               True -> do
                 putStrLn $ "Not OK: " <> show f <> " Got: " <> show res
@@ -2391,9 +2391,9 @@ genName = fmap (T.pack . ("esc_" <> )) $ listOf1 (oneof . (fmap pure) $ ['a'..'z
 
 genEnd :: Int -> Gen (Expr End)
 genEnd 0 = oneof
- [ pure $ Failure [] Invalid
+ [ pure $ Failure [] EVM.Types.InvalidOpcode
  , pure $ Failure [] EVM.Types.IllegalOverflow
- , pure $ Failure [] SelfDestruct
+ , pure $ Failure [] EVM.Types.SelfDestruct
  ]
 genEnd sz = oneof
  [ fmap (EVM.Types.Revert []) subBuf

--- a/test/test.hs
+++ b/test/test.hs
@@ -41,7 +41,6 @@ import Control.Lens hiding (List, pre, (.>), re)
 import qualified Data.Vector as Vector
 import Data.String.Here
 import qualified Data.Map.Strict as Map
-import Data.Vector (Vector)
 
 import Data.Binary.Put (runPut)
 import Data.Binary.Get (runGetOrFail)
@@ -102,21 +101,6 @@ tests = testGroup "hevm"
         (Expr.readStorage' (Lit 0x0) (Lit 0x0)
           (SStore (Lit 0xacab) (Lit 0xdead) (Lit 0x0) (SStore (Var "1312") (Lit 0x0) (Lit 0x0) (ConcreteStore $ Map.fromList [(0x0, Map.fromList [(0x0, 0xab)])]))))
     ]
-  -- , testGroup "Remote State Tests"
-  --   [ testCase "check-prevrandao-post-merge-block" $ do
-  --       let ctrct = assemble
-  --                       [ OpPrevRandao
-  --                       , OpPush (Lit 0)
-  --                       , OpMstore
-  --                       , OpPush (Lit 0)
-  --                       , OpPush (Lit 31)
-  --                       , OpReturn
-  --                       ]
-  --       putStrLn ""
-  --       print ctrct
-  --       res <- runCode (Just (Fetch.BlockNumber 16184420, testRpc)) ctrct (ConcreteBuf "")
-  --       assertEqual "" res (Just (ConcreteBuf $ word256Bytes 0x2267531ab030ed32fd5f2ef51f81427332d0becbd74fe7f4cd5684ddf4b287e0))
-  --   ]
   -- These tests fuzz the simplifier by generating a random expression,
   -- applying some simplification rules, and then using the smt encoding to
   -- check that the simplified version is semantically equivalent to the

--- a/test/test.hs
+++ b/test/test.hs
@@ -107,6 +107,14 @@ tests = testGroup "hevm"
   -- unsimplified one
   , testGroup "contractQuickCheck"
     [ testProperty "random-contract-with-symbolic-call" $ \(expr :: OpContract) -> ioProperty $ do
+      let noLoopVeriOpts :: VeriOpts
+        noLoopVeriOpts = VeriOpts
+          { simp = True
+          , debug = False
+          , maxIter = Just 0
+          , askSmtIters = Just 0
+          , rpcInfo = Nothing
+          }
         expr2 <- fixContractJumps expr
         putStrLn $ "Contract: " <> (show expr2)
         let lits = assemble . getOpData $ expr2


### PR DESCRIPTION
## Description
* Rename Error in `EVM` to `EVMError`.
* Rename Error in `EVM.Types` to `ExprError`
* Rename `UnrecognizedOpcode` to `InvalidOpcode` (this make this the same name as in `EVM.Types`)
* Rename `SelfDestruction` to `SelfDestruct` (this make this the same name as in `EVM.Types`)
* Reorder case checks in `runExpr` to match that in `EVM.Types` so it's clear we cover all
* Rename `TmpError` to `WrappedEVMError`, since it's ONLY generated as part of `runExpr`, and only when it cannot be converted into an `EVM.Types.ExprError` or a `Revert`.
* Remove `SMTTimeout` from `EVMError` since it's never used and does not belong there
* Add `SMTError` to `VerifyResult` to account for SMT solver errors
* Return `Either ExprError` from `verify`, `equivalenceCheck` and associated functions, when `Expr` generation fails
* Adding `Assembler.hs` by dxo
* Adding random bytecode generator to do some fuzzing using QuickCheck. This fixes up `JumpDestination`-s after generation and ensures that jumps only happen _forward_ so we never encode any loops.
* When copying a large `CopySlice`, return a `Left` instead of a very-very large SMT file
* Minor English typo corrections

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
