### PR TITLE
SMT Guided Counterexample Shrinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The `equivalence` command now pretty prints discovered counterexamples
+- Implemented a shrinking algorithm for counterexamples
 
 ### Added
 - A new differential fuzzing test harness that compares the concrete semantics, as well as parts of the symbolic semantics against the geth evm implementation

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -494,16 +494,16 @@ launchExec cmd = do
             let res = case msg of
                         ConcreteBuf bs -> bs
                         _ -> "<symbolic>"
-            print $ ByteStringS res
+            putStrLn $ "Revert: " <> (show $ ByteStringS res)
             exitWith (ExitFailure 2)
           Just (EVM.VMFailure err) -> do
-            print err
+            putStrLn $ "Error: " <> show err
             exitWith (ExitFailure 2)
           Just (EVM.VMSuccess buf) -> do
             let msg = case buf of
                   ConcreteBuf msg' -> msg'
                   _ -> "<symbolic>"
-            print $ ByteStringS msg
+            print $ "Return: " <> (show $ ByteStringS msg)
             case cmd.state of
               Nothing -> pure ()
               Just path ->

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -97,13 +97,7 @@ data SMTCex = SMTCex
 flattenBufs :: SMTCex -> Maybe SMTCex
 flattenBufs cex = do
   bs <- mapM collapse cex.buffers
-  pure $ SMTCex
-    { vars = cex.vars
-    , buffers = bs
-    , store = cex.store
-    , blockContext = cex.blockContext
-    , txContext = cex.txContext
-    }
+  pure $ cex { buffers = bs}
 
 -- | Attemps to collapse a compressed buffer representation down to a flattened one
 collapse :: BufModel -> Maybe BufModel
@@ -1012,7 +1006,7 @@ queryValue getVal w = do
     Right (ResSpecific (valParsed :| [])) ->
       case valParsed of
         (_, TermSpecConstant sc) -> pure $ parseW256 sc
-        _ -> error "Internal Error: cannot parse model for storage index"
+        _ -> error $ "Internal Error: cannot parse model for: " <> show w
     r -> parseErr r
 
 

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -179,7 +179,7 @@ getModel inst cexvars = do
                        (error $ "Internal Error: Could not find hint for buffer: " <> T.unpack name)
                        (Map.lookup name hints)
           shrinkBuf name hint
-        _ -> error "oops"
+        _ -> error "Internal Error: Received model from solver for non AbstractBuf"
 
     -- starting with some guess at the max useful size for a buffer, cap
     -- it's size to that value, and ask the solver to check satisfiability. If

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -12,7 +12,8 @@ import qualified EVM
 import EVM.Exec
 import qualified EVM.Fetch as Fetch
 import EVM.ABI
-import EVM.SMT
+import EVM.SMT (SMTCex(..), SMT2(..), assertProps, formatSMT2)
+import qualified EVM.SMT as SMT
 import EVM.Solvers
 import EVM.Traversals
 import qualified EVM.Expr as Expr
@@ -749,8 +750,11 @@ formatCex cd m@(SMTCex _ _ store blockContext txContext) = T.unlines $
 
 -- | Takes a buffer and a Cex and replaces all abstract values in the buf with concrete ones from the Cex
 subModel :: SMTCex -> Expr a -> Expr a
-subModel c expr = subBufs c.buffers . subVars c.vars . subStore c.store . subVars c.blockContext . subVars c.txContext $ expr
+subModel c expr = subBufs (fmap forceFlattened c.buffers) . subVars c.vars . subStore c.store . subVars c.blockContext . subVars c.txContext $ expr
   where
+    forceFlattened (SMT.Flat bs) = bs
+    forceFlattened b@(SMT.Comp _) = forceFlattened $ fromMaybe (error $ "Internal Error: cannot flatten buffer: " <> show b) (SMT.collapse b)
+
     subVars model b = Map.foldlWithKey subVar b model
     subVar :: Expr a -> Expr EWord -> W256 -> Expr a
     subVar b var val = mapExpr go b

--- a/test/test.hs
+++ b/test/test.hs
@@ -544,6 +544,18 @@ tests = testGroup "hevm"
         assertEqual "Division by 0 needs b=0" (getVar ctr "arg2") 0
         putStrLn "expected counterexample found"
      ,
+      testCase "unused-args-fail" $ do
+         Just c <- solcRuntime "C"
+             [i|
+             contract C {
+               function fun(uint256 a) public pure {
+                 assert(false);
+               }
+             }
+             |]
+         (_, [Cex _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s [0x1] c Nothing [] debugVeriOpts
+         putStrLn "expected counterexample found"
+      ,
      testCase "enum-conversion-fail" $ do
         Just c <- solcRuntime "MyContract"
             [i|


### PR DESCRIPTION
## Description

- removes assertions on buffer lengths derived from the max read index
- implements a sound shrinking routines for buffer models

Previous to this PR we inserted constraints for each buffer that stated that their length could not be larger than the maximum index read from that buffer. This approach was unsound as branch conditions could contain arbitrary restrictions on the length of a buffer without reading from it (via BufLength).

Here we remove these constraints and use the max read index as a starting point for a counterexample shrinking routine. If our initial query returns sat, we check if any of the returned buffer models are very large (we use 1kb as the cutoff), and if they are we run the initial query again, but restrict the length to the smaller of 1kb and the max read index. If the query remains sat, we return this model, if not we double the maximum size and try again.

This should hopefully give us small counterexamples for calldata in a sound manner.

closes https://github.com/ethereum/hevm/issues/211 and https://github.com/ethereum/hevm/issues/112

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
