### PR TITLE
Bounds checking without overflows in the simplifier

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -258,7 +258,7 @@ readWord idx b@(WriteWord idx' val buf)
     _ -> readWordFromBytes idx b
 readWord (Lit idx) b@(CopySlice (Lit srcOff) (Lit dstOff) (Lit size) src dst)
   -- the region we are trying to read is enclosed in the sliced region
-  | (idx - dstOff) + 32 <= size = readWord (Lit $ srcOff + (idx - dstOff)) src
+  | (idx - dstOff) <= size && 32 <= size - (idx - dstOff) = readWord (Lit $ srcOff + (idx - dstOff)) src
   -- the region we are trying to read is compeletely outside of the sliced region
   | (idx - dstOff) >= size && (idx - dstOff) <= (maxBound :: W256) - 31 = readWord (Lit idx) dst
   -- the region we are trying to read partially overlaps the sliced region

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -545,7 +545,7 @@ stripWrites off size = \case
   CopySlice (Lit srcOff) (Lit dstOff) (Lit size') src dst
     -> if dstOff - off >= size && dstOff - off <= (maxBound :: W256) - size' - 1
        then stripWrites off size dst
-       else CopySlice (Lit srcOff) (Lit dstOff) (Lit size)
+       else CopySlice (Lit srcOff) (Lit dstOff) (Lit size')
                       (stripWrites srcOff size' src)
                       (stripWrites off size dst)
   WriteByte i v prev -> WriteByte i v (stripWrites off size prev)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -258,7 +258,7 @@ readWord idx b@(WriteWord idx' val buf)
     _ -> readWordFromBytes idx b
 readWord (Lit idx) b@(CopySlice (Lit srcOff) (Lit dstOff) (Lit size) src dst)
   -- the region we are trying to read is enclosed in the sliced region
-  | (idx - dstOff) <= size && 32 <= size - (idx - dstOff) = readWord (Lit $ srcOff + (idx - dstOff)) src
+  | (idx - dstOff) < size && 32 <= size - (idx - dstOff) = readWord (Lit $ srcOff + (idx - dstOff)) src
   -- the region we are trying to read is compeletely outside of the sliced region
   | (idx - dstOff) >= size && (idx - dstOff) <= (maxBound :: W256) - 31 = readWord (Lit idx) dst
   -- the region we are trying to read partially overlaps the sliced region

--- a/test/test.hs
+++ b/test/test.hs
@@ -114,6 +114,12 @@ tests = testGroup "hevm"
         -- there won't be query now as accessStorage uses fetch cache
         assertBool (show vm4._result) (isNothing vm4._result)
     ]
+  -- , testGroup "SimplifierUnitTests"
+  --   [ testCase "copySlice-overflow" $ do
+  --       let e = 
+  --   , testCase "writeWord-overflow" $ do
+        
+  --   ]
   -- These tests fuzz the simplifier by generating a random expression,
   -- applying some simplification rules, and then using the smt encoding to
   -- check that the simplified version is semantically equivalent to the

--- a/test/test.hs
+++ b/test/test.hs
@@ -114,12 +114,17 @@ tests = testGroup "hevm"
         -- there won't be query now as accessStorage uses fetch cache
         assertBool (show vm4._result) (isNothing vm4._result)
     ]
-  -- , testGroup "SimplifierUnitTests"
-  --   [ testCase "copySlice-overflow" $ do
-  --       let e = 
-  --   , testCase "writeWord-overflow" $ do
-        
-  --   ]
+  , testGroup "SimplifierUnitTests"
+    -- common overflow cases that the simplifier was getting wrong
+    [ testCase "writeWord-overflow" $ do
+        let e = ReadByte (Lit 0x0) (WriteWord (Lit 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd) (Lit 0x0) (ConcreteBuf "\255\255\255\255"))
+        b <- checkEquiv e (Expr.simplify e)
+        assertBool "Simplifier failed" b
+    , testCase "CopySlice-overflow" $ do
+        let e = ReadWord (Lit 0x0) (CopySlice (Lit 0x0) (Lit 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc) (Lit 0x6) (ConcreteBuf "\255\255\255\255\255\255") (ConcreteBuf ""))
+        b <- checkEquiv e (Expr.simplify e)
+        assertBool "Simplifier failed" b
+    ]
   -- These tests fuzz the simplifier by generating a random expression,
   -- applying some simplification rules, and then using the smt encoding to
   -- check that the simplified version is semantically equivalent to the


### PR DESCRIPTION
## Description
To simplify a read that happens after some write(s) on a buffers, we check wether the interval `[ir, ir + szr)` of the read is included, overlaps, or is disjoint from `[iw, iw+ szw)`. However, for large numbers `ir + szr` and `iw+szw` might overflow and wrap around, since the arithmetic is modulo 2^256. This makes bounds checking tricky, since doing it in the straightforward way is incorrect. For example saying that the intervals are disjoint if `ir +szr <= iw || iw + szw <= ir` is incorrect. This was a bug in the simplifier that caused failures in fuzing (#207 and #193). Previous fix for #193, disallowed simplification if there was an overflow (#200) but only for some cases. 

This PR rewrites the bounds checking so no overflow can happen when we check the bounds. This works even if there is wraparound in addresses, so we do not need to check for overflow.

It works as follows:

We want to check if the interval A 
```
0    ir              ir+szr      
|----|****************|--------
 ```
 is included, overlaps, or is disjoint from interval B
```
0    iw             iw+szw      
|----|****************|--------

```
with `ir+szr` and `iw+szw` potentially overflowing. 


First, shift both intervals left by `iw`. Now, interval B is 

```
0           szw           2^256
|************|-------------|
```

and interval A 

```
0    i          i+szr      
|----|************|--------
```

where `i = ir - iw`. 

The new intervals overlap if and only if the initial intervals overlap.

Now
a) if `i < szw` and `szr <= szw - i`, then interval A is included in B. The second condition can be omitted if `szr = 1` (i.e, we are reading a byte). 
b) if `i >=  szw` and `i <= 2^256 - szr`, the two intervals are disjoint. If the second condition guarantees that interval A has not wrapped around, overlapping with B. It can be omitted if `szr = 1` (i.e, we are reading a byte).
c) otherwise, the two intervals partially overlap. 
 
 Note that no overflow or underflow can happen in any of the expressions used in the bounds checking conditions. These checks will work even if there is wraparound in the bounds of the initial intervals.

## Checklist

- [X] tested locally
- [X] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
