### PR TITLE
ci: no concurrent jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: "Build"
 on:
   pull_request:
   push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Description

Uses the [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) feature in github actions to cancel jobs for a previous commit if a new one is pushed to the same branch.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
