### PR TITLE
Preprocess SMT2 sexpressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - SMT encoding of Expr now has assertions for the range of environment values that are less than word size (256 bits).
 
+## Changed
+- SMT2 scripts are now being reprocessed to put one sexpr per line. Having sepxrs that span across multiple lines triggerd a bug in CVC5. 
 
 ## [0.51.1] - 2023-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<<<<<<< HEAD
 ## Fixed
 - SMT encoding of Expr now has assertions for the range of environment values that are less than word size (256 bits).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 ## Fixed
 - SMT encoding of Expr now has assertions for the range of environment values that are less than word size (256 bits).
 
 ## Changed
-- SMT2 scripts are now being reprocessed to put one sexpr per line. Having sepxrs that span across multiple lines triggerd a bug in CVC5. 
+- SMT2 scripts are now being reprocessed to put one sexpr per line. Having sepxrs that span across multiple lines trigers a bug in CVC5. 
 
 ## [0.51.1] - 2023-06-02
 

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -228,7 +228,7 @@ solverArgs solver timeout = case solver of
     [ "-in" ]
   CVC5 ->
     [ "--lang=smt"
-    , "--no-interactive"
+    -- , "--no-interactive"
     , "--produce-models"
     , "--tlimit-per=" <> mkTimeout timeout
     ]

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -228,7 +228,6 @@ solverArgs solver timeout = case solver of
     [ "-in" ]
   CVC5 ->
     [ "--lang=smt"
-    -- , "--no-interactive"
     , "--produce-models"
     , "--tlimit-per=" <> mkTimeout timeout
     ]


### PR DESCRIPTION
## Description

This PR adds a preprocessing step for SMT2 scripts that strips comments and puts each sexpression in its own line.  Having sepxrs that span across multiple lines triggers a bug in CVC5. 

## Checklist

- [X] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [X] updated the changelog
