### PR TITLE
C++ for Darwin

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -121,8 +121,6 @@ library
     Paths_hevm
   autogen-modules:
     Paths_hevm
-  if os(linux) || os(windows)
-    extra-libraries: stdc++
   if os(darwin)
      extra-libraries: c++
   else

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -121,8 +121,12 @@ library
     Paths_hevm
   autogen-modules:
     Paths_hevm
-  if os(linux) || os(windows) || os(darwin)
+  if os(linux) || os(windows)
     extra-libraries: stdc++
+  if os(darwin)
+     extra-libraries: c++
+  else
+     extra-libraries: stdc++
   extra-libraries:
     secp256k1, ff, gmp
   c-sources:

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -121,7 +121,7 @@ library
     Paths_hevm
   autogen-modules:
     Paths_hevm
-  if os(linux) || os(windows)
+  if os(linux) || os(windows) || os(darwin)
     extra-libraries: stdc++
   extra-libraries:
     secp256k1, ff, gmp


### PR DESCRIPTION
## Description

@msooseth's fix for linking error when linking Act with HEVM. Turns out that C++ libraries were not specified for Darwin.