### PR TITLE
Implement Shanghai PUSH0 opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Added
+
+- `PUSH0` opcode that was introduced with the Shanghai fork
+
 ## [0.51.0] - 2023-04-27
 
 ## Added

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -238,6 +238,10 @@ exec1 = do
 
       case getOp(?op) of
 
+        OpPush0 ->
+          limitStack 1 . burn g_base $
+            next >> push 0
+
         OpPush n' -> do
           let n = fromIntegral n'
               !xs = case vm.state.code of

--- a/src/EVM/Assembler.hs
+++ b/src/EVM/Assembler.hs
@@ -105,5 +105,6 @@ assemble os = V.fromList $ concatMap go os
         then [LitByte (0xA0 + n)]
         else error $ "Internal Error: invalid argument to OpLog: " <> show n
       -- we just always assemble OpPush into PUSH32
+      OpPush0 -> [LitByte 0x5f]
       OpPush wrd -> (LitByte 0x7f) : [Expr.indexWord (Lit i) wrd | i <- [0..31]]
       OpUnknown o -> [LitByte o]

--- a/src/EVM/Op.hs
+++ b/src/EVM/Op.hs
@@ -86,6 +86,7 @@ intToOpName a =
    0x5a -> "GAS"
    0x5b -> "JUMPDEST"
    --
+   0x5f -> "PUSH0"
    0x60 -> "PUSH1"
    0x61 -> "PUSH2"
    0x62 -> "PUSH3"
@@ -250,6 +251,7 @@ opString (i, o) = let showPc x | x < 0x10 = '0' : showHex x ""
   OpDup x -> "DUP" ++ show x
   OpSwap x -> "SWAP" ++ show x
   OpLog x -> "LOG" ++ show x
+  OpPush0 -> "PUSH0"
   OpPush x -> case x of
     Lit x' -> "PUSH 0x" ++ (showHex x' "")
     _ -> "PUSH " ++ show x
@@ -332,6 +334,7 @@ getOp x = case x of
   0x59 -> OpMsize
   0x5a -> OpGas
   0x5b -> OpJumpdest
+  0x5f -> OpPush0
   0xf0 -> OpCreate
   0xf1 -> OpCall
   0xf2 -> OpCallcode

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -931,6 +931,7 @@ data GenericOp a
   | OpDup !Word8
   | OpSwap !Word8
   | OpLog !Word8
+  | OpPush0
   | OpPush a
   | OpUnknown Word8
   deriving (Show, Eq, Functor)


### PR DESCRIPTION
## Description
Solidity 0.8.20 targets Shanghai fork by default and programs don't run on hevm due to missing PUSH0 opcode.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
