### PR TITLE
release: sequence macos & linux release steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
           path: ./hevm-x86_64-macos
   linuxRelease:
     name: Create Release
+    needs: macosRelease
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Fixes a race condition in the release pipeline by enforcing an ordering between the linux and macos build steps

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
