### PR TITLE
Add constraints asserting that reads beyond buffer size are zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `hevm symbolic` exits with status code `1` if counterexamples or timeouts are found
+- Calldata reads beyond calldata size are provably equal to zero.
 
 ### Added
 

--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -47,7 +47,7 @@ mkbench c name iters counts = localOption WallTime $ env c (bgroup name . bmarks
 
 main :: IO ()
 main = defaultMain
-  [ mkbench erc20 "erc20" Nothing [1, 2, 4, 8, 16]
+  [ mkbench erc20 "erc20" Nothing [1]
   , mkbench (pure vat) "vat" Nothing [4]
   , mkbench (pure deposit) "deposit" (Just 32) [4]
   , mkbench (pure uniV2Pair) "uniV2" (Just 10) [4]

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -443,7 +443,7 @@ concPrefix e = error $ "Internal error: cannot compute a concrete prefix length 
 -- abstract buffer, it is the largest write that is made on a concrete
 -- location. Parameterized by an environment for buffer variables.
 minLength :: Map.Map Int (Expr Buf) -> Expr Buf -> Maybe Integer
-minLength senv = go 0
+minLength bufEnv = go 0
   where
     go :: W256 -> Expr Buf -> Maybe Integer
     -- base cases
@@ -458,7 +458,7 @@ minLength senv = go 0
     go l (WriteByte _ _ b) = go l b
     go l (CopySlice _ _ _ _ b) = go l b
     go l (GVar (BufVar a)) = do
-      b <- Map.lookup a senv
+      b <- Map.lookup a bufEnv
       go l b
 
 word256At

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -41,7 +41,6 @@ import EVM.CSE
 import EVM.Keccak
 import EVM.Expr hiding (copySlice, writeWord, op1, op2, op3, drop)
 
-
 -- ** Encoding ** ----------------------------------------------------------------------------------
 -- variable names in SMT that we want to get values for
 data CexVars = CexVars
@@ -243,7 +242,7 @@ assertReads props benv senv = concat $ fmap assertRead allReads
   where
     assertRead :: (Expr EWord, Expr EWord, Expr Buf) -> [Prop]
     assertRead (idx, Lit 32, buf) = [POr (PEq (ReadWord idx buf) (Lit 0)) (PNeg (PGEq idx (bufLength buf)))]
-    assertRead (idx, Lit sz, buf) = fmap (\s -> POr (PEq (ReadByte idx buf) (LitByte (num s))) (PNeg (PGEq idx (bufLength buf)))) [0..sz-1]
+    assertRead (idx, Lit sz, buf) = fmap (\s -> POr (PEq (ReadByte idx buf) (LitByte (num s))) (PNeg (PGEq idx (bufLength buf)))) [(0::Int)..num sz-1]
     assertRead (_, _, _) = [] -- cannot generate assertions for accesses of symbolic size
 
     allReads = filter keepRead $ nubOrd $ findBufferAccess props <> findBufferAccess (Map.elems benv) <> findBufferAccess (Map.elems senv)

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -243,7 +243,7 @@ assertReads props benv senv = concat $ fmap assertRead allReads
     assertRead :: (Expr EWord, Expr EWord, Expr Buf) -> [Prop]
     assertRead (idx, Lit 32, buf) = [PImpl (PGEq idx (bufLength buf)) (PEq (ReadWord idx buf) (Lit 0))]
     assertRead (idx, Lit sz, buf) = fmap (\s -> PImpl (PGEq idx (bufLength buf)) (PEq (ReadByte idx buf) (LitByte (num s)))) [(0::Int)..num sz-1]
-    assertRead (_, _, _) = [] -- cannot generate assertions for accesses of symbolic size
+    assertRead (_, _, _) = error "Cannot generate assertions for accesses of symbolic size"
 
     allReads = filter keepRead $ nubOrd $ findBufferAccess props <> findBufferAccess (Map.elems benv) <> findBufferAccess (Map.elems senv)
 

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -238,6 +238,7 @@ mapProp f = \case
   PNeg a -> PNeg (mapProp f a)
   PAnd a b -> PAnd (mapProp f a) (mapProp f b)
   POr a b -> POr (mapProp f a) (mapProp f b)
+  PImpl a b -> PImpl (mapProp f a) (mapProp f b)
 
 -- | Recursively applies a given function to every node in a given expr instance
 -- Recursion schemes do this & a lot more, but defining them over GADT's isn't worth the hassle

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -26,6 +26,7 @@ foldProp f acc p = acc <> (go p)
       PNeg a -> go a
       PAnd a b -> go a <> go b
       POr a b -> go a <> go b
+      PImpl a b -> go a <> go b
 
 -- | Recursively folds a given function over a given expression
 -- Recursion schemes do this & a lot more, but defining them over GADT's isn't worth the hassle
@@ -642,6 +643,10 @@ mapPropM f = \case
     a' <- mapPropM f a
     b' <- mapPropM f b
     pure $ POr a' b'
+  PImpl a b -> do
+    a' <- mapPropM f a
+    b' <- mapPropM f b
+    pure $ PImpl a' b'
 
 
 -- | Generic operations over AST terms

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -642,3 +642,18 @@ mapPropM f = \case
     a' <- mapPropM f a
     b' <- mapPropM f b
     pure $ POr a' b'
+
+
+-- | Generic operations over AST terms
+class TraversableTerm a where
+  mapTerm  :: (forall b. Expr b -> Expr b) -> a -> a
+  foldTerm :: forall c. Monoid c => (forall b. Expr b -> c) -> c -> a -> c
+
+
+instance TraversableTerm (Expr a) where
+  mapTerm = mapExpr
+  foldTerm = foldExpr
+
+instance TraversableTerm Prop where
+  mapTerm = mapProp
+  foldTerm = foldProp

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -384,6 +384,7 @@ data Prop where
   PNeg :: Prop -> Prop
   PAnd :: Prop -> Prop -> Prop
   POr :: Prop -> Prop -> Prop
+  PImpl :: Prop -> Prop -> Prop
   PBool :: Bool -> Prop
 deriving instance (Show Prop)
 
@@ -430,6 +431,7 @@ instance Eq Prop where
   PNeg a == PNeg b = a == b
   PAnd a b == PAnd c d = a == c && b == d
   POr a b == POr c d = a == c && b == d
+  PImpl a b == PImpl c d = a == c && b == d
   _ == _ = False
 
 instance Ord Prop where
@@ -445,6 +447,7 @@ instance Ord Prop where
   PNeg a <= PNeg b = a <= b
   PAnd a b <= PAnd c d = a <= c && b <= d
   POr a b <= POr c d = a <= c && b <= d
+  PImpl a b <= PImpl c d = a <= c && b <= d
   _ <= _ = False
 
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -1623,23 +1623,6 @@ tests = testGroup "hevm"
           assertEqual "w==z for hash collision" w z
           putStrLn "expected counterexample found"
         ,
-        -- testCase "symbolic calldataload" $ do
-        --   Just c <- solcRuntime "A"
-        --     [i|
-        --     contract A {
-        --       function f(uint256 z) public pure {
-        --         uint y;
-        --         assembly {
-        --           y := calldataload(z)
-        --         }
-        --         assert(y == 3);
-        --       }
-        --     }
-        --     |]
-        --   p <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
-        --   print p
-        --   -- putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
-        -- ,
         testCase "calldata beyond calldatasize is 0 (symbolic calldata)" $ do
           Just c <- solcRuntime "A"
             [i|

--- a/test/test.hs
+++ b/test/test.hs
@@ -1674,9 +1674,8 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, p) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] debugVeriOpts
-          print p
-          -- putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
+          (res, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] debugVeriOpts
+          putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "keccak soundness" $ do
           Just c <- solcRuntime "C"

--- a/test/test.hs
+++ b/test/test.hs
@@ -1623,6 +1623,23 @@ tests = testGroup "hevm"
           assertEqual "w==z for hash collision" w z
           putStrLn "expected counterexample found"
         ,
+        -- testCase "symbolic calldataload" $ do
+        --   Just c <- solcRuntime "A"
+        --     [i|
+        --     contract A {
+        --       function f(uint256 z) public pure {
+        --         uint y;
+        --         assembly {
+        --           y := calldataload(z)
+        --         }
+        --         assert(y == 3);
+        --       }
+        --     }
+        --     |]
+        --   p <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] debugVeriOpts
+        --   print p
+        --   -- putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
+        -- ,
         testCase "calldata beyond calldatasize is 0 (symbolic calldata)" $ do
           Just c <- solcRuntime "A"
             [i|

--- a/test/test.hs
+++ b/test/test.hs
@@ -1636,7 +1636,7 @@ tests = testGroup "hevm"
         --       }
         --     }
         --     |]
-        --   p <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] debugVeriOpts
+        --   p <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
         --   print p
         --   -- putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         -- ,
@@ -1691,7 +1691,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] debugVeriOpts
+          (res, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just ("f(uint256)", [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         testCase "keccak soundness" $ do


### PR DESCRIPTION
## Description

Adds assertions stating that a read beyond the length of a buffer is zero. It works as follows: 

- Finds all indices `idx` that are read from any buffer `buf`. 
- Filters our indices that are provably within range.
- Adds assertions of the form `idx >= bufLength buf => buf[idx] = 0`.

## Checklist

- [X] tested locally
- [X] added automated tests
- [ ] updated the docs
- [X] updated the changelog
