### PR TITLE
Expr: restrict readByte and readWord simplification when there is ove…

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -261,7 +261,7 @@ readWord (Lit idx) b@(CopySlice (Lit srcOff) (Lit dstOff) (Lit size) src dst)
   | idx >= dstOff && idx + 32 <= dstOff + size = readWord (Lit $ srcOff + (idx - dstOff)) src
   -- the region we are trying to read is compeletely outside of the sliced reegion
   -- we check that there is no overflow and that addresses do not wrap around
-  | (idx >= dstOff + size || idx + 32 <= dstOff) && (dstOffset <= dstOffset + size) = readWord (Lit idx) dst
+  | (idx >= dstOff + size || idx + 32 <= dstOff) && (dstOff<= dstOff + size) = readWord (Lit idx) dst
   -- the region we are trying to read partially overlaps the sliced region
   | otherwise = readWordFromBytes (Lit idx) b
 readWord i b = readWordFromBytes i b


### PR DESCRIPTION
## Description

Suggested fix for #193. 

Sometimes, in `CopySlide srcOff dstOff size src dst`, it may be that `dstOff + size` overflows and wraps around. If we are reading some byte `x` from this buffer such that `0 <= x < dstOff + size` our simplifier will read it directly from the destination buffer thinking that the read is out of range. 

This shows up in fuzz tests and causes CI to fail.

This PR prevents that by disallowing simplifications when there is an overflow. However, it restricts simplification. For example, if we do `readByte (Lit x) (CopySlide srcOff (Lit dstOff) size src dst)` with `x < dstOff` and a potentially symbolic size, we no longer simplify this to `readByte (Lit x) dst`. 



## Checklist

- [X] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
