### PR TITLE
SymExec: propogate constraints from vm to output expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 
 - hevm now gracefully handles missing `out` directories
+- Constraints are correctly propogated to the final output expression during symbolic execution
 
 ## [0.51.0] - 2023-04-27
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -442,7 +442,7 @@ verifyContract solvers theCode signature' concreteArgs opts initStore maybepre m
 runExpr :: Stepper.Stepper (Expr End)
 runExpr = do
   vm <- Stepper.runFully
-  let asserts = vm.keccakEqs
+  let asserts = vm.keccakEqs <> vm.constraints
   pure $ case vm.result of
     Just (VMSuccess buf) -> Success asserts buf vm.env.storage
     Just (VMFailure e) -> Failure asserts e


### PR DESCRIPTION
## Description

We weren't including the `constraints` from the `vm` in the props of leaves in the final expressions output during symbolic execution. In practice this was mostly affecting abi decoding, and constraints on variables in semi structured calldata.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
