### PR TITLE
Enable OverloadedRecordDot, NoFieldSelectors and DuplicateRecordFields

### DIFF
--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -187,8 +187,8 @@ instance Options.ParseRecord (Command Options.Wrapped) where
 
 optsMode :: Command Options.Unwrapped -> Mode
 optsMode x
-  | Main.debug x = Debug
-  | jsontrace x = JsonTrace
+  | x.debug = Debug
+  | x.jsontrace = JsonTrace
   | otherwise = Run
 
 applyCache :: (Maybe String, Maybe String) -> IO (EVM.VM -> EVM.VM)
@@ -211,51 +211,51 @@ applyCache (state, cache) =
 
 unitTestOptions :: Command Options.Unwrapped -> SolverGroup -> String -> IO UnitTestOptions
 unitTestOptions cmd solvers testFile = do
-  let root = fromMaybe "." (dappRoot cmd)
+  let root = fromMaybe "." cmd.dappRoot
   srcInfo <- readSolc testFile >>= \case
     Nothing -> error "Could not read .sol.json file"
     Just (contractMap, sourceCache) ->
       pure $ dappInfo root contractMap sourceCache
 
-  vmModifier <- applyCache (state cmd, cache cmd)
+  vmModifier <- applyCache (cmd.state, cmd.cache)
 
-  params <- getParametersFromEnvironmentVariables (rpc cmd)
+  params <- getParametersFromEnvironmentVariables cmd.rpc
 
   let
-    testn = testNumber params
+    testn = params.testNumber
     block' = if 0 == testn
        then EVM.Fetch.Latest
        else EVM.Fetch.BlockNumber testn
 
   pure EVM.UnitTest.UnitTestOptions
-    { EVM.UnitTest.solvers = solvers
-    , EVM.UnitTest.rpcInfo = case rpc cmd of
+    { solvers = solvers
+    , rpcInfo = case cmd.rpc of
          Just url -> Just (block', url)
          Nothing  -> Nothing
-    , EVM.UnitTest.maxIter = maxIterations cmd
-    , EVM.UnitTest.askSmtIters = askSmtIterations cmd
-    , EVM.UnitTest.smtDebug = smtdebug cmd
-    , EVM.UnitTest.smtTimeout = smttimeout cmd
-    , EVM.UnitTest.solver = solver cmd
-    , EVM.UnitTest.covMatch = pack <$> covMatch cmd
-    , EVM.UnitTest.verbose = verbose cmd
-    , EVM.UnitTest.match = pack $ fromMaybe ".*" (match cmd)
-    , EVM.UnitTest.maxDepth = depth cmd
-    , EVM.UnitTest.fuzzRuns = fromMaybe 100 (fuzzRuns cmd)
-    , EVM.UnitTest.replay = do
-        arg' <- replay cmd
+    , maxIter = cmd.maxIterations
+    , askSmtIters = cmd.askSmtIterations
+    , smtDebug = cmd.smtdebug
+    , smtTimeout = cmd.smttimeout
+    , solver = cmd.solver
+    , covMatch = pack <$> cmd.covMatch
+    , verbose = cmd.verbose
+    , match = pack $ fromMaybe ".*" cmd.match
+    , maxDepth = cmd.depth
+    , fuzzRuns = fromMaybe 100 cmd.fuzzRuns
+    , replay = do
+        arg' <- cmd.replay
         return (fst arg', LazyByteString.fromStrict (hexByteString "--replay" $ strip0x $ snd arg'))
-    , EVM.UnitTest.vmModifier = vmModifier
-    , EVM.UnitTest.testParams = params
-    , EVM.UnitTest.dapp = srcInfo
-    , EVM.UnitTest.ffiAllowed = ffi cmd
+    , vmModifier = vmModifier
+    , testParams = params
+    , dapp = srcInfo
+    , ffiAllowed = cmd.ffi
     }
 
 main :: IO ()
 main = do
   cmd <- Options.unwrapRecord "hevm -- Ethereum evaluator"
   let
-    root = fromMaybe "." (dappRoot cmd)
+    root = fromMaybe "." cmd.dappRoot
   case cmd of
     Version {} -> putStrLn (showVersion Paths.version)
     Symbolic {} -> withCurrentDirectory root $ assert cmd
@@ -265,12 +265,12 @@ main = do
     DappTest {} ->
       withCurrentDirectory root $ do
         cores <- num <$> getNumProcessors
-        withSolvers Z3 cores (smttimeout cmd) $ \solvers -> do
-          testFile <- findJsonFile (jsonFile cmd)
+        withSolvers Z3 cores cmd.smttimeout $ \solvers -> do
+          testFile <- findJsonFile cmd.jsonFile
           testOpts <- unitTestOptions cmd solvers testFile
-          case (coverage cmd, optsMode cmd) of
+          case (cmd.coverage, optsMode cmd) of
             (False, Run) -> do
-              res <- dappTest testOpts testFile (cache cmd)
+              res <- dappTest testOpts testFile cmd.cache
               unless res exitFailure
             (False, Debug) -> liftIO $ TTY.main testOpts root testFile
             (False, JsonTrace) -> error "json traces not implemented for dappTest"
@@ -298,12 +298,12 @@ findJsonFile Nothing = do
 
 equivalence :: Command Options.Unwrapped -> IO ()
 equivalence cmd = do
-  let bytecodeA = hexByteString "--code" . strip0x $ codeA cmd
-      bytecodeB = hexByteString "--code" . strip0x $ codeB cmd
+  let bytecodeA = hexByteString "--code" . strip0x $ cmd.codeA
+      bytecodeB = hexByteString "--code" . strip0x $ cmd.codeB
       veriOpts = VeriOpts { simp = True
                           , debug = False
-                          , maxIter = maxIterations cmd
-                          , askSmtIters = askSmtIterations cmd
+                          , maxIter = cmd.maxIterations
+                          , askSmtIters = cmd.askSmtIterations
                           , rpcInfo = Nothing
                           }
 
@@ -321,8 +321,8 @@ equivalence cmd = do
 
 getSrcInfo :: Command Options.Unwrapped -> IO DappInfo
 getSrcInfo cmd =
-  let root = fromMaybe "." (dappRoot cmd)
-  in case (jsonFile cmd) of
+  let root = fromMaybe "." cmd.dappRoot
+  in case cmd.jsonFile of
     Nothing ->
       pure emptyDapp
     Just json -> readSolc json >>= \case
@@ -339,10 +339,10 @@ getSrcInfo cmd =
 -- If function signatures are known, they should always be given for best results.
 assert :: Command Options.Unwrapped -> IO ()
 assert cmd = do
-  let block'  = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
-      rpcinfo = (,) block' <$> rpc cmd
+  let block'  = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber cmd.block
+      rpcinfo = (,) block' <$> cmd.rpc
       decipher = hexByteString "bytes" . strip0x
-  calldata' <- case (Main.calldata cmd, sig cmd) of
+  calldata' <- case (cmd.calldata, cmd.sig) of
     -- fully abstract calldata
     (Nothing, Nothing) -> pure
       ( AbstractBuf "txdata"
@@ -359,24 +359,24 @@ assert cmd = do
     (Nothing, Just sig') -> do
       method' <- functionAbi sig'
       let typs = snd <$> view methodInputs method'
-      pure $ symCalldata (view methodSignature method') typs (arg cmd) mempty
+      pure $ symCalldata (view methodSignature method') typs cmd.arg mempty
     _ -> error "incompatible options: calldata and abi"
 
   preState <- symvmFromCommand cmd calldata'
-  let errCodes = fromMaybe defaultPanicCodes (assertions cmd)
+  let errCodes = fromMaybe defaultPanicCodes cmd.assertions
   cores <- num <$> getNumProcessors
-  let solverCount = fromMaybe cores (numSolvers cmd)
-  withSolvers EVM.SMT.Z3 solverCount (smttimeout cmd) $ \solvers -> do
-    if Main.debug cmd then do
+  let solverCount = fromMaybe cores cmd.numSolvers
+  withSolvers EVM.SMT.Z3 solverCount cmd.smttimeout $ \solvers -> do
+    if cmd.debug then do
       srcInfo <- getSrcInfo cmd
       void $ TTY.runFromVM
         solvers
         rpcinfo
-        (maxIterations cmd)
+        cmd.maxIterations
         srcInfo
         preState
     else do
-      let opts = VeriOpts { simp = True, debug = smtdebug cmd, maxIter = maxIterations cmd, askSmtIters = askSmtIterations cmd, rpcInfo = rpcinfo}
+      let opts = VeriOpts { simp = True, debug = cmd.smtdebug, maxIter = cmd.maxIterations, askSmtIters = cmd.askSmtIterations, rpcInfo = rpcinfo}
       (expr, res) <- verify solvers opts preState (Just $ checkAssertions errCodes)
       case res of
         [Qed _] -> putStrLn "\nQED: No reachable property violations discovered\n"
@@ -396,16 +396,16 @@ assert cmd = do
                    , ""
                    ] <> fmap (formatExpr) (getTimeouts cexs)
           T.putStrLn $ T.unlines (counterexamples <> unknowns)
-      when (showTree cmd) $ do
+      when cmd.showTree $ do
         putStrLn "=== Expression ===\n"
         T.putStrLn $ formatExpr expr
         putStrLn ""
-      when (showReachableTree cmd) $ do
+      when cmd.showReachableTree $ do
         reached <- reachable solvers expr
         putStrLn "=== Reachable Expression ===\n"
         T.putStrLn (formatExpr . snd $ reached)
         putStrLn ""
-      when (getModels cmd) $ do
+      when cmd.getModels $ do
         putStrLn $ "=== Models for " <> show (Expr.numBranches expr) <> " branches ===\n"
         ms <- produceModels solvers expr
         forM_ ms (showModel (fst calldata'))
@@ -427,13 +427,13 @@ dappCoverage opts _ solcFile =
   readSolc solcFile >>=
     \case
       Just (contractMap, sourceCache) -> do
-        let unitTests = findUnitTests (EVM.UnitTest.match opts) $ Map.elems contractMap
+        let unitTests = findUnitTests opts.match $ Map.elems contractMap
         covs <- mconcat <$> mapM
           (coverageForUnitTestContract opts contractMap sourceCache) unitTests
         let
           dapp = dappInfo "." contractMap sourceCache
           f (k, vs) = do
-            when (shouldPrintCoverage (EVM.UnitTest.covMatch opts) k) $ do
+            when (shouldPrintCoverage opts.covMatch k) $ do
               putStr ("\x1b[0m" ++ "————— hevm coverage for ") -- Prefixed with color reset
               putStrLn (unpack k ++ " —————")
               putStrLn ""
@@ -470,7 +470,7 @@ launchExec cmd = do
     case optsMode cmd of
       Run -> do
         vm' <- execStateT (EVM.Stepper.interpret (EVM.Fetch.oracle solvers rpcinfo) . void $ EVM.Stepper.execFully) vm
-        when (trace cmd) $ T.hPutStr stderr (showTraceTree dapp vm')
+        when cmd.trace $ T.hPutStr stderr (showTraceTree dapp vm')
         case view EVM.result vm' of
           Nothing ->
             error "internal error; no EVM result"
@@ -488,11 +488,11 @@ launchExec cmd = do
                   ConcreteBuf msg' -> msg'
                   _ -> "<symbolic>"
             print $ ByteStringS msg
-            case state cmd of
+            case cmd.state of
               Nothing -> pure ()
               Just path ->
                 Git.saveFacts (Git.RepoAt path) (Facts.vmFacts vm')
-            case cache cmd of
+            case cmd.cache of
               Nothing -> pure ()
               Just path ->
                 Git.saveFacts (Git.RepoAt path) (Facts.cacheFacts (view EVM.cache vm'))
@@ -500,15 +500,15 @@ launchExec cmd = do
       Debug -> void $ TTY.runFromVM solvers rpcinfo Nothing dapp vm
       --JsonTrace -> void $ execStateT (interpretWithTrace fetcher EVM.Stepper.runFully) vm
       _ -> error "TODO"
-     where block' = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
-           rpcinfo = (,) block' <$> rpc cmd
+     where block' = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber cmd.block
+           rpcinfo = (,) block' <$> cmd.rpc
 
 -- | Creates a (concrete) VM from command line options
 vmFromCommand :: Command Options.Unwrapped -> IO EVM.VM
 vmFromCommand cmd = do
-  withCache <- applyCache (state cmd, cache cmd)
+  withCache <- applyCache (cmd.state, cmd.cache)
 
-  (miner,ts,baseFee,blockNum,prevRan) <- case rpc cmd of
+  (miner,ts,baseFee,blockNum,prevRan) <- case cmd.rpc of
     Nothing -> return (0,Lit 0,0,0,0)
     Just url -> EVM.Fetch.fetchBlockFrom block' url >>= \case
       Nothing -> error "Could not fetch block"
@@ -519,7 +519,7 @@ vmFromCommand cmd = do
                                    , _prevRandao
                                    )
 
-  contract <- case (rpc cmd, address cmd, code cmd) of
+  contract <- case (cmd.rpc, cmd.address, cmd.code) of
     (Just url, Just addr', Just c) -> do
       EVM.Fetch.fetchContractFrom block' url addr' >>= \case
         Nothing ->
@@ -552,43 +552,43 @@ vmFromCommand cmd = do
 
   return $ EVM.Transaction.initTx $ withCache (vm0 baseFee miner ts' blockNum prevRan contract)
     where
-        block'   = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
-        value'   = word value 0
-        caller'  = addr caller 0
-        origin'  = addr origin 0
-        calldata' = ConcreteBuf $ bytes Main.calldata ""
+        block'   = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber cmd.block
+        value'   = word (.value) 0
+        caller'  = addr (.caller) 0
+        origin'  = addr (.origin) 0
+        calldata' = ConcreteBuf $ bytes (.calldata) ""
         decipher = hexByteString "bytes" . strip0x
-        mkCode bs = if create cmd
+        mkCode bs = if cmd.create
                     then EVM.InitCode bs mempty
                     else EVM.RuntimeCode (EVM.ConcreteRuntimeCode bs)
-        address' = if create cmd
-              then addr address (createAddress origin' (word nonce 0))
-              else addr address 0xacab
+        address' = if cmd.create
+              then addr (.address) (createAddress origin' (word (.nonce) 0))
+              else addr (.address) 0xacab
 
         vm0 baseFee miner ts blockNum prevRan c = EVM.makeVm $ EVM.VMOpts
-          { EVM.vmoptContract      = c
-          , EVM.vmoptCalldata      = (calldata', [])
-          , EVM.vmoptValue         = Lit value'
-          , EVM.vmoptAddress       = address'
-          , EVM.vmoptCaller        = litAddr caller'
-          , EVM.vmoptOrigin        = origin'
-          , EVM.vmoptGas           = word64 gas 0xffffffffffffffff
-          , EVM.vmoptBaseFee       = baseFee
-          , EVM.vmoptPriorityFee   = word priorityFee 0
-          , EVM.vmoptGaslimit      = word64 gaslimit 0xffffffffffffffff
-          , EVM.vmoptCoinbase      = addr coinbase miner
-          , EVM.vmoptNumber        = word number blockNum
-          , EVM.vmoptTimestamp     = Lit $ word timestamp ts
-          , EVM.vmoptBlockGaslimit = word64 gaslimit 0xffffffffffffffff
-          , EVM.vmoptGasprice      = word gasprice 0
-          , EVM.vmoptMaxCodeSize   = word maxcodesize 0xffffffff
-          , EVM.vmoptPrevRandao    = word prevRandao prevRan
-          , EVM.vmoptSchedule      = FeeSchedule.berlin
-          , EVM.vmoptChainId       = word chainid 1
-          , EVM.vmoptCreate        = create cmd
-          , EVM.vmoptStorageBase   = EVM.Concrete
-          , EVM.vmoptTxAccessList  = mempty -- TODO: support me soon
-          , EVM.vmoptAllowFFI      = False
+          { vmoptContract      = c
+          , vmoptCalldata      = (calldata', [])
+          , vmoptValue         = Lit value'
+          , vmoptAddress       = address'
+          , vmoptCaller        = litAddr caller'
+          , vmoptOrigin        = origin'
+          , vmoptGas           = word64 (.gas) 0xffffffffffffffff
+          , vmoptBaseFee       = baseFee
+          , vmoptPriorityFee   = word (.priorityFee) 0
+          , vmoptGaslimit      = word64 (.gaslimit) 0xffffffffffffffff
+          , vmoptCoinbase      = addr (.coinbase) miner
+          , vmoptNumber        = word (.number) blockNum
+          , vmoptTimestamp     = Lit $ word (.timestamp) ts
+          , vmoptBlockGaslimit = word64 (.gaslimit) 0xffffffffffffffff
+          , vmoptGasprice      = word (.gasprice) 0
+          , vmoptMaxCodeSize   = word (.maxcodesize) 0xffffffff
+          , vmoptPrevRandao    = word (.prevRandao) prevRan
+          , vmoptSchedule      = FeeSchedule.berlin
+          , vmoptChainId       = word (.chainid) 1
+          , vmoptCreate        = (.create) cmd
+          , vmoptStorageBase   = EVM.Concrete
+          , vmoptTxAccessList  = mempty -- TODO: support me soon
+          , vmoptAllowFFI      = False
           }
         word f def = fromMaybe def (f cmd)
         word64 f def = fromMaybe def (f cmd)
@@ -597,7 +597,7 @@ vmFromCommand cmd = do
 
 symvmFromCommand :: Command Options.Unwrapped -> (Expr Buf, [Prop]) -> IO (EVM.VM)
 symvmFromCommand cmd calldata' = do
-  (miner,blockNum,baseFee,prevRan) <- case rpc cmd of
+  (miner,blockNum,baseFee,prevRan) <- case cmd.rpc of
     Nothing -> return (0,0,0,0)
     Just url -> EVM.Fetch.fetchBlockFrom block' url >>= \case
       Nothing -> error "Could not fetch block"
@@ -609,10 +609,10 @@ symvmFromCommand cmd calldata' = do
 
   let
     caller' = Caller 0
-    ts = maybe Timestamp Lit (timestamp cmd)
-    callvalue' = maybe (CallValue 0) Lit (value cmd)
+    ts = maybe Timestamp Lit cmd.timestamp
+    callvalue' = maybe (CallValue 0) Lit cmd.value
   -- TODO: rework this, ConcreteS not needed anymore
-  let store = case storageModel cmd of
+  let store = case cmd.storageModel of
                 -- InitialS and SymbolicS can read and write to symbolic locations
                 -- ConcreteS cannot (instead values can be fetched from rpc!)
                 -- Initial defaults to 0 for uninitialized storage slots,
@@ -620,18 +620,18 @@ symvmFromCommand cmd calldata' = do
                 Just InitialS  -> EmptyStore
                 Just ConcreteS -> ConcreteStore mempty
                 Just SymbolicS -> AbstractStore
-                Nothing -> if create cmd then EmptyStore else AbstractStore
+                Nothing -> if cmd.create then EmptyStore else AbstractStore
 
-  withCache <- applyCache (state cmd, cache cmd)
+  withCache <- applyCache (cmd.state, cmd.cache)
 
-  contract' <- case (rpc cmd, address cmd, code cmd) of
+  contract' <- case (cmd.rpc, cmd.address, cmd.code) of
     (Just url, Just addr', _) ->
       EVM.Fetch.fetchContractFrom block' url addr' >>= \case
         Nothing ->
           error "contract not found."
         Just contract' -> return contract''
           where
-            contract'' = case code cmd of
+            contract'' = case cmd.code of
               Nothing -> contract'
               -- if both code and url is given,
               -- fetch the contract and overwrite the code
@@ -652,38 +652,38 @@ symvmFromCommand cmd calldata' = do
 
   where
     decipher = hexByteString "bytes" . strip0x
-    block'   = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber (block cmd)
-    origin'  = addr origin 0
-    mkCode bs = if create cmd
+    block'   = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber cmd.block
+    origin'  = addr (.origin) 0
+    mkCode bs = if cmd.create
                    then EVM.InitCode bs mempty
                    else EVM.RuntimeCode (EVM.ConcreteRuntimeCode bs)
-    address' = if create cmd
-          then addr address (createAddress origin' (word nonce 0))
-          else addr address 0xacab
+    address' = if cmd.create
+          then addr (.address) (createAddress origin' (word (.nonce) 0))
+          else addr (.address) 0xacab
     vm0 baseFee miner ts blockNum prevRan cd' callvalue' caller' c = EVM.makeVm $ EVM.VMOpts
-      { EVM.vmoptContract      = c
-      , EVM.vmoptCalldata      = cd'
-      , EVM.vmoptValue         = callvalue'
-      , EVM.vmoptAddress       = address'
-      , EVM.vmoptCaller        = caller'
-      , EVM.vmoptOrigin        = origin'
-      , EVM.vmoptGas           = word64 gas 0xffffffffffffffff
-      , EVM.vmoptGaslimit      = word64 gaslimit 0xffffffffffffffff
-      , EVM.vmoptBaseFee       = baseFee
-      , EVM.vmoptPriorityFee   = word priorityFee 0
-      , EVM.vmoptCoinbase      = addr coinbase miner
-      , EVM.vmoptNumber        = word number blockNum
-      , EVM.vmoptTimestamp     = ts
-      , EVM.vmoptBlockGaslimit = word64 gaslimit 0xffffffffffffffff
-      , EVM.vmoptGasprice      = word gasprice 0
-      , EVM.vmoptMaxCodeSize   = word maxcodesize 0xffffffff
-      , EVM.vmoptPrevRandao    = word prevRandao prevRan
-      , EVM.vmoptSchedule      = FeeSchedule.berlin
-      , EVM.vmoptChainId       = word chainid 1
-      , EVM.vmoptCreate        = create cmd
-      , EVM.vmoptStorageBase   = EVM.Symbolic
-      , EVM.vmoptTxAccessList  = mempty
-      , EVM.vmoptAllowFFI      = False
+      { vmoptContract      = c
+      , vmoptCalldata      = cd'
+      , vmoptValue         = callvalue'
+      , vmoptAddress       = address'
+      , vmoptCaller        = caller'
+      , vmoptOrigin        = origin'
+      , vmoptGas           = word64 (.gas) 0xffffffffffffffff
+      , vmoptGaslimit      = word64 (.gaslimit) 0xffffffffffffffff
+      , vmoptBaseFee       = baseFee
+      , vmoptPriorityFee   = word (.priorityFee) 0
+      , vmoptCoinbase      = addr (.coinbase) miner
+      , vmoptNumber        = word (.number) blockNum
+      , vmoptTimestamp     = ts
+      , vmoptBlockGaslimit = word64 (.gaslimit) 0xffffffffffffffff
+      , vmoptGasprice      = word (.gasprice) 0
+      , vmoptMaxCodeSize   = word (.maxcodesize) 0xffffffff
+      , vmoptPrevRandao    = word (.prevRandao) prevRan
+      , vmoptSchedule      = FeeSchedule.berlin
+      , vmoptChainId       = word (.chainid) 1
+      , vmoptCreate        = (.create) cmd
+      , vmoptStorageBase   = EVM.Symbolic
+      , vmoptTxAccessList  = mempty
+      , vmoptAllowFFI      = False
       }
     word f def = fromMaybe def (f cmd)
     addr f def = fromMaybe def (f cmd)

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -61,7 +61,10 @@ common shared
     ghc-options: -j
   default-language: GHC2021
   default-extensions:
+    DuplicateRecordFields
     LambdaCase
+    NoFieldSelectors
+    OverloadedRecordDot
     OverloadedStrings
     RecordWildCards
     TypeFamilies

--- a/src/EVM/CSE.hs
+++ b/src/EVM/CSE.hs
@@ -40,43 +40,43 @@ go = \case
   -- buffers
   e@(WriteWord {}) -> do
     s <- get
-    case Map.lookup e (bufs s) of
+    case Map.lookup e s.bufs of
       Just v -> pure $ GVar (BufVar v)
       Nothing -> do
         let
-          next = count s
-          bs' = Map.insert e next (bufs s)
+          next = s.count
+          bs' = Map.insert e next s.bufs
         put $ s{bufs=bs', count=next+1}
         pure $ GVar (BufVar next)
   e@(WriteByte {}) -> do
     s <- get
-    case Map.lookup e (bufs s) of
+    case Map.lookup e s.bufs of
       Just v -> pure $ GVar (BufVar v)
       Nothing -> do
         let
-          next = count s
-          bs' = Map.insert e next (bufs s)
+          next = s.count
+          bs' = Map.insert e next s.bufs
         put $ s{bufs=bs', count=next+1}
         pure $ GVar (BufVar next)
   e@(CopySlice {}) -> do
     s <- get
-    case Map.lookup e (bufs s) of
+    case Map.lookup e s.bufs of
       Just v -> pure $ GVar (BufVar v)
       Nothing -> do
         let
-          next = count s
-          bs' = Map.insert e next (bufs s)
+          next = s.count
+          bs' = Map.insert e next s.bufs
         put $ s{count=next+1, bufs=bs'}
         pure $ GVar (BufVar next)
   -- storage
   e@(SStore {}) -> do
     s <- get
-    case Map.lookup e (stores s) of
+    case Map.lookup e s.stores of
       Just v -> pure $ GVar (StoreVar v)
       Nothing -> do
         let
-          next = count s
-          ss' = Map.insert e next (stores s)
+          next = s.count
+          ss' = Map.insert e next s.stores
         put $ s{count=next+1, stores=ss'}
         pure $ GVar (StoreVar next)
   e -> pure e
@@ -91,7 +91,7 @@ eliminateExpr' e = mapExprM go e
 eliminateExpr :: Expr a -> (Expr a, BufEnv, StoreEnv)
 eliminateExpr e =
   let (e', st) = runState (eliminateExpr' e) initState in
-  (e', invertKeyVal (bufs st), invertKeyVal (stores st))
+  (e', invertKeyVal st.bufs, invertKeyVal st.stores)
 
 -- | Common subexpression elimination pass for Prop
 eliminateProp' :: Prop -> State BuilderState Prop
@@ -106,4 +106,4 @@ eliminateProps' props = mapM eliminateProp' props
 eliminateProps :: [Prop] -> ([Prop], BufEnv, StoreEnv)
 eliminateProps props =
   let (props', st) = runState (eliminateProps' props) initState in
-  (props',  invertKeyVal (bufs st),  invertKeyVal (stores st))
+  (props',  invertKeyVal st.bufs,  invertKeyVal st.stores)

--- a/src/EVM/Dapp.hs
+++ b/src/EVM/Dapp.hs
@@ -84,7 +84,7 @@ dappInfo root solcByName sources =
            (f creationCodehash Creation)
       -- contracts with immutable locations can't be id by hash
     , _dappSolcByCode =
-      [(Code (_runtimeCode x) (concat $ elems $ _immutableReferences x), x) | x <- immutables]
+      [(Code x._runtimeCode (concat $ elems x._immutableReferences), x) | x <- immutables]
       -- Sum up the ABI maps from all the contracts.
     , _dappAbiMap   = mconcat (map (view abiMap) solcs)
     , _dappEventMap = mconcat (map (view eventMap) solcs)

--- a/src/EVM/Debug.hs
+++ b/src/EVM/Debug.hs
@@ -43,12 +43,12 @@ prettyContracts x =
 
 srcMapCodePos :: SourceCache -> SrcMap -> Maybe (Text, Int)
 srcMapCodePos cache sm =
-  fmap (second f) $ cache ^? sourceFiles . ix (srcMapFile sm)
+  fmap (second f) $ cache ^? sourceFiles . ix sm.srcMapFile
   where
-    f v = ByteString.count 0xa (ByteString.take (srcMapOffset sm - 1) v) + 1
+    f v = ByteString.count 0xa (ByteString.take (sm.srcMapOffset - 1) v) + 1
 
 srcMapCode :: SourceCache -> SrcMap -> Maybe ByteString
 srcMapCode cache sm =
-  fmap f $ cache ^? sourceFiles . ix (srcMapFile sm)
+  fmap f $ cache ^? sourceFiles . ix sm.srcMapFile
   where
-    f (_, v) = ByteString.take (min 80 (srcMapLength sm)) (ByteString.drop (srcMapOffset sm) v)
+    f (_, v) = ByteString.take (min 80 sm.srcMapLength) (ByteString.drop sm.srcMapOffset v)

--- a/src/EVM/Facts.hs
+++ b/src/EVM/Facts.hs
@@ -214,7 +214,7 @@ factToFile fact = case fact of
   where
     mk :: AsASCII a => [ASCII] -> ASCII -> a -> File
     mk prefix base a =
-      File (Path (dump (addr fact) : prefix) base)
+      File (Path (dump fact.addr : prefix) base)
            (Data $ dump a)
 
 -- This lets us easier pattern match on serialized things.

--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -27,7 +27,7 @@ go :: forall a. Expr a -> State BuilderState (Expr a)
 go = \case
   e@(Keccak _) -> do
     s <- get
-    put $ s{keccaks=Set.insert e (keccaks s)}
+    put $ s{keccaks=Set.insert e s.keccaks}
     pure e
   e -> pure e
 
@@ -73,7 +73,7 @@ keccakAssumptions ps bufs stores = injectivity <> minValue
   where
     (_, st) = runState (findKeccakPropsExprs ps bufs stores) initState
 
-    injectivity = fmap injProp $ combine (Set.toList (keccaks st))
-    minValue = fmap minProp (Set.toList (keccaks st))
+    injectivity = fmap injProp $ combine (Set.toList st.keccaks)
+    minValue = fmap minProp (Set.toList st.keccaks)
 
 

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -78,7 +78,7 @@ data SMTCex = SMTCex
   deriving (Eq, Show)
 
 getVar :: EVM.SMT.SMTCex -> TS.Text -> W256
-getVar cex name = fromJust $ Map.lookup (Var name) (vars cex)
+getVar cex name = fromJust $ Map.lookup (Var name) cex.vars
 
 data SMT2 = SMT2 [Builder] CexVars
   deriving (Eq, Show)
@@ -936,10 +936,10 @@ withSolvers solver count timeout cont = do
           sat <- sendLine inst "(check-sat)"
           res <- case sat of
             "sat" -> do
-              calldatamodels <- getVars parseVar inst (fmap T.toStrict $ calldataV cexvars)
-              buffermodels <- getBufs inst (fmap T.toStrict $ buffersV cexvars)
-              blockctxmodels <- getVars parseBlockCtx inst (fmap T.toStrict $ blockContextV cexvars)
-              txctxmodels <- getVars parseFrameCtx inst (fmap T.toStrict $ txContextV cexvars)
+              calldatamodels <- getVars parseVar inst (fmap T.toStrict cexvars.calldataV)
+              buffermodels <- getBufs inst (fmap T.toStrict cexvars.buffersV)
+              blockctxmodels <- getVars parseBlockCtx inst (fmap T.toStrict cexvars.blockContextV)
+              txctxmodels <- getVars parseFrameCtx inst (fmap T.toStrict cexvars.txContextV)
               pure $ Sat $ SMTCex
                 { vars = calldatamodels
                 , buffers = buffermodels

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -382,7 +382,7 @@ readCombinedJSON json = do
 
 readStdJSON :: Text -> Maybe (Map Text SolcContract, Map Text Value, [(Text, Maybe ByteString)])
 readStdJSON json = do
-  contracts <- KeyMap.toHashMapText <$> json ^? key "contracts" ._Object
+  contracts <- KeyMap.toHashMapText <$> json ^? key "contracts" . _Object
   -- TODO: support the general case of "urls" and "content" in the standard json
   sources <- KeyMap.toHashMapText <$>  json ^? key "sources" . _Object
   let asts = force "JSON lacks abstract syntax trees." . preview (key "ast") <$> sources

--- a/src/EVM/Stepper.hs
+++ b/src/EVM/Stepper.hs
@@ -99,7 +99,7 @@ execFully =
 runFully :: Stepper EVM.VM
 runFully = do
   vm <- run
-  case EVM._result vm of
+  case vm._result of
     Nothing -> error "should not occur"
     Just (VMFailure (Query q)) ->
       wait q >> runFully

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -469,12 +469,12 @@ verify :: SolverGroup -> VeriOpts -> VM -> Maybe Postcondition -> IO (Expr End, 
 verify solvers opts preState maybepost = do
   putStrLn "Exploring contract"
 
-  exprInter <- evalStateT (interpret (Fetch.oracle solvers (rpcInfo opts)) (maxIter opts) (askSmtIters opts) runExpr) preState
-  when (debug opts) $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
+  exprInter <- evalStateT (interpret (Fetch.oracle solvers opts.rpcInfo) opts.maxIter opts.askSmtIters runExpr) preState
+  when opts.debug $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
 
   putStrLn "Simplifying expression"
-  expr <- if (simp opts) then (pure $ Expr.simplify exprInter) else pure exprInter
-  when (debug opts) $ T.writeFile "simplified.expr" (formatExpr expr)
+  expr <- if opts.simp then (pure $ Expr.simplify exprInter) else pure exprInter
+  when opts.debug $ T.writeFile "simplified.expr" (formatExpr expr)
 
   putStrLn $ "Explored contract (" <> show (Expr.numBranches expr) <> " branches)"
 
@@ -491,7 +491,7 @@ verify solvers opts preState maybepost = do
         withQueries = fmap (\(pcs, leaf) -> (assertProps (PNeg (post preState leaf) : assumes <> extractProps leaf <> pcs), leaf)) canViolate
       putStrLn $ "Checking for reachability of " <> show (length withQueries) <> " potential property violation(s)"
 
-      when (debug opts) $ forM_ (zip [(1 :: Int)..] withQueries) $ \(idx, (q, leaf)) -> do
+      when opts.debug $ forM_ (zip [(1 :: Int)..] withQueries) $ \(idx, (q, leaf)) -> do
         TL.writeFile
           ("query-" <> show idx <> ".smt2")
           ("; " <> (TL.pack $ show leaf) <> "\n\n" <> formatSMT2 q <> "\n\n(check-sat)")
@@ -529,13 +529,13 @@ equivalenceCheck solvers bytecodeA bytecodeB opts signature' = do
       let allPairs = [(a,b) | a <- branchesA, b <- branchesB]
       putStrLn $ "Found " <> (show $ length allPairs) <> " total pairs of endstates"
 
-      when (debug opts) $ putStrLn
+      when opts.debug $ putStrLn
                         $ "endstates in bytecodeA: " <> (show $ length branchesA)
                        <> "\nendstates in bytecodeB: " <> (show $ length branchesB)
 
       let differingEndStates = sortBySize (mapMaybe (uncurry distinct) allPairs)
       putStrLn $ "Asking the SMT solver for " <> (show $ length differingEndStates) <> " pairs"
-      when (debug opts) $ forM_ (zip differingEndStates [(1::Integer)..]) (\(x, i) ->
+      when opts.debug $ forM_ (zip differingEndStates [(1::Integer)..]) (\(x, i) ->
         T.writeFile ("prop-checked-" <> show i) (T.pack $ show x))
 
       knownUnsat <- newTVarIO []
@@ -563,8 +563,8 @@ equivalenceCheck solvers bytecodeA bytecodeB opts signature' = do
       let
         bytecode = if BS.null bs then BS.pack [0] else bs
         prestate = abstractVM signature' [] bytecode Nothing SymbolicS
-      expr <- evalStateT (interpret (Fetch.oracle solvers Nothing) (maxIter opts) (askSmtIters opts) runExpr) prestate
-      let simpl = if (simp opts) then (Expr.simplify expr) else expr
+      expr <- evalStateT (interpret (Fetch.oracle solvers Nothing) opts.maxIter opts.askSmtIters runExpr) prestate
+      let simpl = if opts.simp then (Expr.simplify expr) else expr
       pure $ flattenExpr simpl
 
     -- checks for satisfiability of all the props in the provided set. skips
@@ -738,7 +738,7 @@ formatCex cd m@(SMTCex _ _ blockContext txContext) = T.unlines $
 
 -- | Takes a buffer and a Cex and replaces all abstract values in the buf with concrete ones from the Cex
 subModel :: SMTCex -> Expr a -> Expr a
-subModel c expr = subBufs (buffers c) . subVars (vars c) . subVars (blockContext c) . subVars (txContext c) $ expr
+subModel c expr = subBufs c.buffers . subVars c.vars . subVars c.blockContext . subVars c.txContext $ expr
   where
     subVars model b = Map.foldlWithKey subVar b model
     subVar :: Expr a -> Expr EWord -> W256 -> Expr a

--- a/src/EVM/Transaction.hs
+++ b/src/EVM/Transaction.hs
@@ -52,94 +52,94 @@ data Transaction = Transaction {
 -- | utility function for getting a more useful representation of accesslistentries
 -- duplicates only matter for gas computation
 txAccessMap :: Transaction -> Map Addr [W256]
-txAccessMap tx = ((Map.fromListWith (++)) . makeTups) $ txAccessList tx
-  where makeTups = map (\ale -> (accessAddress ale, accessStorageKeys ale))
+txAccessMap tx = ((Map.fromListWith (++)) . makeTups) tx.txAccessList
+  where makeTups = map (\ale -> (ale.accessAddress , ale.accessStorageKeys ))
 
 ecrec :: W256 -> W256 -> W256 -> W256 -> Maybe Addr
 ecrec v r s e = num . word <$> EVM.Precompiled.execute 1 input 32
   where input = BS.concat (word256Bytes <$> [e, v, r, s])
 
 sender :: Int -> Transaction -> Maybe Addr
-sender chainId tx = ecrec v' (txR tx) (txS tx) hash
+sender chainId tx = ecrec v' tx.txR  tx.txS hash
   where hash = keccak' (signingData chainId tx)
-        v    = txV tx
+        v    = tx.txV
         v'   = if v == 27 || v == 28 then v
                else 27 + v
 
 signingData :: Int -> Transaction -> ByteString
 signingData chainId tx =
-  case txType tx of
+  case tx.txType of
     LegacyTransaction -> if v == (chainId * 2 + 35) || v == (chainId * 2 + 36)
       then eip155Data
       else normalData
     AccessListTransaction -> eip2930Data
     EIP1559Transaction -> eip1559Data
-  where v          = fromIntegral (txV tx)
-        to'        = case txToAddr tx of
+  where v          = fromIntegral tx.txV
+        to'        = case tx.txToAddr of
           Just a  -> BS $ word160Bytes a
           Nothing -> BS mempty
-        maxFee = fromJust $ txMaxFeePerGas tx
-        maxPrio = fromJust $ txMaxPriorityFeeGas tx
-        gasPrice = fromJust $ txGasPrice tx
-        accessList = txAccessList tx
+        maxFee = fromJust tx.txMaxFeePerGas
+        maxPrio = fromJust tx.txMaxPriorityFeeGas
+        gasPrice = fromJust tx.txGasPrice
+        accessList = tx.txAccessList
         rlpAccessList = EVM.RLP.List $ map (\accessEntry ->
-          EVM.RLP.List [BS $ word160Bytes (accessAddress accessEntry),
-                        EVM.RLP.List $ map rlpWordFull $ accessStorageKeys accessEntry]
+          EVM.RLP.List [BS $ word160Bytes accessEntry.accessAddress,
+                        EVM.RLP.List $ map rlpWordFull accessEntry.accessStorageKeys]
           ) accessList
-        normalData = rlpList [rlpWord256 (txNonce tx),
+        normalData = rlpList [rlpWord256 tx.txNonce,
                               rlpWord256 gasPrice,
-                              rlpWord256 (num $ txGasLimit tx),
+                              rlpWord256 (num tx.txGasLimit),
                               to',
-                              rlpWord256 (txValue tx),
-                              BS (txData tx)]
-        eip155Data = rlpList [rlpWord256 (txNonce tx),
+                              rlpWord256 tx.txValue,
+                              BS tx.txData]
+        eip155Data = rlpList [rlpWord256 tx.txNonce,
                               rlpWord256 gasPrice,
-                              rlpWord256 (num $ txGasLimit tx),
+                              rlpWord256 (num tx.txGasLimit),
                               to',
-                              rlpWord256 (txValue tx),
-                              BS (txData tx),
+                              rlpWord256 tx.txValue,
+                              BS tx.txData,
                               rlpWord256 (fromIntegral chainId),
                               rlpWord256 0x0,
                               rlpWord256 0x0]
         eip1559Data = cons 0x02 $ rlpList [
           rlpWord256 (fromIntegral chainId),
-          rlpWord256 (txNonce tx),
+          rlpWord256 tx.txNonce,
           rlpWord256 maxPrio,
           rlpWord256 maxFee,
-          rlpWord256 (num $ txGasLimit tx),
+          rlpWord256 (num tx.txGasLimit),
           to',
-          rlpWord256 (txValue tx),
-          BS (txData tx),
+          rlpWord256 tx.txValue,
+          BS tx.txData,
           rlpAccessList]
 
         eip2930Data = cons 0x01 $ rlpList [
           rlpWord256 (fromIntegral chainId),
-          rlpWord256 (txNonce tx),
+          rlpWord256 tx.txNonce,
           rlpWord256 gasPrice,
-          rlpWord256 (num $ txGasLimit tx),
+          rlpWord256 (num tx.txGasLimit),
           to',
-          rlpWord256 (txValue tx),
-          BS (txData tx),
+          rlpWord256 tx.txValue,
+          BS tx.txData,
           rlpAccessList]
 
 accessListPrice :: FeeSchedule Word64 -> [AccessListEntry] -> Word64
 accessListPrice fs al =
     sum (map
       (\ale ->
-        g_access_list_address fs +
-        (g_access_list_storage_key fs * (fromIntegral . length) (accessStorageKeys ale)))
+        fs.g_access_list_address  +
+        (fs.g_access_list_storage_key  * (fromIntegral . length) ale.accessStorageKeys))
         al)
 
 txGasCost :: FeeSchedule Word64 -> Transaction -> Word64
 txGasCost fs tx =
-  let calldata     = txData tx
+  let calldata     = tx.txData
       zeroBytes    = BS.count 0 calldata
       nonZeroBytes = BS.length calldata - zeroBytes
-      baseCost     = g_transaction fs
-        + (if isNothing (txToAddr tx) then g_txcreate fs else 0)
-        + (accessListPrice fs $ txAccessList tx)
-      zeroCost     = g_txdatazero fs
-      nonZeroCost  = g_txdatanonzero fs
+      baseCost     = fs.g_transaction
+        + (if isNothing tx.txToAddr then fs.g_txcreate else 0)
+        + (accessListPrice fs tx.txAccessList )
+      zeroCost     = fs.g_txdatazero
+      nonZeroCost  = fs.g_txdatanonzero
   in baseCost + zeroCost * (fromIntegral zeroBytes) + nonZeroCost * (fromIntegral nonZeroBytes)
 
 instance FromJSON AccessListEntry where

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -646,7 +646,7 @@ word256Bytes :: W256 -> ByteString
 word256Bytes x = BS.pack [byteAt x (31 - i) | i <- [0..31]]
 
 word160Bytes :: Addr -> ByteString
-word160Bytes x = BS.pack [byteAt (addressWord160 x) (19 - i) | i <- [0..19]]
+word160Bytes x = BS.pack [byteAt x.addressWord160 (19 - i) | i <- [0..19]]
 
 newtype Nibble = Nibble Word8
   deriving ( Num, Integral, Real, Ord, Enum, Eq, Bounded, Generic)

--- a/test/BlockchainTests.hs
+++ b/test/BlockchainTests.hs
@@ -182,8 +182,8 @@ checkStateFail diff x vm (okMoney, okNonce, okData, okCode) = do
         , ("bad-storage", not okData  || okMoney || okNonce || okCode)
         , ("bad-code",    not okCode  || okMoney || okNonce || okData)
         ])
-    check = checkContracts x
-    expected = testExpectation x
+    check = x.checkContracts
+    expected = x.testExpectation
     actual = Map.map (,mempty) $ view (EVM.env . EVM.contracts) vm -- . to (fmap (clearZeroStorage.clearOrigStorage))) vm
     printStorage = show -- TODO: fixme
 
@@ -199,7 +199,7 @@ checkStateFail diff x vm (okMoney, okNonce, okData, okCode) = do
 
 checkExpectation :: Bool -> Case -> EVM.VM -> IO (Maybe String)
 checkExpectation diff x vm = do
-  let expectation = testExpectation x
+  let expectation = x.testExpectation
       (okState, b2, b3, b4, b5) = checkExpectedContracts vm expectation
   if okState then
     pure Nothing
@@ -256,7 +256,7 @@ clearNonce (c, s) = (set nonce 0 c, s)
 clearCode :: (EVM.Contract, Storage) -> (EVM.Contract, Storage)
 clearCode (c, s) = (set contractcode (EVM.RuntimeCode (EVM.ConcreteRuntimeCode "")) c, s)
 
-newtype ContractWithStorage = ContractWithStorage { unContractWithStorage :: (EVM.Contract, Storage) }
+newtype ContractWithStorage = ContractWithStorage (EVM.Contract, Storage)
 
 instance FromJSON ContractWithStorage where
   parseJSON (JSON.Object v) = do
@@ -298,10 +298,11 @@ instance FromJSON Block where
 parseContracts ::
   Which -> JSON.Object -> JSON.Parser (Map Addr (EVM.Contract, Storage))
 parseContracts w v =
-  (Map.map unContractWithStorage) <$> (v .: which >>= parseJSON)
+  (Map.map unwrap) <$> (v .: which >>= parseJSON)
   where which = case w of
           Pre  -> "pre"
           Post -> "postState"
+        unwrap (ContractWithStorage x) = x
 
 parseBCSuite ::
   Lazy.ByteString -> Either String (Map String Case)
@@ -339,7 +340,7 @@ errorFatal _ = False
 fromBlockchainCase :: BlockchainCase -> Either BlockchainError Case
 fromBlockchainCase (BlockchainCase blocks preState postState network) =
   case (blocks, network) of
-    ([block], "London") -> case blockTxs block of
+    ([block], "London") -> case block.blockTxs of
       [tx] -> fromBlockchainCase' block tx preState postState
       []        -> Left NoTxs
       _         -> Left TooManyTxs
@@ -350,7 +351,7 @@ fromBlockchainCase' :: Block -> Transaction
                        -> Map Addr (EVM.Contract, Storage) -> Map Addr (EVM.Contract, Storage)
                        -> Either BlockchainError Case
 fromBlockchainCase' block tx preState postState =
-  let isCreate = isNothing (txToAddr tx) in
+  let isCreate = isNothing tx.txToAddr in
   case (sender 1 tx, checkTx tx block preState) of
       (Nothing, _) -> Left SignatureUnverified
       (_, Nothing) -> Left (if isCreate then FailedCreate else InvalidTx)
@@ -358,21 +359,21 @@ fromBlockchainCase' block tx preState postState =
         (EVM.VMOpts
          { vmoptContract      = EVM.initialContract theCode
          , vmoptCalldata      = (cd, [])
-         , vmoptValue         = Lit (txValue tx)
+         , vmoptValue         = Lit tx.txValue
          , vmoptAddress       = toAddr
          , vmoptCaller        = litAddr origin
          , vmoptStorageBase   = Concrete
          , vmoptOrigin        = origin
-         , vmoptGas           = txGasLimit tx - fromIntegral (txGasCost feeSchedule tx)
-         , vmoptBaseFee       = blockBaseFee block
-         , vmoptPriorityFee   = priorityFee tx (blockBaseFee block)
-         , vmoptGaslimit      = txGasLimit tx
-         , vmoptNumber        = blockNumber block
-         , vmoptTimestamp     = Lit $ blockTimestamp block
-         , vmoptCoinbase      = blockCoinbase block
-         , vmoptPrevRandao    = blockDifficulty block
+         , vmoptGas           = tx.txGasLimit  - fromIntegral (txGasCost feeSchedule tx)
+         , vmoptBaseFee       = block.blockBaseFee
+         , vmoptPriorityFee   = priorityFee tx block.blockBaseFee
+         , vmoptGaslimit      = tx.txGasLimit
+         , vmoptNumber        = block.blockNumber
+         , vmoptTimestamp     = Lit block.blockTimestamp
+         , vmoptCoinbase      = block.blockCoinbase
+         , vmoptPrevRandao    = block.blockDifficulty
          , vmoptMaxCodeSize   = 24576
-         , vmoptBlockGaslimit = blockGasLimit block
+         , vmoptBlockGaslimit = block.blockGasLimit
          , vmoptGasprice      = effectiveGasPrice
          , vmoptSchedule      = feeSchedule
          , vmoptChainId       = 1
@@ -383,38 +384,38 @@ fromBlockchainCase' block tx preState postState =
         checkState
         postState
           where
-            toAddr = fromMaybe (EVM.createAddress origin senderNonce) (txToAddr tx)
+            toAddr = fromMaybe (EVM.createAddress origin senderNonce) tx.txToAddr
             senderNonce = view (accountAt origin . nonce) (Map.map fst preState)
             feeSchedule = EVM.FeeSchedule.berlin
             toCode = Map.lookup toAddr preState
             theCode = if isCreate
-                      then EVM.InitCode (txData tx) mempty
+                      then EVM.InitCode tx.txData mempty
                       else maybe (EVM.RuntimeCode (EVM.ConcreteRuntimeCode "")) (view contractcode . fst) toCode
-            effectiveGasPrice = effectiveprice tx (blockBaseFee block)
+            effectiveGasPrice = effectiveprice tx block.blockBaseFee
             cd = if isCreate
                  then mempty
-                 else ConcreteBuf $ txData tx
+                 else ConcreteBuf tx.txData
 
 effectiveprice :: Transaction -> W256 -> W256
 effectiveprice tx baseFee = priorityFee tx baseFee + baseFee
 
 priorityFee :: Transaction -> W256 -> W256
 priorityFee tx baseFee = let
-    (txPrioMax, txMaxFee) = case txType tx of
+    (txPrioMax, txMaxFee) = case tx.txType of
                EIP1559Transaction ->
-                 let maxPrio = fromJust $ txMaxPriorityFeeGas tx
-                     maxFee = fromJust $ txMaxFeePerGas tx
+                 let maxPrio = fromJust tx.txMaxPriorityFeeGas
+                     maxFee = fromJust tx.txMaxFeePerGas
                  in (maxPrio, maxFee)
                _ ->
-                 let gasPrice = fromJust $ txGasPrice tx
+                 let gasPrice = fromJust tx.txGasPrice
                  in (gasPrice, gasPrice)
   in min txPrioMax (txMaxFee - baseFee)
 
 maxBaseFee :: Transaction -> W256
 maxBaseFee tx =
-  case txType tx of
-     EIP1559Transaction -> fromJust $ txMaxFeePerGas tx
-     _ -> fromJust $ txGasPrice tx
+  case tx.txType of
+     EIP1559Transaction -> fromJust tx.txMaxFeePerGas
+     _ -> fromJust tx.txGasPrice
 
 validateTx :: Transaction -> Block -> Map Addr (EVM.Contract, Storage) -> Maybe ()
 validateTx tx block cs = do
@@ -422,9 +423,9 @@ validateTx tx block cs = do
   origin        <- sender 1 tx
   originBalance <- (view balance) <$> view (at origin) cs'
   originNonce   <- (view nonce)   <$> view (at origin) cs'
-  let gasDeposit = (effectiveprice tx (blockBaseFee block)) * (num $ txGasLimit tx)
-  if gasDeposit + (txValue tx) <= originBalance
-    && txNonce tx == originNonce && blockBaseFee block <= maxBaseFee tx
+  let gasDeposit = (effectiveprice tx block.blockBaseFee) * (num tx.txGasLimit)
+  if gasDeposit + tx.txValue <= originBalance
+    && tx.txNonce == originNonce && block.blockBaseFee <= maxBaseFee tx
   then Just ()
   else Nothing
 
@@ -432,9 +433,9 @@ checkTx :: Transaction -> Block -> Map Addr (EVM.Contract, Storage) -> Maybe (Ma
 checkTx tx block prestate = do
   origin <- sender 1 tx
   validateTx tx block prestate
-  let isCreate   = isNothing (txToAddr tx)
+  let isCreate   = isNothing tx.txToAddr
       senderNonce = view (accountAt origin . nonce) (Map.map fst prestate)
-      toAddr      = fromMaybe (EVM.createAddress origin senderNonce) (txToAddr tx)
+      toAddr      = fromMaybe (EVM.createAddress origin senderNonce) tx.txToAddr
       prevCode    = view (accountAt toAddr . contractcode) (Map.map fst prestate)
       prevNonce   = view (accountAt toAddr . nonce) (Map.map fst prestate)
   if isCreate && ((case prevCode of {EVM.RuntimeCode (EVM.ConcreteRuntimeCode b) -> not (BS.null b); _ -> True}) || (prevNonce /= 0))
@@ -445,10 +446,10 @@ checkTx tx block prestate = do
 vmForCase :: Case -> EVM.VM
 vmForCase x =
   let
-    a = checkContracts x
+    a = x.checkContracts
     cs = Map.map fst a
     st = Map.mapKeys num $ Map.map snd a
-    vm = EVM.makeVm (testVmOpts x)
+    vm = EVM.makeVm x.testVmOpts
       & set (EVM.env . EVM.contracts) cs
       & set (EVM.env . EVM.storage) (ConcreteStore st)
       & set (EVM.env . EVM.origStorage) st

--- a/test/test.hs
+++ b/test/test.hs
@@ -2070,7 +2070,7 @@ tests = testGroup "hevm"
             filteredBSym = symbolicMem [ replaceAll "" $ x *=~[re|^//|] | x <- onlyAfter [re|^// step:|] unfiltered, not $ x =~ [re|^$|] ]
           start <- getCurrentTime
           putStrLn $ "Checking file: " <> f
-          when (debug myVeriOpts) $ do
+          when myVeriOpts.debug $ do
             putStrLn "-------------Original Below-----------------"
             mapM_ putStrLn unfiltered
             putStrLn "------------- Filtered A + Symb below-----------------"
@@ -2122,7 +2122,7 @@ runSimpleVM :: ByteString -> ByteString -> Maybe ByteString
 runSimpleVM x ins = case loadVM x of
                       Nothing -> Nothing
                       Just vm -> let calldata' = (ConcreteBuf ins)
-                       in case runState (assign (state.calldata) calldata' >> exec) vm of
+                       in case runState (assign (state . calldata) calldata' >> exec) vm of
                             (VMSuccess (ConcreteBuf bs), _) -> Just bs
                             _ -> Nothing
 


### PR DESCRIPTION
## Description
`OverloadedRecordDot` is available from 9.2 and allows for nice records access without lens. I think the next step would be to move to something more modern for lens such as `generic-lens` or `optics-core`. We can then drop the underscores from records and access them through the dot syntax and reach for lens for more complex cases.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
