### PR TITLE
Change interpret to take vm arg instead of StateT

### DIFF
--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -34,7 +34,7 @@ import qualified EVM.UnitTest
 import GHC.Conc
 import Optics.Core hiding (pre, Empty)
 import Control.Monad              (void, when, forM_, unless)
-import Control.Monad.State.Strict (execStateT, liftIO)
+import Control.Monad.State.Strict (liftIO)
 import Data.ByteString            (ByteString)
 import Data.List                  (intercalate, isSuffixOf, intersperse)
 import Data.Text                  (unpack, pack)
@@ -491,7 +491,7 @@ launchExec cmd = do
   withSolvers Z3 0 Nothing $ \solvers -> do
     case optsMode cmd of
       Run -> do
-        vm' <- execStateT (EVM.Stepper.interpret (EVM.Fetch.oracle solvers rpcinfo) . void $ EVM.Stepper.execFully) vm
+        vm' <- EVM.Stepper.interpret (EVM.Fetch.oracle solvers rpcinfo) vm EVM.Stepper.runFully
         when cmd.trace $ T.hPutStr stderr (showTraceTree dapp vm')
         case vm'.result of
           Nothing ->

--- a/src/EVM/Dev.hs
+++ b/src/EVM/Dev.hs
@@ -402,7 +402,7 @@ initVm bs = vm
 
 -- | Builds the Expr for the given evm bytecode object
 buildExpr :: SolverGroup -> ByteString -> IO (Expr End)
-buildExpr solvers bs = evalStateT (interpret (Fetch.oracle solvers Nothing) Nothing Nothing runExpr) (initVm bs)
+buildExpr solvers bs = interpret (Fetch.oracle solvers Nothing) Nothing Nothing (initVm bs) runExpr
 
 dai :: IO ByteString
 dai = do

--- a/test/EVM/Test/BlockchainTests.hs
+++ b/test/EVM/Test/BlockchainTests.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
-{-# LANGUAGE TupleSections #-}
-
 module EVM.Test.BlockchainTests where
 
 import Prelude hiding (Word)
@@ -21,7 +18,6 @@ import EVM.Types
 import Control.Arrow ((***), (&&&))
 import Optics.Core
 import Control.Monad
-import Control.Monad.State.Strict (execStateT)
 import Data.Aeson ((.:), (.:?), FromJSON (..))
 import Data.Aeson qualified as JSON
 import Data.Aeson.Types qualified as JSON
@@ -134,16 +130,15 @@ ciProblematicTests = Map.fromList
   ]
 
 runVMTest :: Bool -> (String, Case) -> IO ()
-runVMTest diffmode (_name, x) =
- do
+runVMTest diffmode (_name, x) = do
   let vm0 = vmForCase x
-  result <- execStateT (EVM.Stepper.interpret (EVM.Fetch.zero 0 (Just 0)) . void $ EVM.Stepper.execFully) vm0
+  result <- EVM.Stepper.interpret (EVM.Fetch.zero 0 (Just 0)) vm0 EVM.Stepper.runFully
   maybeReason <- checkExpectation diffmode x result
   forM_ maybeReason assertFailure
 
 -- | Example usage:
--- | $ cabal new-repl ethereum-tests
--- | ghci> debugVMTest "BlockchainTests/GeneralStateTests/VMTests/vmArithmeticTest/twoOps.json" "twoOps_d0g0v0_London"
+-- $ cabal new-repl ethereum-tests
+-- ghci> debugVMTest "BlockchainTests/GeneralStateTests/VMTests/vmArithmeticTest/twoOps.json" "twoOps_d0g0v0_London"
 debugVMTest :: String -> String -> IO ()
 debugVMTest file test = do
   repo <- getEnv "HEVM_ETHEREUM_TESTS_REPO"

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -415,7 +415,7 @@ runCodeWithTrace rpcinfo evmEnv alloc txn (fromAddr, toAddress) = withSolvers Z3
       calldata' = ConcreteBuf txn.txdata
       code' = alloc.code
       buildExpr :: SolverGroup -> VM -> IO (Expr End)
-      buildExpr s vm = evalStateT (interpret (Fetch.oracle s Nothing) Nothing Nothing runExpr) vm
+      buildExpr s vm = interpret (Fetch.oracle s Nothing) Nothing Nothing vm runExpr
 
   expr <- buildExpr solvers $ symbolify origVM
   (res, (vm, trace)) <- runStateT (interpretWithTrace (Fetch.oracle solvers rpcinfo) Stepper.execFully) (origVM, [])
@@ -459,7 +459,7 @@ vmForRuntimeCode runtimecode calldata' evmToolEnv alloc txn (fromAddr, toAddress
 runCode :: Fetch.RpcInfo -> ByteString -> Expr Buf -> IO (Maybe (Expr Buf))
 runCode rpcinfo code' calldata' = withSolvers Z3 0 Nothing $ \solvers -> do
   let origVM = vmForRuntimeCode code' calldata' emptyEvmToolEnv emptyEVMToolAlloc EVM.Transaction.emptyTransaction (ethrunAddress, createAddress ethrunAddress 1)
-  res <- evalStateT (Stepper.interpret (Fetch.oracle solvers rpcinfo) Stepper.execFully) origVM
+  res <- Stepper.interpret (Fetch.oracle solvers rpcinfo) origVM Stepper.execFully
   pure $ case res of
     Left _ -> Nothing
     Right b -> Just b


### PR DESCRIPTION
## Description
This simplifies the code a bit and reduces peak memory on ethereum-tests from ~10G to ~9G.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
