### PR TITLE
Fix small discrepancies between CLI and `checkAssert`

### DIFF
--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -360,7 +360,7 @@ assert cmd = do
     (Nothing, Just sig') -> do
       method' <- functionAbi sig'
       let typs = snd <$> method'.inputs
-      pure $ symCalldata method'.methodSignature typs cmd.arg mempty
+      pure $ symCalldata method'.methodSignature typs cmd.arg (AbstractBuf "txdata")
     _ -> error "incompatible options: calldata and abi"
 
   preState <- symvmFromCommand cmd calldata'

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -177,7 +177,7 @@ abstractVM :: Maybe (Text, [AbiType]) -> [String] -> ByteString -> Maybe Precond
 abstractVM typesignature concreteArgs contractCode maybepre storagemodel = finalVm
   where
     (calldata', calldataProps) = case typesignature of
-                 Nothing -> (AbstractBuf "txdata", [])
+                 Nothing -> (AbstractBuf "txdata", [Expr.bufLength (AbstractBuf "txdata") .< (Lit (2 ^ (64 :: Integer)))])
                  Just (name, typs) -> symCalldata name typs concreteArgs (AbstractBuf "txdata")
     store = case storagemodel of
               SymbolicS -> AbstractStore


### PR DESCRIPTION
## Description

Fixes some tiny discrepancies between `assert` in cli.hs and `checkAssert`/`verifyContract` in `SymExec.hs` used by unit tests:

- Use abstract base buffer when signature is provided in `assert`.
- In `checkAssert`, add upper bound constraint `txdata <= 2^64` for calldata even if no signature is provided.

## Checklist

- [X] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
