### PR TITLE
Adding SCBinary parsing, enabling some YUL tests

### DIFF
--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -23,7 +23,7 @@ import Data.Containers.ListUtils (nubOrd)
 import Language.SMT2.Parser (getValueRes, parseCommentFreeFileMsg)
 import Language.SMT2.Syntax (SpecConstant(..), GeneralRes(..), Term(..), QualIdentifier(..), Identifier(..), Sort(..), Index(..), VarBinding(..))
 import Data.Word
-import Numeric (readHex)
+import Numeric (readHex, readBin)
 import Data.ByteString (ByteString)
 
 import qualified Data.ByteString as BS
@@ -897,6 +897,7 @@ getBufs inst names = foldM getBuf mempty names
 
 parseSC :: (Num a, Eq a) => SpecConstant -> a
 parseSC (SCHexadecimal a) = fst . head . Numeric.readHex . T.unpack . T.fromStrict $ a
+parseSC (SCBinary a) = fst . head . Numeric.readBin . T.unpack . T.fromStrict $ a
 parseSC sc = error $ "Internal Error: cannot parse: " <> show sc
 
 withSolvers :: Solver -> Natural -> Maybe Natural -> (SolverGroup -> IO a) -> IO a

--- a/test/test.hs
+++ b/test/test.hs
@@ -2013,18 +2013,16 @@ tests = testGroup "hevm"
                     , "unusedStoreEliminator/remove_before_revert.yul"
                     , "unusedStoreEliminator/unknown_length2.yul"
                     , "unusedStoreEliminator/unrelated_relative.yul"
+                    , "fullSuite/extcodelength.yul"
+                    , "unusedStoreEliminator/create_inside_function.yul"-- "trying to reset symbolic storage with writes in create"
 
                     -- Takes too long, would timeout on most test setups.
                     -- We could probably fix these by "bunching together" queries
                     , "reasoningBasedSimplifier/mulmod.yul"
 
                     -- TODO check what's wrong with these!
-                    , "unusedStoreEliminator/create_inside_function.yul"
-                    , "fullSimplify/not_applied_removes_non_constant_and_not_movable.yul" -- create bug?
-                    , "unusedStoreEliminator/create.yul" -- create bug?
-                    , "fullSuite/extcodelength.yul" -- extcodecopy bug?
-                    , "loadResolver/keccak_short.yul" -- keccak bug
-                    , "reasoningBasedSimplifier/signed_division.yul" -- ACTUAL bug, SDIV I think?
+                    , "loadResolver/keccak_short.yul" -- ACTUAL bug -- keccak
+                    , "reasoningBasedSimplifier/signed_division.yul" -- ACTUAL bug, SDIV
                     ]
 
         solcRepo <- fromMaybe (error "cannot find solidity repo") <$> (lookupEnv "HEVM_SOLIDITY_REPO")


### PR DESCRIPTION
## Description
This adds `SCBinary` parsing, and enables some disabled YUL simplification tests. With the fix to `SCBinary` it seems that we have an actual issue with `reasoningBasedSimplifier/signed_division.yul`, likely SDIV. I'll take a closer look later.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
