### PR TITLE
Storage counterexamples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New cheatcode `prank(address)` that sets `msg.sender` to the specified address for the next call.
 - Improved equivalence checker that avoids checking similar branches more than once.
 - Improved simplification for arithmetic expressions
+- Construction of storage counterexamples based on the model returned by the SMT solver.
 
 ## [0.50.2] - 2023-01-06
 

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -1004,7 +1004,7 @@ withSolvers solver count timeout cont = do
             "sat" -> do
               calldatamodels <- getVars parseVar inst (fmap T.toStrict cexvars.calldataV)
               buffermodels <- getBufs inst (fmap T.toStrict cexvars.buffersV)
-              storagemodels <- getStore inst (storeReads cexvars)
+              storagemodels <- getStore inst cexvars.storeReads
               blockctxmodels <- getVars parseBlockCtx inst (fmap T.toStrict cexvars.blockContextV)
               txctxmodels <- getVars parseFrameCtx inst (fmap T.toStrict cexvars.txContextV)
               pure $ Sat $ SMTCex

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -130,8 +130,7 @@ findStorageReads = foldProp go []
   where
     go :: Expr a -> [(Expr EWord, Expr EWord)]
     go = \case
-      SLoad addr slot storage ->
-        if isAbstractStorage storage then [(addr, slot)] else []
+      SLoad addr slot storage -> [(addr, slot) | isAbstractStorage storage]
       _ -> []
 
 assertProps :: [Prop] -> SMT2

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -122,7 +122,7 @@ isAbstractStorage = getAny . foldExpr go (Any False)
 -- | This function overapproximates the reads from the abstract
 -- storage. Potentially, it can return a location that has been
 -- overwritten in the abstract store. However, such reads will have
--- been simplified away, is the source expresion is simplified.
+-- been simplified away, if the source expression is simplified.
 findStorageReads :: Prop -> [(Expr EWord, Expr EWord)]
 findStorageReads = foldProp go []
   where
@@ -830,7 +830,7 @@ getStore inst sreads = do
 
 
 
--- | Interpret an N-dimentional array as a value of type a.
+-- | Interpret an N-dimensional array as a value of type a.
 -- Parameterized by an interpretation function for array values.
 interpretNDArray :: (Map Symbol Term -> Term -> a) -> (Map Symbol Term) -> Term -> (W256 -> a)
 interpretNDArray interp env = \case
@@ -860,7 +860,7 @@ interpretNDArray interp env = \case
     isStore t = t == Unqualified (IdSymbol "store")
 
 
--- | Interpret an 1-dimentional array as a function
+-- | Interpret an 1-dimensional array as a function
 interpret1DArray :: (Map Symbol Term) -> Term -> (W256 -> W256)
 interpret1DArray = interpretNDArray interpretW256
   where
@@ -872,7 +872,7 @@ interpret1DArray = interpretNDArray interpretW256
         Nothing -> error "Internal error: unknown identifier, cannot parse array"
     interpretW256 _ t = error $ "Internal error: cannot parse array value. Unexpected term: " <> (show t)
 
--- | Interpret an 2-dimentional array as a function
+-- | Interpret an 2-dimensional array as a function
 interpret2DArray :: (Map Symbol Term) -> Term -> (W256 -> W256 -> W256)
 interpret2DArray = interpretNDArray interpret1DArray
 

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -120,9 +120,11 @@ isAbstractStorage = getAny . foldExpr go (Any False)
     go _ = Any False
 
 -- | This function overapproximates the reads from the abstract
--- storage. Potentially, it can return a location that has been
--- overwritten in the abstract store. However, such reads will have
--- been simplified away, if the source expression is simplified.
+-- storage. Potentially, it can return locations that do not read a
+-- slot directly from the abstract store but from subsequent writes on
+-- the store (e.g, SLoad addr idx (SStore addr idx val AbstractStore)).
+-- However, we expect that most of such reads will have been
+-- simplified away.
 findStorageReads :: Prop -> [(Expr EWord, Expr EWord)]
 findStorageReads = foldProp go []
   where

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -738,7 +738,7 @@ formatCex cd m@(SMTCex _ _ _ blockContext txContext) = T.unlines $
 
 -- | Takes a buffer and a Cex and replaces all abstract values in the buf with concrete ones from the Cex
 subModel :: SMTCex -> Expr a -> Expr a
-subModel c expr = subBufs c.buffers . subVars c.vars . subVars c.blockContext . subVars c.txContext $ expr
+subModel c expr = subBufs c.buffers . subVars c.vars . subStore c.store . subVars c.blockContext . subVars c.txContext $ expr
   where
     subVars model b = Map.foldlWithKey subVar b model
     subVar :: Expr a -> Expr EWord -> W256 -> Expr a
@@ -760,4 +760,12 @@ subModel c expr = subBufs c.buffers . subVars c.vars . subVars c.blockContext . 
           a@(AbstractBuf _) -> if a == var
                       then ConcreteBuf val
                       else a
+          e -> e
+
+    subStore :: Map W256 (Map W256 W256) -> Expr a -> Expr a
+    subStore m b = mapExpr go b
+      where
+        go :: Expr a -> Expr a
+        go = \case
+          AbstractStore -> ConcreteStore m
           e -> e

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -676,11 +676,12 @@ showModel cd (expr, res) = do
 
 
 formatCex :: Expr Buf -> SMTCex -> Text
-formatCex cd m@(SMTCex _ _ _ blockContext txContext) = T.unlines $
+formatCex cd m@(SMTCex _ _ store blockContext txContext) = T.unlines $
   [ "Calldata:"
   , indent 2 cd'
   , ""
   ]
+  <> storeCex
   <> txCtx
   <> blockCtx
   where
@@ -692,6 +693,15 @@ formatCex cd m@(SMTCex _ _ _ blockContext txContext) = T.unlines $
     -- callvalue check inserted by solidity in contracts that don't have any
     -- payable functions).
     cd' = prettyBuf $ Expr.simplify $ subModel m cd
+
+    storeCex :: [Text]
+    storeCex
+      | Map.null store = []
+      | otherwise =
+          [ "Storage:"
+          , indent 2 $ T.unlines $ Map.foldrWithKey (\key val acc -> ("Addr " <> (T.pack $ show key) <> ": " <> (T.pack $ show (Map.toList val))) : acc) mempty store
+          , ""
+          ]
 
     txCtx :: [Text]
     txCtx

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -676,7 +676,7 @@ showModel cd (expr, res) = do
 
 
 formatCex :: Expr Buf -> SMTCex -> Text
-formatCex cd m@(SMTCex _ _ blockContext txContext) = T.unlines $
+formatCex cd m@(SMTCex _ _ _ blockContext txContext) = T.unlines $
   [ "Calldata:"
   , indent 2 cd'
   , ""

--- a/test/test.hs
+++ b/test/test.hs
@@ -1660,7 +1660,7 @@ tests = testGroup "hevm"
                   & set (state . callvalue) (Lit 0)
                   & over (env . contracts)
                        (Map.insert aAddr (initialContract (RuntimeCode (ConcreteRuntimeCode a))))
-            verify s debugVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
+            verify s defaultVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
 
           let storeCex = store cex
               addrC = W256 $ num $ createAddress ethrunAddress 1
@@ -1763,7 +1763,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (_, [(Cex (_, cex))]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] debugVeriOpts
+          (_, [(Cex (_, cex))]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           let storeCex = store cex
               addr =  W256 $ num $ createAddress ethrunAddress 1
               testCex = Map.size storeCex == 1 &&
@@ -1787,7 +1787,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (_, [(Cex (_, cex))]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] debugVeriOpts
+          (_, [(Cex (_, cex))]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           let storeCex = store cex
           let addr = W256 $ num $ createAddress ethrunAddress 1
           let a = getVar cex "arg1"

--- a/test/test.hs
+++ b/test/test.hs
@@ -1133,7 +1133,7 @@ tests = testGroup "hevm"
               in case leaf of
                 Return _ _ postStore -> Expr.add prex (Expr.mul (Lit 2) y) .== (Expr.readStorage' this (Lit 0) postStore)
                 _ -> PBool True
-        (res, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> verifyContract s c (Just ("f(uint256)", [AbiUIntType 256])) [] debugVeriOpts SymbolicS (Just pre) (Just post)
+        (res, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> verifyContract s c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts SymbolicS (Just pre) (Just post)
         putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         -- tests how whiffValue handles Neg via application of the triple IsZero simplification rule

--- a/test/test.hs
+++ b/test/test.hs
@@ -1662,7 +1662,7 @@ tests = testGroup "hevm"
                        (Map.insert aAddr (initialContract (RuntimeCode (ConcreteRuntimeCode a))))
             verify s defaultVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
 
-          let storeCex = store cex
+          let storeCex = cex.store
               addrC = W256 $ num $ createAddress ethrunAddress 1
               addrA = W256 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B
               testCex = Map.size storeCex == 2 &&
@@ -1764,7 +1764,7 @@ tests = testGroup "hevm"
             }
             |]
           (_, [(Cex (_, cex))]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
-          let storeCex = store cex
+          let storeCex = cex.store
               addr =  W256 $ num $ createAddress ethrunAddress 1
               testCex = Map.size storeCex == 1 &&
                         case Map.lookup addr storeCex of
@@ -1788,7 +1788,7 @@ tests = testGroup "hevm"
             }
             |]
           (_, [(Cex (_, cex))]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
-          let storeCex = store cex
+          let storeCex = cex.store
           let addr = W256 $ num $ createAddress ethrunAddress 1
           let a = getVar cex "arg1"
           let testCex = Map.size storeCex == 1 &&

--- a/test/test.hs
+++ b/test/test.hs
@@ -53,6 +53,7 @@ import EVM.RLP
 import EVM.Solidity
 import EVM.Types
 import EVM.Traversals
+import EVM.Concrete (createAddress)
 import EVM.SMT hiding (one)
 import qualified EVM.Expr as Expr
 import qualified Data.Text as T
@@ -1653,18 +1654,26 @@ tests = testGroup "hevm"
               aAddr = Addr 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B
           Just c <- solcRuntime "C" code'
           Just a <- solcRuntime "A" code'
-          (_, [Cex cex]) <- withSolvers Z3 1 Nothing $ \s -> do
+          (_, [Cex (_, cex)]) <- withSolvers Z3 1 Nothing $ \s -> do
             let vm0 = abstractVM (Just ("call_A()", [])) [] c Nothing SymbolicS
             let vm = vm0
                   & set (state . callvalue) (Lit 0)
                   & over (env . contracts)
                        (Map.insert aAddr (initialContract (RuntimeCode (ConcreteRuntimeCode a))))
-                  -- NOTE: this used to as follows, but there is no _storage field in Contract record
-                  -- (Map.insert aAddr (initialContract (RuntimeCode $ ConcreteBuffer a) &
-                  --                     set EVM.storage (EVM.Symbolic [] store)))
             verify s debugVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
-          print cex
-          -- putStrLn "found counterexample:"
+
+          let storeCex = store cex
+              addrC = W256 $ num $ createAddress ethrunAddress 1
+              addrA = W256 0x35D1b3F3D7966A1DFe207aa4514C12a259A0492B
+              testCex = Map.size storeCex == 2 &&
+                        case (Map.lookup addrC storeCex, Map.lookup addrA storeCex) of
+                          (Just sC, Just sA) -> Map.size sC == 1 && Map.size sA == 1 &&
+                            case (Map.lookup 0 sC, Map.lookup 0 sA) of
+                              (Just x, Just y) -> x /= y
+                              _ -> False
+                          _ -> False
+          assertBool "Did not find expected storage cex" testCex
+          putStrLn "expected counterexample found"
         ,
         expectFail $ testCase "calling unique contracts (read from storage)" $ do
           Just c <- solcRuntime "C"
@@ -1742,6 +1751,55 @@ tests = testGroup "hevm"
 
           (_, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("distributivity(uint256,uint256,uint256)", [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLn "Proven"
+        ,
+        testCase "storage-cex-1" $ do
+          Just c <- solcRuntime "C"
+            [i|
+            contract C {
+              uint x;
+              uint y;
+              function fun(uint256 a) external{
+                assert (x == y);
+              }
+            }
+            |]
+          (_, [(Cex (_, cex))]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] debugVeriOpts
+          let storeCex = store cex
+              addr =  W256 $ num $ createAddress ethrunAddress 1
+              testCex = Map.size storeCex == 1 &&
+                        case Map.lookup addr storeCex of
+                          Just s -> Map.size s == 2 &&
+                                    case (Map.lookup 0 s, Map.lookup 1 s) of
+                                      (Just x, Just y) -> x /= y
+                                      _ -> False
+                          _ -> False
+          assertBool "Did not find expected storage cex" testCex
+          putStrLn "Expected counterexample found"
+        ,
+        testCase "storage-cex-2" $ do
+          Just c <- solcRuntime "C"
+            [i|
+            contract C {
+              uint[10] arr1;
+              uint[10] arr2;
+              function fun(uint256 a) external{
+                assert (arr1[0] < arr2[a]);
+              }
+            }
+            |]
+          (_, [(Cex (_, cex))]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x01] c (Just ("fun(uint256)", [AbiUIntType 256])) [] debugVeriOpts
+          let storeCex = store cex
+          let addr = W256 $ num $ createAddress ethrunAddress 1
+          let a = getVar cex "arg1"
+          let testCex = Map.size storeCex == 1 &&
+                        case Map.lookup addr storeCex of
+                          Just s -> Map.size s == 2 &&
+                                    case (Map.lookup 0 s, Map.lookup (10 + a) s) of
+                                      (Just x, Just y) -> x >= y
+                                      _ -> False
+                          _ -> False
+          assertBool "Did not find expected storage cex" testCex
+          putStrLn "Expected counterexample found"
  ]
   , testGroup "Equivalence checking"
     [

--- a/test/test.hs
+++ b/test/test.hs
@@ -1800,6 +1800,21 @@ tests = testGroup "hevm"
                           _ -> False
           assertBool "Did not find expected storage cex" testCex
           putStrLn "Expected counterexample found"
+        ,
+        testCase "storage-cex-concrete" $ do
+          Just c <- solcRuntime "C"
+            [i|
+            contract C {
+              uint x;
+              uint y;
+              function fun(uint256 a) external{
+                assert (x == y);
+              }
+            }
+            |]
+          (res, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> verifyContract s c (Just ("fun(uint256)", [AbiUIntType 256])) [] defaultVeriOpts ConcreteS Nothing (Just $ checkAssertions [0x01])
+          putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
+
  ]
   , testGroup "Equivalence checking"
     [


### PR DESCRIPTION
## Description

Construction of storage counterexamples based on the model returned by the SMT. The approach is: 

- Keep track of the storage slots that are read by a particular query.
- Parse the storage model returned by the SMT as a Haskell function.
- Query the SMT solver for the concrete value of the slots that we are interested in, and add them to a storage map. The value of the map is the value of the function for the given slot.

## Checklist

- [X] tested locally
- [X] added automated tests
- [ ] updated the docs
- [X] updated the changelog
