### PR TITLE
Remove StrictData to improve performance

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1,7 +1,6 @@
 {-# Language ImplicitParams #-}
 {-# Language DataKinds #-}
 {-# Language GADTs #-}
-{-# Language StrictData #-}
 {-# Language TemplateHaskell #-}
 
 module EVM where
@@ -104,7 +103,7 @@ data VM = VM
   , _logs           :: [Expr Log]
   , _traces         :: Zipper.TreePos Zipper.Empty Trace
   , _cache          :: Cache
-  , _burned         :: Word64
+  , _burned         :: {-# UNPACK #-} !Word64
   , _iterations     :: Map CodeLocation Int
   , _constraints    :: [Prop]
   , _keccakEqs      :: [Prop]
@@ -248,14 +247,14 @@ data FrameState = FrameState
   { _contract     :: Addr
   , _codeContract :: Addr
   , _code         :: ContractCode
-  , _pc           :: Int
+  , _pc           :: {-# UNPACK #-} !Int
   , _stack        :: [Expr EWord]
   , _memory       :: Expr Buf
   , _memorySize   :: Word64
   , _calldata     :: Expr Buf
   , _callvalue    :: Expr EWord
   , _caller       :: Expr EWord
-  , _gas          :: Word64
+  , _gas          :: {-# UNPACK #-} !Word64
   , _returndata   :: Expr Buf
   , _static       :: Bool
   }

--- a/src/EVM/Concrete.hs
+++ b/src/EVM/Concrete.hs
@@ -1,5 +1,3 @@
-{-# Language StrictData #-}
-
 module EVM.Concrete where
 
 import Prelude hiding (Word)

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -1,6 +1,5 @@
 {-# Language DeriveAnyClass #-}
 {-# Language DataKinds #-}
-{-# Language StrictData #-}
 {-# Language QuasiQuotes #-}
 
 module EVM.Solidity
@@ -178,11 +177,11 @@ data JumpType = JumpInto | JumpFrom | JumpRegular
   deriving (Show, Eq, Ord, Generic)
 
 data SrcMap = SM {
-  srcMapOffset :: {-# UNPACK #-} Int,
-  srcMapLength :: {-# UNPACK #-} Int,
-  srcMapFile   :: {-# UNPACK #-} Int,
+  srcMapOffset :: {-# UNPACK #-} !Int,
+  srcMapLength :: {-# UNPACK #-} !Int,
+  srcMapFile   :: {-# UNPACK #-} !Int,
   srcMapJump   :: JumpType,
-  srcMapModifierDepth :: {-# UNPACK #-} Int
+  srcMapModifierDepth :: {-# UNPACK #-} !Int
 } deriving (Show, Eq, Ord, Generic)
 
 data SrcMapParseState

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -144,13 +144,13 @@ data Expr (a :: EType) where
 
   -- identifiers
 
-  Lit            :: W256 -> Expr EWord
+  Lit            :: {-# UNPACK #-} !W256 -> Expr EWord
   Var            :: Text -> Expr EWord
   GVar           :: GVar a -> Expr a
 
   -- bytes
 
-  LitByte        :: Word8      -> Expr Byte
+  LitByte        :: {-# UNPACK #-} !Word8 -> Expr Byte
   IndexWord      :: Expr EWord -> Expr EWord -> Expr Byte
   EqByte         :: Expr Byte  -> Expr Byte  -> Expr EWord
 


### PR DESCRIPTION
## Description
It looks like `StrictData` considerably worsens performance. Those few changes make the `ethereum-tests` suite run way faster and use less memory.

Before:
```
All 18425 tests passed (59.20s)
 339,633,148,432 bytes allocated in the heap
  50,851,677,224 bytes copied during GC
   5,848,354,664 bytes maximum residency (58 sample(s))
     228,278,424 bytes maximum slop
           16567 MiB total memory in use (0 MB lost due to fragmentation)

                                     Tot time (elapsed)  Avg pause  Max pause
  Gen  0     74371 colls,     0 par   11.506s  11.521s     0.0002s    0.0412s
  Gen  1        58 colls,     0 par   14.590s  14.591s     0.2516s    2.9466s

  INIT    time    0.000s  (  0.000s elapsed)
  MUT     time   62.712s  ( 62.701s elapsed)
  GC      time   26.096s  ( 26.112s elapsed)
  EXIT    time    0.000s  (  0.000s elapsed)
  Total   time   88.808s  ( 88.814s elapsed)

  %GC     time       0.0%  (0.0% elapsed)

  Alloc rate    5,415,776,764 bytes per MUT second

  Productivity  70.6% of total user, 70.6% of total elapsed
```

After:
```
All 18425 tests passed (44.06s)                                                                                                                                                                                                               
 309,213,114,032 bytes allocated in the heap                                                                                                                                                                                                  
  31,994,007,040 bytes copied during GC                                                                                                                                                                                                       
   3,762,108,336 bytes maximum residency (57 sample(s))                                                                                                                                                                                       
     185,952,336 bytes maximum slop                                                                                                                                                                                                           
            7117 MiB total memory in use (0 MB lost due to fragmentation)                                                                                                                                                                     
                                                                                                                                                                                                                                              
                                     Tot time (elapsed)  Avg pause  Max pause                                                                                                                                                                 
  Gen  0     67440 colls,     0 par    7.469s   7.481s     0.0001s    0.0420s                                                                                                                                                                 
  Gen  1        57 colls,     0 par    8.232s   8.233s     0.1444s    0.9039s                                                                                                                                                                 
                                                                                                                                                                                                                                              
  INIT    time    0.000s  (  0.000s elapsed)                                                                                                                                                                                                  
  MUT     time   58.143s  ( 58.134s elapsed)                                                                                                                                                                                                  
  GC      time   15.701s  ( 15.714s elapsed)                                                                                                                                                                                                  
  EXIT    time    0.000s  (  0.000s elapsed)                                                                                                                                                                                                  
  Total   time   73.844s  ( 73.849s elapsed)                                                                                                                                                                                                  
                                                                                                                                                                                                                                              
  %GC     time       0.0%  (0.0% elapsed)                                                                                                                                                                                                     
                                                                                                                                                                                                                                              
  Alloc rate    5,318,144,343 bytes per MUT second                                                                                                                                                                                            
                                                                                                                                                                                                                                              
  Productivity  78.7% of total user, 78.7% of total elapsed           
```

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
