### PR TITLE
Add support for function pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - The `hevm` library can now be built on Windows systems.
+- Support for function pointers in ABI
 
 ## [0.50.3] - 2023-02-17
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -372,6 +372,20 @@ tests = testGroup "hevm"
                 _ -> error "AbiTuple expected"
           let hevmEncoded = encodeAbiValue (AbiTuple $ Vector.fromList [x',y'])
           assertEqual "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmEncoded)
+
+    -- we need a separate test for this because the type of a function is "function() external" in solidity but just "function" in the abi:
+    , testProperty "abi encoding vs. solidity (function pointer)" $ withMaxSuccess 20 $ forAll (genAbiValue AbiFunctionType) $
+      \y -> ioProperty $ do
+          Just encoded <- runFunction [i|
+              function foo(function() external a) public pure returns (bytes memory x) {
+                x = abi.encode(a);
+              }
+            |] (abiMethod "foo(function)" (AbiTuple (Vector.singleton y)))
+          let solidityEncoded = case decodeAbiValue (AbiTupleType $ Vector.fromList [AbiBytesDynamicType]) (BS.fromStrict encoded) of
+                AbiTuple (Vector.toList -> [e]) -> e
+                _ -> error "AbiTuple expected"
+          let hevmEncoded = encodeAbiValue (AbiTuple $ Vector.fromList [y])
+          assertEqual "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmEncoded)
     ]
 
   , testGroup "Precompiled contracts"


### PR DESCRIPTION
## Description
This PR adds support for function pointers in the ABI. Function pointers are represented with a 24-byte bytestring, and act very similarly to `AbiBytes 24`.

## Checklist

- [X] tested locally
- [X] added automated tests
- [ ] updated the docs (nothing to add)
- [X] updated the changelog
