### PR TITLE
Fix off-by-one bug in EVM.Debug.srcMapCodePos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The `prank` cheatcode now transfers value from the correct address
+- Fixed an off-by-one error in `EVM.Debug.srcMapCodePos`
 
 ## [0.50.4] - 2023-03-17
 

--- a/src/EVM/Debug.hs
+++ b/src/EVM/Debug.hs
@@ -47,7 +47,7 @@ srcMapCodePos :: SourceCache -> SrcMap -> Maybe (Text, Int)
 srcMapCodePos cache sm =
   fmap (second f) $ cache.files ^? ix sm.file
   where
-    f v = ByteString.count 0xa (ByteString.take (sm.offset - 1) v) + 1
+    f v = ByteString.count 0xa (ByteString.take sm.offset v) + 1
 
 srcMapCode :: SourceCache -> SrcMap -> Maybe ByteString
 srcMapCode cache sm =


### PR DESCRIPTION
## Description
`EVM.Debug.srcMapCodePos` subtracts one from the character offset when taking characters in order to count the number of newlines. This results in one too few characters being taken. For example, if the first character in the solidity file is a newline and the offset is 1, we would expect the function to return that we are on line 2 but it would actually return that we are on line 1. This PR fixes the off-by-one bug.

In particular, this fixes a problem in Echidna where incorrect lines were being highlighted in the coverage report.
Coverage report before PR:
<img width="538" alt="Screenshot 2023-04-11 at 4 26 18 PM" src="https://user-images.githubusercontent.com/129795909/231280398-9aa4338a-f75b-4f72-b3e1-200a31e28b9d.png">
Coverage report after PR:
<img width="538" alt="Screenshot 2023-04-11 at 4 27 20 PM" src="https://user-images.githubusercontent.com/129795909/231280575-c2b444a7-d4aa-4f34-9e22-d15dff04da7c.png">

## Checklist

- [X] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [X] updated the changelog
