### PR TITLE
Expr: fix sgt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `--solvers` cli option is now respected (previously we always used Z3)
 - The `equivalence` command now fails with the correct status code when counterexamples are found
 - The `equivalence` command now respects the given `--sig` argument
+- Correct symbolic execution for the `SGT` opcode
 
 ### Changed
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -137,7 +137,7 @@ slt = op2 SLT (\x y ->
   in if sx < sy then 1 else 0)
 
 sgt :: Expr EWord -> Expr EWord -> Expr EWord
-sgt = op2 SLT (\x y ->
+sgt = op2 SGT (\x y ->
   let sx, sy :: Int256
       sx = fromIntegral x
       sy = fromIntegral y
@@ -408,7 +408,7 @@ bufLength = bufLengthEnv mempty False
 bufLengthEnv :: Map.Map Int (Expr Buf) -> Bool -> Expr Buf -> Expr EWord
 bufLengthEnv env useEnv buf = go (Lit 0) buf
   where
-    go :: Expr EWord -> Expr Buf -> Expr EWord  
+    go :: Expr EWord -> Expr Buf -> Expr EWord
     go l (ConcreteBuf b) = EVM.Expr.max l (Lit (num . BS.length $ b))
     go l (AbstractBuf b) = Max l (BufLength (AbstractBuf b))
     go l (WriteWord idx _ b) = go (EVM.Expr.max l (add idx (Lit 32))) b
@@ -794,7 +794,7 @@ simplify e = if (mapExpr go e == e)
 
     go (Max (Lit 0) a) = a
     go (Min (Lit 0) _) = Lit 0
-    
+
     go a = a
 
 

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -570,6 +570,9 @@ exprToSMT = \case
   SLT a b ->
     let cond = op2 "bvslt" a b in
     "(ite " <> cond `sp` one `sp` zero <> ")"
+  SGT a b ->
+    let cond = op2 "bvsgt" a b in
+    "(ite " <> cond `sp` one `sp` zero <> ")"
   GT a b ->
     let cond = op2 "bvugt" a b in
     "(ite " <> cond `sp` one `sp` zero <> ")"

--- a/test/test.hs
+++ b/test/test.hs
@@ -900,6 +900,19 @@ tests = testGroup "hevm"
         (_, [Qed _])  <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "sdiv works as expected"
       ,
+     testCase "signed-overflow-checks" $ do
+        Just c <- solcRuntime "C"
+            [i|
+            contract C {
+              function fun(uint160 a) external {
+                  int256 j = int256(uint256(a)) + 1;
+                  assert(false);
+              }
+            }
+            |]
+        (_, [Cex _])  <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint160)" [AbiUIntType 160])) [] defaultVeriOpts
+        putStrLn "expected cex discovered"
+      ,
      testCase "opcode-signextend-neg" $ do
         Just c <- solcRuntime "MyContract"
             [i|


### PR DESCRIPTION
## Description

Fixes the symbolic evaluation of the `SGT` opcode, which was previously evaluated as `SLT` due to a copy paste error :woman_facepalming:

Fixes https://github.com/ethereum/hevm/issues/223.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
