### PR TITLE
Prove traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A new stack based loop detection heuristic
 - Analysis of partial execution traces is now supported
+- execution traces are now shown for failed `prove_` tests
 
 ## Changed
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1998,6 +1998,20 @@ zipperRootForest z =
 traceForest :: VM -> Forest Trace
 traceForest vm = zipperRootForest vm.traces
 
+traceForest' :: Expr End -> Forest Trace
+traceForest' (Success _ (Traces f _) _ _) = f
+traceForest' (Partial _ (Traces f _) _) = f
+traceForest' (Failure _ (Traces f _) _) = f
+traceForest' (ITE {}) = error "Internal Error: ITE does not contain a trace"
+traceForest' (GVar {}) = error "Internal Error: Unexpected GVar"
+
+traceContext :: Expr End -> Map Addr Contract
+traceContext (Success _ (Traces _ c) _ _) = c
+traceContext (Partial _ (Traces _ c) _) = c
+traceContext (Failure _ (Traces _ c) _) = c
+traceContext (ITE {}) = error "Internal Error: ITE does not contain a trace"
+traceContext (GVar {}) = error "Internal Error: Unexpected GVar"
+
 traceTopLog :: [Expr Log] -> EVM ()
 traceTopLog [] = noop
 traceTopLog ((LogEntry addr bytes topics) : _) = do

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -195,7 +195,6 @@ showTraceTree dapp vm =
   in pack $ concatMap showTree traces
 
 showTraceTree' :: DappInfo -> Expr End -> Text
-showTraceTree' _ (ITE {}) = error "Internal Error: ITE does not contain a trace"
 showTraceTree' dapp leaf =
   let forest = traceForest' leaf
       traces = fmap (fmap (unpack . showTrace dapp (traceContext leaf))) forest

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -263,19 +263,6 @@ showTrace dapp vm trace =
             Nothing ->
               logn
 
-    QueryTrace q ->
-      case q of
-        PleaseFetchContract addr _ ->
-          "fetch contract " <> pack (show addr) <> pos
-        PleaseFetchSlot addr slot _ ->
-          "fetch storage slot " <> pack (show slot) <> " from " <> pack (show addr) <> pos
-        PleaseAskSMT {} ->
-          "ask smt" <> pos
-        --PleaseMakeUnique {} ->
-          --"make unique value" <> pos
-        PleaseDoFFI cmd _ ->
-          "execute ffi " <> pack (show cmd) <> pos
-
     ErrorTrace e ->
       case e of
         Revert out ->

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -379,15 +379,15 @@ prettyError = \case
   BadCheatCode a -> "Bad cheat code: sig: " <> show a
 
 prettyvmresult :: Expr End -> String
-prettyvmresult (Failure _ (Revert (ConcreteBuf ""))) = "Revert"
-prettyvmresult (Success _ (ConcreteBuf msg) _) =
+prettyvmresult (Failure _ _ (Revert (ConcreteBuf ""))) = "Revert"
+prettyvmresult (Success _ _ (ConcreteBuf msg) _) =
   if BS.null msg
   then "Stop"
   else "Return: " <> show (ByteStringS msg)
-prettyvmresult (Success _ _ _) =
+prettyvmresult (Success _ _ _ _) =
   "Return: <symbolic>"
-prettyvmresult (Failure _ err) = prettyError err
-prettyvmresult (Partial _ p) = T.unpack $ formatPartial p
+prettyvmresult (Failure _ _ err) = prettyError err
+prettyvmresult (Partial _ _ p) = T.unpack $ formatPartial p
 prettyvmresult r = error $ "Internal Error: Invalid result: " <> show r
 
 indent :: Int -> Text -> Text
@@ -434,7 +434,7 @@ formatExpr = go
         , indent 2 (formatExpr t)
         , indent 2 (formatExpr f)
         , ")"]
-      Success asserts buf store -> T.unlines
+      Success asserts _ buf store -> T.unlines
         [ "(Return"
         , indent 2 $ T.unlines
           [ "Data:"
@@ -447,7 +447,7 @@ formatExpr = go
           ]
         , ")"
         ]
-      Failure asserts err -> T.unlines
+      Failure asserts _ err -> T.unlines
         [ "(Failure"
         , indent 2 $ T.unlines
           [ "Error:"

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -38,6 +38,7 @@ import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.IO as TL
+import Data.Tree.Zipper qualified as Zipper
 import EVM.Format (formatExpr, formatPartial)
 import Data.Set (Set, isSubsetOf, size)
 import qualified Data.Set as Set
@@ -277,7 +278,6 @@ interpret fetcher maxIter askSmtIters heuristic vm =
            in interpret fetcher maxIter askSmtIters heuristic vma (k ra))
           (let (rb, vmb) = runState (continue False) vm { result = Nothing }
            in interpret fetcher maxIter askSmtIters heuristic vmb (k rb))
-
         pure $ ITE cond a b
       Stepper.Wait q -> do
         let performQuery = do
@@ -294,7 +294,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
                 case (maxIterationsReached vm maxIter, isLoopHead heuristic vm) of
                   -- Yes. return a partial leaf
                   (Just _, Just True) ->
-                    pure $ Partial vm.keccakEqs $ MaxIterationsReached vm.state.pc vm.state.contract
+                    pure $ Partial vm.keccakEqs (Zipper.toForest vm.traces) $ MaxIterationsReached vm.state.pc vm.state.contract
                   -- No. keep executing
                   _ ->
                     let (r, vm') = runState (continue (Case (c > 0))) vm
@@ -310,7 +310,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
                     -- got us to this point and return a partial leaf for the other side
                     let (r, vm') = runState (continue (Case $ not n)) vm
                     a <- interpret fetcher maxIter askSmtIters heuristic vm' (k r)
-                    pure $ ITE cond a (Partial vm.keccakEqs (MaxIterationsReached vm.state.pc vm.state.contract))
+                    pure $ ITE cond a (Partial vm.keccakEqs (Zipper.toForest vm.traces) (MaxIterationsReached vm.state.pc vm.state.contract))
                   -- we're in a loop and askSmtIters has been reached
                   (Just True, True, _) ->
                     -- ask the smt solver about the loop condition
@@ -395,8 +395,8 @@ checkAssert solvers errs c signature' concreteArgs opts =
 -}
 checkAssertions :: [Word256] -> Postcondition
 checkAssertions errs _ = \case
-  Failure _ (Revert (ConcreteBuf msg)) -> PBool $ msg `notElem` (fmap panicMsg errs)
-  Failure _ (Revert b) -> foldl' PAnd (PBool True) (fmap (PNeg . PEq b . ConcreteBuf . panicMsg) errs)
+  Failure _ _ (Revert (ConcreteBuf msg)) -> PBool $ msg `notElem` (fmap panicMsg errs)
+  Failure _ _ (Revert b) -> foldl' PAnd (PBool True) (fmap (PNeg . PEq b . ConcreteBuf . panicMsg) errs)
   _ -> PBool True
 
 -- | By default hevm only checks for user-defined assertions
@@ -444,9 +444,9 @@ runExpr = do
   vm <- Stepper.runFully
   let asserts = vm.keccakEqs
   pure $ case vm.result of
-    Just (VMSuccess buf) -> Success asserts buf vm.env.storage
-    Just (VMFailure e) -> Failure asserts e
-    Just (Unfinished p) -> Partial asserts p
+    Just (VMSuccess buf) -> Success asserts (Zipper.toForest vm.traces) buf vm.env.storage
+    Just (VMFailure e) -> Failure asserts (Zipper.toForest vm.traces) e
+    Just (Unfinished p) -> Partial asserts (Zipper.toForest vm.traces) p
     _ -> error "Internal Error: vm in intermediate state after call to runFully"
 
 -- | Converts a given top level expr into a list of final states and the
@@ -457,9 +457,9 @@ flattenExpr = go []
     go :: [Prop] -> Expr End -> [Expr End]
     go pcs = \case
       ITE c t f -> go (PNeg ((PEq c (Lit 0))) : pcs) t <> go (PEq c (Lit 0) : pcs) f
-      Success ps msg store -> [Success (ps <> pcs) msg store]
-      Failure ps e -> [Failure (ps <> pcs) e]
-      Partial ps p -> [Partial (ps <> pcs) p]
+      Success ps trace msg store -> [Success (ps <> pcs) trace msg store]
+      Failure ps trace e -> [Failure (ps <> pcs) trace e]
+      Partial ps trace p -> [Partial (ps <> pcs) trace p]
       GVar _ -> error "cannot flatten an Expr containing a GVar"
 
 -- | Strips unreachable branches from a given expr
@@ -540,13 +540,13 @@ evalProp = \case
 extractProps :: Expr End -> [Prop]
 extractProps = \case
   ITE _ _ _ -> []
-  Success asserts _ _ -> asserts
-  Failure asserts _ -> asserts
-  Partial asserts _ -> asserts
+  Success asserts _ _ _ -> asserts
+  Failure asserts _ _ -> asserts
+  Partial asserts _ _ -> asserts
   GVar _ -> error "cannot extract props from a GVar"
 
 isPartial :: Expr a -> Bool
-isPartial (Partial _ _) = True
+isPartial (Partial _ _ _) = True
 isPartial _ = False
 
 getPartials :: [Expr End] -> [PartialExec]
@@ -554,7 +554,7 @@ getPartials = mapMaybe go
   where
     go :: Expr End -> Maybe PartialExec
     go = \case
-      Partial _ p -> Just p
+      Partial _ _ p -> Just p
       _ -> Nothing
 
 -- | Symbolically execute the VM and check all endstates against the
@@ -730,12 +730,12 @@ equivalenceCheck solvers bytecodeA bytecodeB opts calldata' = do
     distinct aEnd bEnd =
       let
         differingResults = case (aEnd, bEnd) of
-          (Success _ aOut aStore, Success _ bOut bStore) ->
+          (Success _ _ aOut aStore, Success _ _ bOut bStore) ->
             if aOut == bOut && aStore == bStore
             then PBool False
             else aStore ./= bStore .|| aOut ./= bOut
-          (Failure _ (Revert a), Failure _ (Revert b)) -> if a == b then PBool False else a ./= b
-          (Failure _ a, Failure _ b) -> if a == b then PBool False else PBool True
+          (Failure _ _ (Revert a), Failure _ _ (Revert b)) -> if a == b then PBool False else a ./= b
+          (Failure _ _ a, Failure _ _ b) -> if a == b then PBool False else PBool True
           -- partial end states can't be compared to actual end states, so we always ignore them
           (Partial {}, _) -> PBool False
           (_, Partial {}) -> PBool False

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -294,7 +294,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
                 case (maxIterationsReached vm maxIter, isLoopHead heuristic vm) of
                   -- Yes. return a partial leaf
                   (Just _, Just True) ->
-                    pure $ Partial vm.keccakEqs (Zipper.toForest vm.traces) $ MaxIterationsReached vm.state.pc vm.state.contract
+                    pure $ Partial vm.keccakEqs (Traces (Zipper.toForest vm.traces) vm.env.contracts) $ MaxIterationsReached vm.state.pc vm.state.contract
                   -- No. keep executing
                   _ ->
                     let (r, vm') = runState (continue (Case (c > 0))) vm
@@ -310,7 +310,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
                     -- got us to this point and return a partial leaf for the other side
                     let (r, vm') = runState (continue (Case $ not n)) vm
                     a <- interpret fetcher maxIter askSmtIters heuristic vm' (k r)
-                    pure $ ITE cond a (Partial vm.keccakEqs (Zipper.toForest vm.traces) (MaxIterationsReached vm.state.pc vm.state.contract))
+                    pure $ ITE cond a (Partial vm.keccakEqs (Traces (Zipper.toForest vm.traces) vm.env.contracts) (MaxIterationsReached vm.state.pc vm.state.contract))
                   -- we're in a loop and askSmtIters has been reached
                   (Just True, True, _) ->
                     -- ask the smt solver about the loop condition
@@ -444,9 +444,9 @@ runExpr = do
   vm <- Stepper.runFully
   let asserts = vm.keccakEqs
   pure $ case vm.result of
-    Just (VMSuccess buf) -> Success asserts (Zipper.toForest vm.traces) buf vm.env.storage
-    Just (VMFailure e) -> Failure asserts (Zipper.toForest vm.traces) e
-    Just (Unfinished p) -> Partial asserts (Zipper.toForest vm.traces) p
+    Just (VMSuccess buf) -> Success asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) buf vm.env.storage
+    Just (VMFailure e) -> Failure asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) e
+    Just (Unfinished p) -> Partial asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) p
     _ -> error "Internal Error: vm in intermediate state after call to runFully"
 
 -- | Converts a given top level expr into a list of final states and the

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -86,9 +86,9 @@ foldExpr f acc expr = acc <> (go expr)
 
       -- control flow
 
-      e@(Success a b c d) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldTrace f) mempty b) <> (go c) <> (go d)
-      e@(Failure a b _) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldTrace f) mempty b)
-      e@(Partial a b _) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldTrace f) mempty b)
+      e@(Success a b c d) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldl (foldTrace f)) mempty b) <> (go c) <> (go d)
+      e@(Failure a b _) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldl (foldTrace f)) mempty b)
+      e@(Partial a b _) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldl (foldTrace f)) mempty b)
       e@(ITE a b c) -> f e <> (go a) <> (go b) <> (go c)
 
       -- integers
@@ -348,15 +348,15 @@ mapExprM f expr = case expr of
 
   Failure a b c -> do
     a' <- mapM (mapPropM f) a
-    b' <- mapM (mapTraceM f) b
+    b' <- mapM (mapM (mapTraceM f)) b
     f (Failure a' b' c)
   Partial a b c -> do
     a' <- mapM (mapPropM f) a
-    b' <- mapM (mapTraceM f) b
+    b' <- mapM (mapM (mapTraceM f)) b
     f (Partial a' b' c)
   Success a b c d -> do
     a' <- mapM (mapPropM f) a
-    b' <- mapM (mapTraceM f) b
+    b' <- mapM (mapM (mapTraceM f)) b
     c' <- mapExprM f c
     d' <- mapExprM f d
     f (Success a' b' c' d')

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -1,4 +1,5 @@
 {-# Language DataKinds #-}
+{-# Language ScopedTypeVariables #-}
 
 {- |
     Module: EVM.Traversals
@@ -27,6 +28,24 @@ foldProp f acc p = acc <> (go p)
       PAnd a b -> go a <> go b
       POr a b -> go a <> go b
       PImpl a b -> go a <> go b
+
+foldTrace :: forall b . Monoid b => (forall a . Expr a -> b) -> b -> Trace -> b
+foldTrace f acc t = acc <> (go t)
+  where
+    go :: Trace -> b
+    go (Trace _ _ d) = case d of
+      EventTrace a b c -> foldExpr f mempty a <> foldExpr f mempty b <> (foldl (foldExpr f) mempty c)
+      FrameTrace a -> go' a
+      ErrorTrace _ -> mempty
+      EntryTrace _ -> mempty
+      ReturnTrace a b -> foldExpr f mempty a <> go' b
+
+    go' :: FrameContext -> b
+    go' = \case
+      CreationContext _ b _ _ -> foldExpr f mempty b
+      CallContext _ _ _ _ e _ g (_, h) _ -> foldExpr f mempty e <> foldExpr f mempty g <> foldExpr f mempty h
+
+
 
 -- | Recursively folds a given function over a given expression
 -- Recursion schemes do this & a lot more, but defining them over GADT's isn't worth the hassle
@@ -67,9 +86,9 @@ foldExpr f acc expr = acc <> (go expr)
 
       -- control flow
 
-      e@(Success a b c) -> f e <> (foldl (foldProp f) mempty a) <> (go b) <> (go c)
-      e@(Failure a _) -> f e <> (foldl (foldProp f) mempty a)
-      e@(Partial a _) -> f e <> (foldl (foldProp f) mempty a)
+      e@(Success a b c d) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldTrace f) mempty b) <> (go c) <> (go d)
+      e@(Failure a b _) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldTrace f) mempty b)
+      e@(Partial a b _) -> f e <> (foldl (foldProp f) mempty a) <> (foldl (foldTrace f) mempty b)
       e@(ITE a b c) -> f e <> (go a) <> (go b) <> (go c)
 
       -- integers
@@ -241,6 +260,22 @@ mapProp f = \case
   POr a b -> POr (mapProp f a) (mapProp f b)
   PImpl a b -> PImpl (mapProp f a) (mapProp f b)
 
+mapTrace :: (forall a . Expr a -> Expr a) -> Trace -> Trace
+mapTrace f (Trace x y z) = Trace x y (go z)
+  where
+    go :: TraceData -> TraceData
+    go = \case
+      EventTrace a b c -> EventTrace (f a) (f b) (fmap (mapExpr f) c)
+      FrameTrace a -> FrameTrace (go' a)
+      ErrorTrace a -> ErrorTrace a
+      EntryTrace a -> EntryTrace a
+      ReturnTrace a b -> ReturnTrace (f a) (go' b)
+
+    go' :: FrameContext -> FrameContext
+    go' = \case
+      CreationContext a b c d -> CreationContext a (f b) c d
+      CallContext a b c d e g h (i,j) k -> CallContext a b c d (f e) g (f h) (i,f j) k
+
 -- | Recursively applies a given function to every node in a given expr instance
 -- Recursion schemes do this & a lot more, but defining them over GADT's isn't worth the hassle
 mapExpr :: (forall a . Expr a -> Expr a) -> Expr b -> Expr b
@@ -311,17 +346,20 @@ mapExprM f expr = case expr of
 
   -- control flow
 
-  Failure a b -> do
+  Failure a b c -> do
     a' <- mapM (mapPropM f) a
-    f (Failure a' b)
-  Partial a b -> do
+    b' <- mapM (mapTraceM f) b
+    f (Failure a' b' c)
+  Partial a b c -> do
     a' <- mapM (mapPropM f) a
-    f (Partial a' b)
-  Success a b c -> do
+    b' <- mapM (mapTraceM f) b
+    f (Partial a' b' c)
+  Success a b c d -> do
     a' <- mapM (mapPropM f) a
-    b' <- mapExprM f b
+    b' <- mapM (mapTraceM f) b
     c' <- mapExprM f c
-    f (Success a' b' c')
+    d' <- mapExprM f d
+    f (Success a' b' c' d')
 
   ITE a b c -> do
     a' <- mapExprM f a
@@ -653,6 +691,37 @@ mapPropM f = \case
     b' <- mapPropM f b
     pure $ PImpl a' b'
 
+mapTraceM :: forall m . Monad m => (forall a . Expr a -> m (Expr a)) -> Trace -> m Trace
+mapTraceM f (Trace x y z) = do
+  z' <- go z
+  pure $ Trace x y z'
+  where
+    go :: TraceData -> m TraceData
+    go = \case
+      EventTrace a b c -> do
+        a' <- mapExprM f a
+        b' <- mapExprM f b
+        c' <- mapM (mapExprM f) c
+        pure $ EventTrace a' b' c'
+      FrameTrace a -> do
+        a' <- go' a
+        pure $ FrameTrace a'
+      ReturnTrace a b -> do
+        a' <- mapExprM f a
+        b' <- go' b
+        pure $ ReturnTrace a' b'
+      a -> pure a
+
+    go' :: FrameContext -> m FrameContext
+    go' = \case
+      CreationContext a b c d -> do
+        b' <- mapExprM f b
+        pure $ CreationContext a b' c d
+      CallContext a b c d e g h (i,j) k -> do
+        e' <- mapExprM f e
+        h' <- mapExprM f h
+        j' <- mapExprM f j
+        pure $ CallContext a b c d e' g h' (i,j') k
 
 -- | Generic operations over AST terms
 class TraversableTerm a where

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -41,6 +41,7 @@ import Data.Sequence qualified as Seq
 import Data.Serialize qualified as Cereal
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
+import Data.Tree
 import Data.Vector qualified as V
 import Data.Vector.Storable qualified as SV
 import Numeric (readHex, showHex)
@@ -160,9 +161,9 @@ data Expr (a :: EType) where
 
   -- control flow
 
-  Partial        :: [Prop] -> [Trace] -> PartialExec -> Expr End
-  Failure        :: [Prop] -> [Trace] -> EvmError -> Expr End
-  Success        :: [Prop] -> [Trace] -> Expr Buf -> Expr Storage -> Expr End
+  Partial        :: [Prop] -> Forest Trace -> PartialExec -> Expr End
+  Failure        :: [Prop] -> Forest Trace -> EvmError -> Expr End
+  Success        :: [Prop] -> Forest Trace -> Expr Buf -> Expr Storage -> Expr End
   ITE            :: Expr EWord -> Expr End -> Expr End -> Expr End
 
   -- integers

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -41,7 +41,6 @@ import Data.Sequence qualified as Seq
 import Data.Serialize qualified as Cereal
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
-import Data.Tree
 import Data.Vector qualified as V
 import Data.Vector.Storable qualified as SV
 import Numeric (readHex, showHex)
@@ -161,9 +160,9 @@ data Expr (a :: EType) where
 
   -- control flow
 
-  Partial        :: [Prop] -> Forest Trace -> PartialExec -> Expr End
-  Failure        :: [Prop] -> Forest Trace -> EvmError -> Expr End
-  Success        :: [Prop] -> Forest Trace -> Expr Buf -> Expr Storage -> Expr End
+  Partial        :: [Prop] -> [Trace] -> PartialExec -> Expr End
+  Failure        :: [Prop] -> [Trace] -> EvmError -> Expr End
+  Success        :: [Prop] -> [Trace] -> Expr Buf -> Expr Storage -> Expr End
   ITE            :: Expr EWord -> Expr End -> Expr End -> Expr End
 
   -- integers

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -85,7 +85,6 @@ deriving instance Show (GVar a)
 deriving instance Eq (GVar a)
 deriving instance Ord (GVar a)
 
-
 {- |
   Expr implements an abstract respresentation of an EVM program
 
@@ -161,9 +160,9 @@ data Expr (a :: EType) where
 
   -- control flow
 
-  Partial        :: [Prop] -> Forest Trace -> PartialExec -> Expr End
-  Failure        :: [Prop] -> Forest Trace -> EvmError -> Expr End
-  Success        :: [Prop] -> Forest Trace -> Expr Buf -> Expr Storage -> Expr End
+  Partial        :: [Prop] -> Traces -> PartialExec -> Expr End
+  Failure        :: [Prop] -> Traces -> EvmError -> Expr End
+  Success        :: [Prop] -> Traces -> Expr Buf -> Expr Storage -> Expr End
   ITE            :: Expr EWord -> Expr End -> Expr End -> Expr End
 
   -- integers
@@ -816,6 +815,18 @@ data TraceData
   | EntryTrace Text
   | ReturnTrace (Expr Buf) FrameContext
   deriving (Eq, Ord, Show, Generic)
+
+-- | Wrapper type containing vm traces and the context needed to pretty print them properly
+data Traces = Traces
+  { traces :: Forest Trace
+  , contracts :: Map Addr Contract
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+instance Semigroup Traces where
+  (Traces a b) <> (Traces c d) = Traces (a <> c) (b <> d)
+instance Monoid Traces where
+  mempty = Traces mempty mempty
 
 
 -- VM Initialization -------------------------------------------------------------------------------

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -41,6 +41,7 @@ import Data.Sequence qualified as Seq
 import Data.Serialize qualified as Cereal
 import Data.Text qualified as T
 import Data.Text.Encoding qualified as T
+import Data.Tree
 import Data.Vector qualified as V
 import Data.Vector.Storable qualified as SV
 import Numeric (readHex, showHex)
@@ -160,9 +161,9 @@ data Expr (a :: EType) where
 
   -- control flow
 
-  Partial        :: [Prop] -> PartialExec -> Expr End
-  Failure        :: [Prop] -> EvmError -> Expr End
-  Success        :: [Prop] -> Expr Buf -> Expr Storage -> Expr End
+  Partial        :: [Prop] -> Forest Trace -> PartialExec -> Expr End
+  Failure        :: [Prop] -> Forest Trace -> EvmError -> Expr End
+  Success        :: [Prop] -> Forest Trace -> Expr Buf -> Expr Storage -> Expr End
   ITE            :: Expr EWord -> Expr End -> Expr End -> Expr End
 
   -- integers
@@ -618,7 +619,7 @@ data FrameContext
     , callreversion :: (Map Addr Contract, Expr Storage)
     , subState      :: SubState
     }
-  deriving (Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 -- | The "accrued substate" across a transaction
 data SubState = SubState
@@ -629,7 +630,7 @@ data SubState = SubState
   , refunds             :: [(Addr, Word64)]
   -- in principle we should include logs here, but do not for now
   }
-  deriving (Show)
+  deriving (Eq, Ord, Show)
 
 -- | The "registers" of the VM along with memory and data stack
 data FrameState = FrameState
@@ -713,7 +714,7 @@ data Contract = Contract
   , codeOps      :: V.Vector (Int, Op)
   , external     :: Bool
   }
-  deriving (Show)
+  deriving (Eq, Ord, Show)
 
 
 -- Bytecode Representations ------------------------------------------------------------------------
@@ -806,16 +807,15 @@ data Trace = Trace
   , contract  :: Contract
   , tracedata :: TraceData
   }
-  deriving (Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 data TraceData
   = EventTrace (Expr EWord) (Expr Buf) [Expr EWord]
   | FrameTrace FrameContext
-  | QueryTrace Query
   | ErrorTrace EvmError
   | EntryTrace Text
   | ReturnTrace (Expr Buf) FrameContext
-  deriving (Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 
 -- VM Initialization -------------------------------------------------------------------------------
@@ -933,7 +933,7 @@ data GenericOp a
   | OpLog !Word8
   | OpPush a
   | OpUnknown Word8
-  deriving (Show, Eq, Functor)
+  deriving (Show, Eq, Ord, Functor)
 
 
 -- Function Selectors ------------------------------------------------------------------------------

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -726,12 +726,12 @@ symRun opts@UnitTestOptions{..} vm testName types = do
                    .|| (readStorage' (litAddr cheatCode) (Lit 0x6661696c65640000000000000000000000000000000000000000000000000000) store .== Lit 1)
         postcondition = curry $ case shouldFail of
           True -> \(_, post) -> case post of
-                                  Success _ _ store -> failed store
+                                  Success _ _ _ store -> failed store
                                   _ -> PBool True
           False -> \(_, post) -> case post of
-                                   Success _ _ store -> PNeg (failed store)
-                                   Failure _ _ -> PBool False
-                                   Partial _ _ -> PBool True
+                                   Success _ _ _ store -> PNeg (failed store)
+                                   Failure _ _ _ -> PBool False
+                                   Partial _ _ _ -> PBool True
                                    _ -> error "Internal Error: Invalid leaf node"
 
     vm' <- EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo) vm $
@@ -763,7 +763,7 @@ symFailure UnitTestOptions {..} testName cd types failures' =
     where
       ctx = DappContext { info = dapp, env = mempty }
       showRes = \case
-                       Success _ _ _ -> if "proveFail" `isPrefixOf` testName
+                       Success _ _ _ _ -> if "proveFail" `isPrefixOf` testName
                                       then "Successful execution"
                                       else "Failed: DSTest Assertion Violation"
                        res ->

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -736,7 +736,7 @@ symRun opts@UnitTestOptions{..} vm testName types = do
 
     vm' <- EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo) vm $
       Stepper.evm $ do
-        popTrace
+        pushTrace (EntryTrace testName)
         makeTxCall testParams cd
         get
 
@@ -761,25 +761,24 @@ symFailure UnitTestOptions {..} testName cd types failures' =
     , intercalate "\n" $ indentLines 2 . mkMsg <$> failures'
     ]
     where
-      ctx = DappContext { info = dapp, env = mempty }
       showRes = \case
-                       Success _ _ _ _ -> if "proveFail" `isPrefixOf` testName
-                                      then "Successful execution"
-                                      else "Failed: DSTest Assertion Violation"
-                       res ->
-                         --let ?context = DappContext { _contextInfo = dapp, _contextEnv = vm ^?! EVM.env . EVM.contracts}
-                         let ?context = ctx
-                         in Text.pack $ prettyvmresult res
+        Success _ _ _ _ -> if "proveFail" `isPrefixOf` testName
+                       then "Successful execution"
+                       else "Failed: DSTest Assertion Violation"
+        res ->
+          let ?context = DappContext { info = dapp, env = traceContext res}
+          in Text.pack $ prettyvmresult res
       mkMsg (leaf, cex) = Text.unlines
         ["Counterexample:"
         ,""
         ,"  result:   " <> showRes leaf
-        ,"  calldata: " <> let ?context = ctx in prettyCalldata cex cd testName types
+        ,"  calldata: " <> let ?context =  DappContext dapp (traceContext leaf)
+                           in prettyCalldata cex cd testName types
         , case verbose of
-            --Just _ -> unlines
-              --[ ""
-              --, unpack $ indentLines 2 (showTraceTree dapp vm)
-              --]
+            Just _ -> Text.unlines
+              [ ""
+              , indentLines 2 (showTraceTree' dapp leaf)
+              ]
             _ -> ""
         ]
 
@@ -798,15 +797,6 @@ showVal :: AbiValue -> Text
 showVal (AbiBytes _ bs) = formatBytes bs
 showVal (AbiAddress addr) = Text.pack  . show $ addr
 showVal v = Text.pack . show $ v
-
-
--- prettyCalldata :: (?context :: DappContext) => Expr Buf -> Text -> [AbiType]-> IO Text
--- prettyCalldata buf sig types = do
---   cdlen' <- num <$> SBV.getValue cdlen
---   cd <- case buf of
---     ConcreteBuf cd -> return $ BS.take cdlen' cd
---     cd -> mapM (SBV.getValue . fromSized) (take cdlen' cd) <&> BS.pack
---   pure $ (head (Text.splitOn "(" sig)) <> showCall types (ConcreteBuffer cd)
 
 execSymTest :: UnitTestOptions -> ABIMethod -> (Expr Buf, [Prop]) -> Stepper (Expr End)
 execSymTest UnitTestOptions{ .. } method cd = do

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -841,7 +841,7 @@ tests = testGroup "contract-quickcheck-run"
               concretizedExpr = concretize expr (ConcreteBuf txData)
               simplConcExpr = Expr.simplify concretizedExpr
               getReturnVal :: Expr End -> Maybe ByteString
-              getReturnVal (Success _ (ConcreteBuf bs) _) = Just bs
+              getReturnVal (Success _ _ (ConcreteBuf bs) _) = Just bs
               getReturnVal _ = Nothing
               simplConcrExprRetval = getReturnVal simplConcExpr
             traceOK <- compareTraces hevmTrace (evmtoolTraceOutput.trace)

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -90,7 +90,7 @@ tests = testGroup "rpc"
         let
           blockNum = 16198552
           calldata' = symCalldata "transfer(address,uint256)" [AbiAddressType, AbiUIntType 256] ["0xdead"] (AbstractBuf "txdata")
-          postc _ (Failure _ (Revert _)) = PBool False
+          postc _ (Failure _ _ (Revert _)) = PBool False
           postc _ _ = PBool True
         vm <- weth9VM blockNum calldata'
         (_, [Cex (_, model)]) <- withSolvers Z3 1 Nothing $ \solvers ->

--- a/test/test.hs
+++ b/test/test.hs
@@ -2571,13 +2571,13 @@ genName = fmap (T.pack . ("esc_" <> )) $ listOf1 (oneof . (fmap pure) $ ['a'..'z
 
 genEnd :: Int -> Gen (Expr End)
 genEnd 0 = oneof
- [ fmap (Failure [] mempty . UnrecognizedOpcode) arbitrary
- , pure $ Failure [] mempty IllegalOverflow
- , pure $ Failure [] mempty SelfDestruction
+ [ fmap (Failure mempty mempty . UnrecognizedOpcode) arbitrary
+ , pure $ Failure mempty mempty IllegalOverflow
+ , pure $ Failure mempty mempty SelfDestruction
  ]
 genEnd sz = oneof
- [ fmap (Failure [] mempty . Revert) subBuf
- , liftM4 Success (return []) (return []) subBuf subStore
+ [ fmap (Failure mempty mempty . Revert) subBuf
+ , liftM4 Success (return mempty) (return mempty) subBuf subStore
  , liftM3 ITE subWord subEnd subEnd
  ]
  where


### PR DESCRIPTION
## Description

This is based on top of https://github.com/ethereum/hevm/pull/252, as it requires the reorganised types there.

This adds pretty traces in counter examples from `prove_` tests to match the output from a counterexample generated from a fuzz test. We do this by adding the existing traces contained within the VM to each leaf type in `Expr End`. 

As an example the output from the `prove_transfer` test in `test/contracts/fail/dsProveFail.sol` now looks like:

```
> [FAIL] prove_transfer(uint256,address,uint256)

Failure: prove_transfer(uint256,address,uint256)

  Counterexample:

    result:   Revert: 0x4e487b710000000000000000000000000000000000000000000000000000000000000011
    calldata: prove_transfer(0,0x0000000000000000000000000000000000000000,1)

    test.sol:SolidityTest
     ├╴constructor
     ├╴setUp()
     │  └╴create <unknown contract>@0xCe71065D4017F316EC606Fe4422e11eB2c47c246 (test.sol:8)
     │     └╴← 0x1925 bytes of code
     └╴prove_transfer(uint256,address,uint256)
        ├╴call 0xCe71065D4017F316EC606Fe4422e11eB2c47c246::mint<symbolic> (test.sol:60)
        │  ├╴Transfer(<symbolic>) (lib/erc20.sol:187)
        │  └╴← 0x
        ├╴call 0xCe71065D4017F316EC606Fe4422e11eB2c47c246::balanceOf<symbolic> (test.sol:62)
        │  └╴← (<symbolic>)
        └╴call 0xCe71065D4017F316EC606Fe4422e11eB2c47c246::transfer<symbolic> (test.sol:63)
           └╴error Revert Panic(17) <source not found>
```

previously we would only show the result and the calldata (without the pretty execution trace)

fixes https://github.com/ethereum/hevm/issues/137

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
