### PR TITLE
nix: fix hls in nix-shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
         # --- shell ---
 
         devShell = with pkgs;
-          let libraryPath = "${lib.makeLibraryPath [ libff secp256k1 ]}";
+          let libraryPath = "${lib.makeLibraryPath [ libff secp256k1 gmp ]}";
           in haskellPackages.shellFor {
             packages = _: [ hevmUnwrapped ];
             buildInputs = [


### PR DESCRIPTION
## Description

hls was crashing for me locally because gmp wasn't present in the shell env...

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
