### PR TITLE
cli: fail gracefully if out/ is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+
+- hevm now gracefully handles missing `out` directories
+
 ## [0.51.0] - 2023-04-27
 
 ## Added

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -43,7 +43,8 @@ import Data.Maybe                 (fromMaybe, mapMaybe)
 import Data.Version               (showVersion)
 import Data.DoubleWord            (Word256)
 import System.IO                  (stderr)
-import System.Directory           (withCurrentDirectory, getCurrentDirectory)
+import System.Directory           (withCurrentDirectory, getCurrentDirectory, doesDirectoryExist)
+import System.FilePath            ((</>))
 import System.Exit                (exitFailure, exitWith, ExitCode(..))
 
 import qualified Data.ByteString        as ByteString
@@ -337,10 +338,14 @@ getSrcInfo :: Command Options.Unwrapped -> IO DappInfo
 getSrcInfo cmd = do
   root <- getRoot cmd
   withCurrentDirectory root $ do
-    buildOutput <- readBuildOutput root (getProjectType cmd)
-    case buildOutput of
-      Left _ -> pure emptyDapp
-      Right o -> pure $ dappInfo root o
+    outExists <- doesDirectoryExist (root </> "out")
+    if outExists
+    then do
+      buildOutput <- readBuildOutput root (getProjectType cmd)
+      case buildOutput of
+        Left _ -> pure emptyDapp
+        Right o -> pure $ dappInfo root o
+    else pure emptyDapp
 
 getProjectType :: Command Options.Unwrapped -> ProjectType
 getProjectType cmd = fromMaybe Foundry cmd.projectType


### PR DESCRIPTION
## Description

Fixes https://github.com/ethereum/hevm/issues/263. We no longer error out if no `out/` directory is present in the root directory.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
