### PR TITLE
Range assertion for environment variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Fixed
+- SMT encoding of Expr now has assertions for the range of environment values that are less than word size (256 bits).
+
+
 ## [0.51.1] - 2023-06-02
 
 ## Fixed

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           z3
           cvc5
           git
-          foundry.defaultPackage.${system}
+          # foundry.defaultPackage.${system}
         ];
 
         secp256k1-static = stripDylib (pkgs.secp256k1.overrideAttrs (attrs: {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           z3
           cvc5
           git
-          # foundry.defaultPackage.${system}
+          foundry.defaultPackage.${system}
         ];
 
         secp256k1-static = stripDylib (pkgs.secp256k1.overrideAttrs (attrs: {

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -993,3 +993,6 @@ containsNode p = getAny . foldExpr go (Any False)
     go :: Expr a -> Any
     go node | p node  = Any True
     go _ = Any False
+
+inRange :: Int -> Expr EWord -> Prop
+inRange sz e = PAnd (PGEq e (Lit 0)) (PLEq e (Lit $ 2 ^ sz - 1))

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -103,9 +103,6 @@ extractCex :: VerifyResult -> Maybe (Expr End, SMTCex)
 extractCex (Cex c) = Just c
 extractCex _ = Nothing
 
-inRange :: Int -> Expr EWord -> Prop
-inRange sz e = PAnd (PGEq e (Lit 0)) (PLEq e (Lit $ 2 ^ sz - 1))
-
 bool :: Expr EWord -> Prop
 bool e = POr (PEq e (Lit 1)) (PEq e (Lit 0))
 
@@ -114,18 +111,18 @@ symAbiArg :: Text -> AbiType -> CalldataFragment
 symAbiArg name = \case
   AbiUIntType n ->
     if n `mod` 8 == 0 && n <= 256
-    then let v = Var name in St [inRange n v] v
+    then let v = Var name in St [Expr.inRange n v] v
     else error "bad type"
   AbiIntType n ->
     if n `mod` 8 == 0 && n <= 256
     -- TODO: is this correct?
-    then let v = Var name in St [inRange n v] v
+    then let v = Var name in St [Expr.inRange n v] v
     else error "bad type"
   AbiBoolType -> let v = Var name in St [bool v] v
-  AbiAddressType -> let v = Var name in St [inRange 160 v] v
+  AbiAddressType -> let v = Var name in St [Expr.inRange 160 v] v
   AbiBytesType n ->
     if n > 0 && n <= 32
-    then let v = Var name in St [inRange (n * 8) v] v
+    then let v = Var name in St [Expr.inRange (n * 8) v] v
     else error "bad type"
   AbiArrayType sz tp ->
     Comp $ fmap (\n -> symAbiArg (name <> n) tp) [T.pack (show n) | n <- [0..sz-1]]

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -696,9 +696,13 @@ equivalenceCheck' solvers branchesA branchesB opts = do
     -- the solver if we can determine unsatisfiability from the cache already
     -- the last element of the returned tuple indicates whether the cache was
     -- used or not
-    check :: UnsatCache -> Set Prop -> IO (EquivResult, Bool)
-    check knownUnsat props = do
+    check :: UnsatCache -> (Set Prop) -> Int -> IO (EquivResult, Bool)
+    check knownUnsat props idx = do
       let smt = assertProps $ Set.toList props
+      -- if debug is on, write the query to a file
+      when opts.debug $ TL.writeFile
+        ("query-" <> show idx <> ".smt2") (formatSMT2 smt <> "\n\n(check-sat)")
+
       ku <- readTVarIO knownUnsat
       res <- if subsetAny props ku
              then pure (True, Unsat)
@@ -723,7 +727,8 @@ equivalenceCheck' solvers branchesA branchesB opts = do
     checkAll :: [(Set Prop)] -> UnsatCache -> Int -> IO [(EquivResult, Bool)]
     checkAll input cache numproc = do
        wrap <- pool numproc
-       parMapIO (wrap . (check cache)) input
+       parMapIO (wrap . (uncurry $ check cache)) $ zip input [1..]
+
 
     -- Takes two branches and returns a set of props that will need to be
     -- satisfied for the two branches to violate the equivalence check. i.e.

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -698,7 +698,7 @@ equivalenceCheck' solvers branchesA branchesB opts = do
       let smt = assertProps $ Set.toList props
       -- if debug is on, write the query to a file
       when opts.debug $ TL.writeFile
-        ("query-" <> show idx <> ".smt2") (formatSMT2 smt <> "\n\n(check-sat)")
+        ("equiv-query-" <> show idx <> ".smt2") (formatSMT2 smt <> "\n\n(check-sat)")
 
       ku <- readTVarIO knownUnsat
       res <- if subsetAny props ku


### PR DESCRIPTION
## Description

This PR adds assertions for the range of environment variables that are less than word size (256bits). This was necessary for equivalence proofs with Act code. 

Also, it adds some code to print SMT queries generated by the equivalence checker when debug flag is on.

## Checklist

- [X] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [X] updated the changelog
