### PR TITLE
hevm: enable compact-unwind on macOS

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -206,6 +206,7 @@ executable hevm
   if os(darwin)
     extra-libraries: c++
     ld-options: -Wl,-keep_dwarf_unwind
+    ghc-options: -fcompact-unwind
   else
     extra-libraries: stdc++
   build-depends:
@@ -321,6 +322,7 @@ common test-common
     extra-libraries: c++
     -- https://gitlab.haskell.org/ghc/ghc/-/issues/11829
     ld-options: -Wl,-keep_dwarf_unwind
+    ghc-options: -fcompact-unwind
   else
     extra-libraries: stdc++
 

--- a/test/contracts/pass/unwind.sol
+++ b/test/contracts/pass/unwind.sol
@@ -1,0 +1,31 @@
+import {DSTest} from "ds-test/test.sol";
+
+// tests unwind support in precompiles
+contract Unwind is DSTest {
+    function testInvalidSum() public {
+        bytes32 x = hex"01";
+        try this.callBn256Add(x, x, x, x) returns (bytes32[2] memory) {
+            failed();
+        } catch (bytes memory) { }
+    }
+
+    function callBn256Add(
+        bytes32 ax,
+        bytes32 ay,
+        bytes32 bx,
+        bytes32 by
+    ) external returns (bytes32[2] memory result) {
+        bytes32[4] memory input;
+        input[0] = ax;
+        input[1] = ay;
+        input[2] = bx;
+        input[3] = by;
+        assembly {
+            let success := call(gas(), 0x06, 0, input, 0x80, result, 0x40)
+            switch success
+            case 0 {
+                revert(0, 0)
+            }
+        }
+    }
+}

--- a/test/test.hs
+++ b/test/test.hs
@@ -715,6 +715,9 @@ tests = testGroup "hevm"
         let testFile = "test/contracts/fail/cheatCodes.sol"
         runSolidityTestCustom testFile "testBadFFI" Nothing False Nothing Foundry >>= assertEqual "test result" False
         runSolidityTestCustom testFile "test_prank_underflow" Nothing False Nothing Foundry >>= assertEqual "test result" False
+    , testCase "Unwind" $ do
+        let testFile = "test/contracts/pass/unwind.sol"
+        runSolidityTest testFile ".*" >>= assertEqual "test result" True
     ]
   , testGroup "max-iterations"
     [ testCase "concrete-loops-reached" $ do


### PR DESCRIPTION
## Description

It seems unwinding was not working correctly on arm64 macOS, this appears to fix it.
Refer to https://gitlab.haskell.org/ghc/ghc/-/issues/11829 for further details.

Fixes: #280

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
