### PR TITLE
SymExec: better formatting for addresses in cexs

### DIFF
--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -713,7 +713,7 @@ formatCex cd m@(SMTCex _ _ store blockContext txContext) = T.unlines $
       | Map.null store = []
       | otherwise =
           [ "Storage:"
-          , indent 2 $ T.unlines $ Map.foldrWithKey (\key val acc -> ("Addr " <> (T.pack $ show key) <> ": " <> (T.pack $ show (Map.toList val))) : acc) mempty store
+          , indent 2 $ T.unlines $ Map.foldrWithKey (\key val acc -> ("Addr " <> (T.pack . show . Addr . num $ key) <> ": " <> (T.pack $ show (Map.toList val))) : acc) mempty store
           , ""
           ]
 


### PR DESCRIPTION
## Description 

Very tiny change to our counterexample formatting code that shows addresses in the storage counterexample in a format that allows them to be directly pasted into solidity files (i.e. left padded to 20 bytes and checksummed).

Before:

```
Storage:
  Addr 0xbbdb77fd35f260e720c9b1d8a33325e7f562739: [(0x800,0x981000818101617800000000140000000000400229e070000000000000000000),(0x80000000000,0x70e0a29a850004c026cfabf9fdbffdf0d10cd5d0080000000000000000000000)]
```

After:

```
Storage:
  Addr 0x0BBdb77FD35F260e720c9B1D8a33325E7f562739: [(0x800,0x981000818101617800000000140000000000400229e070000000000000000000),(0x80000000000,0x70e0a29a850004c026cfabf9fdbffdf0d10cd5d0080000000000000000000000)]
```

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
