### PR TITLE
cli: symbolic: correct status code when cex are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- `hevm symbolic` exits with status code `1` if counterexamples or timeouts are found
+
 ### Added
 
 - New cheatcode `prank(address)` that sets `msg.sender` to the specified address for the next call.

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -396,6 +396,7 @@ assert cmd = do
                    , ""
                    ] <> fmap (formatExpr) (getTimeouts cexs)
           T.putStrLn $ T.unlines (counterexamples <> unknowns)
+          exitFailure
       when cmd.showTree $ do
         putStrLn "=== Expression ===\n"
         T.putStrLn $ formatExpr expr


### PR DESCRIPTION
## Description

v small bug where we weren't exiting with the correct status code if cexs were found during symbolic execution

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
