### PR TITLE
EVM: no underflow when transfering eth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ foundry repo, and all unit tests will be executed (including prove tests).
 
 `hevm test` no longer supports parsing solidity output in the combined json format.
 
+## Fixed
+
+- Fixed a bug where underflow was possible when transfering eth
+
 ## [0.50.5] - 2023-03-18
 
 ## Changed

--- a/test/contracts/fail/cheatCodes.sol
+++ b/test/contracts/fail/cheatCodes.sol
@@ -8,6 +8,11 @@ interface Hevm {
     function sign(uint256,bytes32) external returns (uint8,bytes32,bytes32);
     function addr(uint256) external returns (address);
     function ffi(string[] calldata) external returns (bytes memory);
+    function prank(address) external;
+}
+
+contract Payable {
+    function hi() public payable {}
 }
 
 contract TestFailCheatCodes is DSTest {
@@ -20,5 +25,15 @@ contract TestFailCheatCodes is DSTest {
 
         // should revert if --ffi hasn't been passed to hevm...
         hevm.ffi(inputs);
+    }
+
+    function test_prank_underflow() public {
+        address from = address(0x1312);
+        uint amt = 10;
+
+        Payable target = new Payable();
+
+        hevm.prank(from);
+        target.hi{value : amt}();
     }
 }

--- a/test/test.hs
+++ b/test/test.hs
@@ -710,6 +710,7 @@ tests = testGroup "hevm"
     , testCase "Cheat-Codes-Fail" $ do
         let testFile = "test/contracts/fail/cheatCodes.sol"
         runSolidityTestCustom testFile "testBadFFI" Nothing False Nothing Foundry >>= assertEqual "test result" False
+        runSolidityTestCustom testFile "test_prank_underflow" Nothing False Nothing Foundry >>= assertEqual "test result" False
     ]
   , testGroup "Symbolic execution"
       [


### PR DESCRIPTION
## Description

Fixes an issue where underflow was possible when transfering eth from accounts with insufficient balance. 

Fixes https://github.com/ethereum/hevm/issues/247

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
