### PR TITLE
Fix showing source line number in debugger

### DIFF
--- a/src/EVM/TTY.hs
+++ b/src/EVM/TTY.hs
@@ -1000,7 +1000,7 @@ drawSolidityPane ui =
           in vBox
             [ hBorderWithLabel $
                 txt (fromMaybe "<unknown>" fileName)
-                  <+> str (":" ++ show lineNo)
+                  <+> str (":" ++ (maybe "?" show lineNo))
 
                   -- Show the AST node type if present
                   <+> txt (" (" <> fromMaybe "?"


### PR DESCRIPTION
## Description
Currently, the debugger shows the line number as `Just <number>`. Show plain number and `?` if it is `Nothing`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
