### PR TITLE
Optimize W256 serialization

### DIFF
--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -926,10 +926,6 @@ formatTestLog events (LogEntry _ args (topic:_)) =
                   _ -> Nothing
               _ -> Just "<symbolic decimal>"
 
-
-word32Bytes :: Word32 -> ByteString
-word32Bytes x = BS.pack [byteAt x (3 - i) | i <- [0..3]]
-
 abiCall :: TestVMParams -> Either (Text, AbiValue) ByteString -> EVM ()
 abiCall params args =
   let cd = case args of


### PR DESCRIPTION
## Description
`word256Bytes` and `word160Bytes` changes gave minor improvements but one byte push optimization cut the memory usage by a big margin:

Before:
```
All 18425 tests passed (134.11s)
 607,519,981,048 bytes allocated in the heap
  73,796,642,616 bytes copied during GC
   9,281,674,128 bytes maximum residency (60 sample(s))
     289,158,256 bytes maximum slop
           24549 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     131832 colls,     0 par   13.509s  13.535s     0.0001s    0.0455s
  Gen  1        60 colls,     0 par   15.663s  15.763s     0.2627s    3.3043s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time  155.339s  (155.323s elapsed)
  GC      time   29.172s  ( 29.298s elapsed)
  RP      time    0.000s  (  0.000s elapsed)
  PROF    time    0.000s  (  0.000s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time  184.511s  (184.621s elapsed)

  %GC     time       0.0%  (0.0% elapsed)

  Alloc rate    3,910,936,826 bytes per MUT second

  Productivity  84.2% of total user, 84.1% of total elapsed
```
After:
```
All 18425 tests passed (126.38s)                                                                                       
 598,828,149,224 bytes allocated in the heap                                                                           
  77,037,298,392 bytes copied during GC                                                                                
   7,436,878,040 bytes maximum residency (55 sample(s))                                                                
     149,774,760 bytes maximum slop                                                                                    
           19655 MiB total memory in use (0 MB lost due to fragmentation)                                              
                                                                                                                       
                                     Tot time (elapsed)  Avg pause  Max pause                                          
  Gen  0     128036 colls,     0 par   13.482s  13.508s     0.0001s    0.0479s                                         
  Gen  1        55 colls,     0 par   15.853s  15.854s     0.2882s    2.4922s                                          
                                                                                                                       
  INIT    time    0.000s  (  0.000s elapsed)                                                                           
  MUT     time  144.687s  (144.667s elapsed)                                                                           
  GC      time   29.334s  ( 29.362s elapsed)                                                                           
  RP      time    0.000s  (  0.000s elapsed)                                                                           
  PROF    time    0.000s  (  0.000s elapsed)                                                                           
  EXIT    time    0.000s  (  0.000s elapsed)                                                                           
  Total   time  174.022s  (174.030s elapsed)                                                                           
                                                                                                                       
  %GC     time       0.0%  (0.0% elapsed)                                                                              
                                                                                                                       
  Alloc rate    4,138,790,334 bytes per MUT second                                                                     
                                                                                                                       
  Productivity  83.1% of total user, 83.1% of total elapsed        
```

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
