### PR TITLE
cli: equivalence: pretty print cexs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `--solvers` cli option is now respected (previously we always used Z3)
 - The `equivalence` command now fails with the correct status code when counterexamples are found
 
+### Changed
+
+- The `equivalence` command now pretty prints discovered counterexamples
+
 ### Added
 
 - The `hevm` library can now be built on Windows systems.

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -315,7 +315,7 @@ equivalence cmd = do
       False -> do
         putStrLn "No discrepancies found"
         when (any isTimeout res) $ do
-          putStrLn "But timeout(s) occurred:"
+          putStrLn "But timeout(s) occurred"
           exitFailure
       True -> do
         let cexs = mapMaybe getCex res

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -15,7 +15,6 @@ import qualified EVM.Stepper
 import EVM.SymExec
 import EVM.Debug
 import qualified EVM.Expr as Expr
-import EVM.SMT
 import EVM.Solvers
 import qualified EVM.TTY as TTY
 import EVM.Solidity
@@ -36,7 +35,7 @@ import Control.Lens hiding (pre, passing)
 import Control.Monad              (void, when, forM_, unless)
 import Control.Monad.State.Strict (execStateT, liftIO)
 import Data.ByteString            (ByteString)
-import Data.List                  (intercalate, isSuffixOf)
+import Data.List                  (intercalate, isSuffixOf, intersperse)
 import Data.Text                  (unpack, pack)
 import Data.Maybe                 (fromMaybe, mapMaybe)
 import Data.Version               (showVersion)
@@ -316,10 +315,14 @@ equivalence cmd = do
       False -> do
         putStrLn "No discrepancies found"
         when (any isTimeout res) $ do
-          putStrLn "But timeout(s) occurred"
+          putStrLn "But timeout(s) occurred:"
           exitFailure
       True -> do
-        putStrLn $ "Not equivalent. Counterexample(s):" <> show (filter (not . isQed) res)
+        let cexs = mapMaybe getCex res
+        T.putStrLn . T.unlines $
+          [ "Not equivalent. The following inputs result in differing behaviours:"
+          , "" , "-----", ""
+          ] <> (intersperse (T.unlines [ "", "-----" ]) $ fmap (formatCex (AbstractBuf "txdata")) cexs)
         exitFailure
 
 getSolver :: Command Options.Unwrapped -> IO Solver
@@ -394,21 +397,23 @@ assert cmd = do
       (expr, res) <- verify solvers opts preState (Just $ checkAssertions errCodes)
       case res of
         [Qed _] -> putStrLn "\nQED: No reachable property violations discovered\n"
-        cexs -> do
-          let counterexamples
-                | null (getCexs cexs) = []
+        _ -> do
+          let cexs = snd <$> mapMaybe getCex res
+              timeouts = mapMaybe getTimeout res
+              counterexamples
+                | null cexs = []
                 | otherwise =
                    [ ""
                    , "Discovered the following counterexamples:"
                    , ""
-                   ] <> fmap (formatCex (fst calldata')) (getCexs cexs)
+                   ] <> fmap (formatCex (fst calldata')) cexs
               unknowns
-                | null (getTimeouts cexs) = []
+                | null timeouts = []
                 | otherwise =
                    [ ""
                    , "Could not determine reachability of the following end states:"
                    , ""
-                   ] <> fmap (formatExpr) (getTimeouts cexs)
+                   ] <> fmap (formatExpr) timeouts
           T.putStrLn $ T.unlines (counterexamples <> unknowns)
           exitFailure
       when cmd.showTree $ do
@@ -425,17 +430,13 @@ assert cmd = do
         ms <- produceModels solvers expr
         forM_ ms (showModel (fst calldata'))
 
-getCexs :: [VerifyResult] -> [SMTCex]
-getCexs = mapMaybe go
-  where
-    go (Cex cex) = Just $ snd cex
-    go _ = Nothing
+getCex :: ProofResult a b c -> Maybe b
+getCex (Cex c) = Just c
+getCex _ = Nothing
 
-getTimeouts :: [VerifyResult] -> [Expr End]
-getTimeouts = mapMaybe go
-  where
-    go (Timeout leaf) = Just leaf
-    go _ = Nothing
+getTimeout :: ProofResult a b c -> Maybe c
+getTimeout (Timeout c) = Just c
+getTimeout _ = Nothing
 
 dappCoverage :: UnitTestOptions -> Mode -> String -> IO ()
 dappCoverage opts _ solcFile =


### PR DESCRIPTION
## Description

Pretty prints the discovered counterexamples when equivalence checking. There is still room for improvement here, ideally we would also display the actual differing results, not just the inputs that produce a difference.

Example output:

```
Found 36 total pairs of endstates
Asking the SMT solver for 19 pairs
Reuse of previous queries was Useful in 0 cases
Not equivalent. The following inputs result in differing behaviours:

-----

Calldata:
  0x4dad5d1e8d40fffffe0000000000000011c19e55f9045ff8809cc098d644a0100006003885000000020000000000000011585dbcffffbf80

Transaction Context:
  CallValue: 0x0



-----

Calldata:
  0x4dad5d1e24740024800113afd83c000000000000000000000011a68df5da4707fe5fbe7e92160024800bb0980b85000000000000000020

Transaction Context:
  CallValue: 0x0



-----

Calldata:
  0x4dad5d1ed200000000497b5c01000000000000000ffffffffffffffffffc000000000080d1ffc0004000000000800000200000000000000000000000000400000000007f

Transaction Context:
  CallValue: 0x0
  ```

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
