### PR TITLE
Implement debug() cheat code

### DIFF
--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -235,6 +235,9 @@ oracle solvers info q = do
            Nothing ->
              error ("oracle error: " ++ show q)
 
+    EVM.PleaseDebugMe _vm continue ->
+      pure continue
+
 type Fetcher = EVM.Query -> IO (EVM ())
 
 -- | Checks which branches are satisfiable, checking the pathconditions for consistency

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -277,6 +277,8 @@ showTrace dapp vm trace =
           --"make unique value" <> pos
         PleaseDoFFI cmd _ ->
           "execute ffi " <> pack (show cmd) <> pos
+        PleaseDebugMe _vm _ ->
+          "debug " <> pos
 
     ErrorTrace e ->
       case e of


### PR DESCRIPTION
## Description
This cheat code provides a way to stop the execution and hand over the current vm state for debugging. An alternative name to consider - `breakpoint()`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
