### PR TITLE
Better error printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SMT encoding of Expr now has assertions for the range of environment values that are less than word size (256 bits).
 - Trace now contains the cheat code calls
+- More consistent error messages
 
 ## Changed
 

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -513,11 +513,11 @@ launchExec cmd = do
               Just path ->
                 Git.saveFacts (Git.RepoAt path) (Facts.cacheFacts vm'.cache)
           _ ->
-            error $ internalError "no EVM result"
+            internalError "no EVM result"
 
       Debug -> void $ TTY.runFromVM solvers rpcinfo Nothing dapp vm
       --JsonTrace -> void $ execStateT (interpretWithTrace fetcher EVM.Stepper.runFully) vm
-      _ -> error $ internalError "TODO"
+      _ -> internalError "TODO"
      where block = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber cmd.block
            rpcinfo = (,) block <$> cmd.rpc
 
@@ -566,7 +566,7 @@ vmFromCommand cmd = do
 
   let ts' = case maybeLitWord ts of
         Just t -> t
-        Nothing -> error $ internalError "unexpected symbolic timestamp when executing vm test"
+        Nothing -> internalError "unexpected symbolic timestamp when executing vm test"
 
   pure $ EVM.Transaction.initTx $ withCache (vm0 baseFee miner ts' blockNum prevRan contract)
     where

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -283,7 +283,7 @@ main = do
                   res <- unitTest testOpts out.contracts cmd.cache
                   unless res exitFailure
                 (False, Debug) -> liftIO $ TTY.main testOpts root (Just out)
-                (False, JsonTrace) -> error "json traces not implemented for dappTest"
+                (False, JsonTrace) -> error $ internalError "json traces not implemented for dappTest"
                 (True, _) -> liftIO $ dappCoverage testOpts (optsMode cmd) out
 
 
@@ -513,11 +513,11 @@ launchExec cmd = do
               Just path ->
                 Git.saveFacts (Git.RepoAt path) (Facts.cacheFacts vm'.cache)
           _ ->
-            error "Internal error: no EVM result"
+            error $ internalError "no EVM result"
 
       Debug -> void $ TTY.runFromVM solvers rpcinfo Nothing dapp vm
       --JsonTrace -> void $ execStateT (interpretWithTrace fetcher EVM.Stepper.runFully) vm
-      _ -> error "TODO"
+      _ -> error $ internalError "TODO"
      where block = maybe EVM.Fetch.Latest EVM.Fetch.BlockNumber cmd.block
            rpcinfo = (,) block <$> cmd.rpc
 
@@ -529,7 +529,7 @@ vmFromCommand cmd = do
   (miner,ts,baseFee,blockNum,prevRan) <- case cmd.rpc of
     Nothing -> pure (0,Lit 0,0,0,0)
     Just url -> EVM.Fetch.fetchBlockFrom block url >>= \case
-      Nothing -> error "Could not fetch block"
+      Nothing -> error "Error: Could not fetch block"
       Just Block{..} -> pure ( coinbase
                              , timestamp
                              , baseFee
@@ -541,7 +541,7 @@ vmFromCommand cmd = do
     (Just url, Just addr', Just c) -> do
       EVM.Fetch.fetchContractFrom block url addr' >>= \case
         Nothing ->
-          error $ "contract not found: " <> show address
+          error $ "Error: contract not found: " <> show address
         Just contract ->
           -- if both code and url is given,
           -- fetch the contract and overwrite the code
@@ -554,7 +554,7 @@ vmFromCommand cmd = do
     (Just url, Just addr', Nothing) ->
       EVM.Fetch.fetchContractFrom block url addr' >>= \case
         Nothing ->
-          error $ "contract not found: " <> show address
+          error $ "Error: contract not found: " <> show address
         Just contract -> pure contract
 
     (_, _, Just c)  ->
@@ -562,11 +562,11 @@ vmFromCommand cmd = do
         initialContract (mkCode $ hexByteString "--code" $ strip0x c)
 
     (_, _, Nothing) ->
-      error "must provide at least (rpc + address) or code"
+      error "Error: must provide at least (rpc + address) or code"
 
   let ts' = case maybeLitWord ts of
         Just t -> t
-        Nothing -> error "unexpected symbolic timestamp when executing vm test"
+        Nothing -> error $ internalError "unexpected symbolic timestamp when executing vm test"
 
   pure $ EVM.Transaction.initTx $ withCache (vm0 baseFee miner ts' blockNum prevRan contract)
     where
@@ -618,7 +618,7 @@ symvmFromCommand cmd calldata = do
   (miner,blockNum,baseFee,prevRan) <- case cmd.rpc of
     Nothing -> pure (0,0,0,0)
     Just url -> EVM.Fetch.fetchBlockFrom block url >>= \case
-      Nothing -> error "Could not fetch block"
+      Nothing -> error "Error: Could not fetch block"
       Just Block{..} -> pure ( coinbase
                              , number
                              , baseFee
@@ -637,7 +637,7 @@ symvmFromCommand cmd calldata = do
     (Just url, Just addr', _) ->
       EVM.Fetch.fetchContractFrom block url addr' >>= \case
         Nothing ->
-          error "contract not found."
+          error "Error: contract not found."
         Just contract' -> pure contract''
           where
             contract'' = case cmd.code of
@@ -654,7 +654,7 @@ symvmFromCommand cmd calldata = do
     (_, _, Just c)  ->
       pure (initialContract . mkCode $ decipher c)
     (_, _, Nothing) ->
-      error "must provide at least (rpc + address) or code"
+      error "Error: must provide at least (rpc + address) or code"
 
   pure $ (EVM.Transaction.initTx $ withCache $ vm0 baseFee miner ts blockNum prevRan calldata callvalue caller contract)
     & set (#env % #storage) store

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -283,7 +283,7 @@ main = do
                   res <- unitTest testOpts out.contracts cmd.cache
                   unless res exitFailure
                 (False, Debug) -> liftIO $ TTY.main testOpts root (Just out)
-                (False, JsonTrace) -> error $ internalError "json traces not implemented for dappTest"
+                (False, JsonTrace) -> internalError "json traces not implemented for dappTest"
                 (True, _) -> liftIO $ dappCoverage testOpts (optsMode cmd) out
 
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -187,7 +187,7 @@ exec1 = do
     mem  = vm.state.memory
     stk  = vm.state.stack
     self = vm.state.contract
-    this = fromMaybe (error $ internalError "state contract") (Map.lookup self vm.env.contracts)
+    this = fromMaybe (internalError "state contract") (Map.lookup self vm.env.contracts)
 
     fees@FeeSchedule {..} = vm.block.schedule
 
@@ -227,7 +227,7 @@ exec1 = do
                   InitCode conc _ -> BS.index conc vm.state.pc
                   RuntimeCode (ConcreteRuntimeCode bs) -> BS.index bs vm.state.pc
                   RuntimeCode (SymbolicRuntimeCode ops) ->
-                    fromMaybe (error $ internalError "could not analyze symbolic code") $
+                    fromMaybe (internalError "could not analyze symbolic code") $
                       maybeLitByte $ ops V.! vm.state.pc
 
       case getOp(?op) of
@@ -741,7 +741,7 @@ exec1 = do
               accessMemoryRange xOffset xSize $ do
                 let
                   output = readMemory xOffset' xSize' vm
-                  codesize = fromMaybe (error $ internalError "processing opcode RETURN. Cannot return dynamically sized abstract data")
+                  codesize = fromMaybe (internalError "processing opcode RETURN. Cannot return dynamically sized abstract data")
                                . maybeLitWord . bufLength $ output
                   maxsize = vm.block.maxCodeSize
                   creation = case vm.frames of
@@ -933,7 +933,7 @@ executePrecompile preCompileAddr gasCap inOffset inSize outOffset outSize xs  = 
   let input = readMemory (Lit inOffset) (Lit inSize) vm
       fees = vm.block.schedule
       cost = costOfPrecompile fees preCompileAddr input
-      notImplemented = error $ internalError "precompile at address " <> show preCompileAddr <> " not yet implemented"
+      notImplemented = internalError $ "precompile at address " <> show preCompileAddr <> " not yet implemented"
       precompileFail = burn (gasCap - cost) $ do
                          assign (#state % #stack) (Lit 0 : xs)
                          pushTrace $ ErrorTrace PrecompileFailure
@@ -1242,7 +1242,7 @@ finalize = do
             Just ops ->
               onContractCode $ RuntimeCode (SymbolicRuntimeCode ops)
     _ ->
-      error $ internalError "Finalising an unfinished tx."
+      internalError "Finalising an unfinished tx."
 
   -- compute and pay the refund to the caller and the
   -- corresponding payment to the miner
@@ -1286,7 +1286,7 @@ loadContract target =
   preuse (#env % #contracts % ix target % #contractcode) >>=
     \case
       Nothing ->
-        error $ internalError "Call target doesn't exist"
+        internalError "Call target doesn't exist"
       Just targetCode -> do
         assign (#state % #contract) target
         assign (#state % #code)     targetCode
@@ -1688,8 +1688,8 @@ create self this xSize xGas' xValue xs newAddr initCode = do
               ConcreteStore s -> ConcreteStore (Map.delete (num newAddr) s)
               AbstractStore -> AbstractStore
               EmptyStore -> EmptyStore
-              SStore {} -> error $ internalError "trying to reset symbolic storage with writes in create"
-              GVar _  -> error $ internalError "unexpected global variable"
+              SStore {} -> internalError "trying to reset symbolic storage with writes in create"
+              GVar _  -> internalError "unexpected global variable"
 
         modifying (#env % #storage) resetStorage
         modifying (#env % #origStorage) (Map.delete (num newAddr))
@@ -1727,9 +1727,9 @@ replaceCode target newCode =
               , nonce = now.nonce
               }
         RuntimeCode _ ->
-          error $ internalError "can't replace code of deployed contract " <> show target
+          internalError $ "can't replace code of deployed contract " <> show target
       Nothing ->
-        error $ internalError "can't replace code of nonexistent contract"
+        internalError "can't replace code of nonexistent contract"
 
 replaceCodeOfSelf :: ContractCode -> EVM ()
 replaceCodeOfSelf newCode = do
@@ -1810,7 +1810,7 @@ finishFrame how = do
             modifying (#state % #gas) (+ remainingGas)
 
       -- Now dispatch on whether we were creating or calling,
-      -- and whether we shall return, revert, or error (six cases).
+      -- and whether we shall return, revert, or internalError(six cases).
       case nextFrame.context of
 
         -- Were we calling?
@@ -1988,7 +1988,7 @@ popTrace :: EVM ()
 popTrace =
   modifying #traces $
     \t -> case Zipper.parent t of
-            Nothing -> error $ internalError "internal error (trace root)"
+            Nothing -> internalError "internal internalError(trace root)"
             Just t' -> Zipper.nextSpace t'
 
 zipperRootForest :: Zipper.TreePos Zipper.Empty a -> Forest a
@@ -2004,15 +2004,15 @@ traceForest' :: Expr End -> Forest Trace
 traceForest' (Success _ (Traces f _) _ _) = f
 traceForest' (Partial _ (Traces f _) _) = f
 traceForest' (Failure _ (Traces f _) _) = f
-traceForest' (ITE {}) = error "Internal Error: ITE does not contain a trace"
-traceForest' (GVar {}) = error "Internal Error: Unexpected GVar"
+traceForest' (ITE {}) = internalError"Internal Error: ITE does not contain a trace"
+traceForest' (GVar {}) = internalError"Internal Error: Unexpected GVar"
 
 traceContext :: Expr End -> Map Addr Contract
 traceContext (Success _ (Traces _ c) _ _) = c
 traceContext (Partial _ (Traces _ c) _) = c
 traceContext (Failure _ (Traces _ c) _) = c
-traceContext (ITE {}) = error "Internal Error: ITE does not contain a trace"
-traceContext (GVar {}) = error "Internal Error: Unexpected GVar"
+traceContext (ITE {}) = internalError"Internal Error: ITE does not contain a trace"
+traceContext (GVar {}) = internalError"Internal Error: Unexpected GVar"
 
 traceTopLog :: [Expr Log] -> EVM ()
 traceTopLog [] = noop
@@ -2020,7 +2020,7 @@ traceTopLog ((LogEntry addr bytes topics) : _) = do
   trace <- withTraceLocation (EventTrace addr bytes topics)
   modifying #traces $
     \t -> Zipper.nextSpace (Zipper.insert (Node trace []) t)
-traceTopLog ((GVar _) : _) = error $ internalError "unexpected global variable"
+traceTopLog ((GVar _) : _) = internalError "unexpected global variable"
 
 -- * Stack manipulation
 
@@ -2094,7 +2094,7 @@ isValidJumpDest vm x = let
     code = vm.state.code
     self = vm.state.codeContract
     contract = fromMaybe
-      (error $ internalError "self not found in current contracts")
+      (internalError "self not found in current contracts")
       (Map.lookup self vm.env.contracts)
     op = case code of
       InitCode ops _ -> BS.indexMaybe ops x
@@ -2143,7 +2143,7 @@ mkOpIxMap (RuntimeCode (SymbolicRuntimeCode ops))
                      then (x' - 0x60 + 1, i + 1, j,     m >> SV.write v i j)
             -- other data --
                      else (0,             i + 1, j + 1, m >> SV.write v i j)
-          _ -> error $ internalError "cannot analyze symbolic code:\nx: " <> show x <> " i: " <> show i <> " j: " <> show j
+          _ -> internalError $ "cannot analyze symbolic code:\nx: " <> show x <> " i: " <> show i <> " j: " <> show j
 
         go v (1, !i, !j, !m) _ =
           {- End of PUSH op. -}   (0,            i + 1, j + 1, m >> SV.write v i j)
@@ -2161,7 +2161,7 @@ vmOp vm =
         RuntimeCode (ConcreteRuntimeCode xs') ->
           (BS.index xs' i, fmap LitByte $ BS.unpack $ BS.drop i xs')
         RuntimeCode (SymbolicRuntimeCode xs') ->
-          ( fromMaybe (error $ internalError "unexpected symbolic code") . maybeLitByte $ xs' V.! i , V.toList $ V.drop i xs')
+          ( fromMaybe (internalError "unexpected symbolic code") . maybeLitByte $ xs' V.! i , V.toList $ V.drop i xs')
   in if (opslen code' < i)
      then Nothing
      else Just (readOp op pushdata)
@@ -2188,7 +2188,7 @@ mkCodeOps contractCode =
         Nothing ->
           mempty
         Just (x, xs') ->
-          let x' = fromMaybe (error $ internalError "unexpected symbolic code argument") $ maybeLitByte x
+          let x' = fromMaybe (internalError "unexpected symbolic code argument") $ maybeLitByte x
               j = opSize x'
           in (i, readOp x' xs') Seq.<| go (i + j) (drop j xs)
 
@@ -2251,7 +2251,7 @@ concreteModexpGasFee input =
 -- Gas cost of precompiles
 costOfPrecompile :: FeeSchedule Word64 -> Addr -> Expr Buf -> Word64
 costOfPrecompile (FeeSchedule {..}) precompileAddr input =
-  let errorDynamicSize = error $ internalError "precompile input cannot have a dynamic size"
+  let errorDynamicSize = internalError "precompile input cannot have a dynamic size"
       inputLen = case input of
                    ConcreteBuf bs -> fromIntegral $ BS.length bs
                    AbstractBuf _ -> errorDynamicSize
@@ -2270,7 +2270,7 @@ costOfPrecompile (FeeSchedule {..}) precompileAddr input =
     -- MODEXP
     0x5 -> case input of
              ConcreteBuf i -> concreteModexpGasFee i
-             _ -> error $ internalError "Unsupported symbolic modexp gas calc "
+             _ -> internalError "Unsupported symbolic modexp gas calc "
     -- ECADD
     0x6 -> g_ecadd
     -- ECMUL
@@ -2280,8 +2280,8 @@ costOfPrecompile (FeeSchedule {..}) precompileAddr input =
     -- BLAKE2
     0x9 -> case input of
              ConcreteBuf i -> g_fround * (num $ asInteger $ lazySlice 0 4 i)
-             _ -> error $ internalError "Unsupported symbolic blake2 gas calc"
-    _ -> error $ internalError "unimplemented precompiled contract " ++ show precompileAddr
+             _ -> internalError "Unsupported symbolic blake2 gas calc"
+    _ -> internalError $ "unimplemented precompiled contract " ++ show precompileAddr
 
 -- Gas cost of memory expansion
 memoryCost :: FeeSchedule Word64 -> Word64 -> Word64

--- a/src/EVM/ABI.hs
+++ b/src/EVM/ABI.hs
@@ -296,7 +296,7 @@ abiTailSize x =
         AbiArrayDynamic _ xs -> 32 + sum ((abiHeadSize <$> xs) <> (abiTailSize <$> xs))
         AbiArray _ _ xs -> sum ((abiHeadSize <$> xs) <> (abiTailSize <$> xs))
         AbiTuple v -> sum ((abiHeadSize <$> v) <> (abiTailSize <$> v))
-        _ -> error $ internalError "impossible"
+        _ -> internalError "impossible"
 
 abiHeadSize :: AbiValue -> Int
 abiHeadSize x =
@@ -312,7 +312,7 @@ abiHeadSize x =
         AbiTuple v   -> sum (abiHeadSize <$> v)
         AbiArray _ _ xs -> sum (abiHeadSize <$> xs)
         AbiFunction _ -> 32
-        _ -> error $ internalError "impossible"
+        _ -> internalError "impossible"
 
 putAbiSeq :: Vector AbiValue -> Put
 putAbiSeq xs =
@@ -392,7 +392,7 @@ pack32 n xs =
 asUInt :: Integral i => Int -> (i -> a) -> Get a
 asUInt n f = y <$> getAbi (AbiUIntType n)
   where y (AbiUInt _ x) = f (fromIntegral x)
-        y _ = error $ internalError "can't happen"
+        y _ = internalError "can't happen"
 
 getWord256 :: Get Word256
 getWord256 = pack32 8 <$> replicateM 8 getWord32be
@@ -498,7 +498,7 @@ instance Read Boolz where
 makeAbiValue :: AbiType -> String -> AbiValue
 makeAbiValue typ str = case readP_to_S (parseAbiValue typ) (padStr str) of
   [(val,"")] -> val
-  _ -> error $ internalError "could not parse abi argument: " ++ str ++ " : " ++ show typ
+  _ -> internalError $ "could not parse abi argument: " ++ str ++ " : " ++ show typ
   where
     padStr = case typ of
       (AbiBytesType n) -> padRight' (2 * n + 2) -- +2 is for the 0x prefix
@@ -525,7 +525,7 @@ parseAbiValue (AbiArrayDynamicType typ) =
 parseAbiValue (AbiArrayType n typ) =
   AbiArray n typ <$> do a <- listP (parseAbiValue typ)
                         pure $ Vector.fromList a
-parseAbiValue (AbiTupleType _) = error $ internalError "tuple types not supported"
+parseAbiValue (AbiTupleType _) = internalError "tuple types not supported"
 parseAbiValue AbiFunctionType = AbiFunction <$> do ByteStringS bytes <- bytesP
                                                    pure bytes
 

--- a/src/EVM/Assembler.hs
+++ b/src/EVM/Assembler.hs
@@ -94,15 +94,15 @@ assemble os = V.fromList $ concatMap go os
       OpDup n ->
         if 1 <= n && n <= 16
         then [LitByte (0x80 + (n - 1))]
-        else error $ "Internal Error: invalid argument to OpDup: " <> show n
+        else error $ internalError "invalid argument to OpDup: " <> show n
       OpSwap n ->
         if 1 <= n && n <= 16
         then [LitByte (0x90 + (n - 1))]
-        else error $ "Internal Error: invalid argument to OpSwap: " <> show n
+        else error $ internalError "invalid argument to OpSwap: " <> show n
       OpLog n ->
         if 0 <= n && n <= 4
         then [LitByte (0xA0 + n)]
-        else error $ "Internal Error: invalid argument to OpLog: " <> show n
+        else error $ internalError "invalid argument to OpLog: " <> show n
       -- we just always assemble OpPush into PUSH32
       OpPush wrd -> (LitByte 0x7f) : [Expr.indexWord (Lit i) wrd | i <- [0..31]]
       OpPush0 -> [LitByte 0x5f]

--- a/src/EVM/Assembler.hs
+++ b/src/EVM/Assembler.hs
@@ -94,15 +94,15 @@ assemble os = V.fromList $ concatMap go os
       OpDup n ->
         if 1 <= n && n <= 16
         then [LitByte (0x80 + (n - 1))]
-        else error $ internalError "invalid argument to OpDup: " <> show n
+        else internalError $ "invalid argument to OpDup: " <> show n
       OpSwap n ->
         if 1 <= n && n <= 16
         then [LitByte (0x90 + (n - 1))]
-        else error $ internalError "invalid argument to OpSwap: " <> show n
+        else internalError $ "invalid argument to OpSwap: " <> show n
       OpLog n ->
         if 0 <= n && n <= 4
         then [LitByte (0xA0 + n)]
-        else error $ internalError "invalid argument to OpLog: " <> show n
+        else internalError $ "invalid argument to OpLog: " <> show n
       -- we just always assemble OpPush into PUSH32
       OpPush wrd -> (LitByte 0x7f) : [Expr.indexWord (Lit i) wrd | i <- [0..31]]
       OpPush0 -> [LitByte 0x5f]

--- a/src/EVM/Dev.hs
+++ b/src/EVM/Dev.hs
@@ -51,7 +51,7 @@ runDappTest root =
 testOpts :: SolverGroup -> FilePath -> FilePath -> IO UnitTestOptions
 testOpts solvers root testFile = do
   srcInfo <- readSolc DappTools root testFile >>= \case
-    Left e -> error e
+    Left e -> error $ internalError e
     Right out ->
       pure $ dappInfo root out
 

--- a/src/EVM/Dev.hs
+++ b/src/EVM/Dev.hs
@@ -51,7 +51,7 @@ runDappTest root =
 testOpts :: SolverGroup -> FilePath -> FilePath -> IO UnitTestOptions
 testOpts solvers root testFile = do
   srcInfo <- readSolc DappTools root testFile >>= \case
-    Left e -> error $ internalError e
+    Left e -> internalError e
     Right out ->
       pure $ dappInfo root out
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -415,7 +415,7 @@ bufLengthEnv env useEnv buf = go (Lit 0) buf
     go l (GVar (BufVar a)) | useEnv =
       case Map.lookup a env of
         Just b -> go l b
-        Nothing -> error "Internal error: cannot compute length of open expression"
+        Nothing -> error $ internalError "cannot compute length of open expression"
     go l (GVar (BufVar a)) = EVM.Expr.max l (BufLength (GVar (BufVar a)))
 
 -- | If a buffer has a concrete prefix, we return it's length here
@@ -437,10 +437,10 @@ concPrefix (CopySlice (Lit srcOff) (Lit _) (Lit _) src (ConcreteBuf "")) = do
     -- writes to an abstract index are ignored
     go l (WriteWord _ _ b) = go l b
     go l (WriteByte _ _ b) = go l b
-    go _ (CopySlice _ _ _ _ _) = error "Internal Error: cannot compute a concrete prefix length for nested copySlice expressions"
-    go _ (GVar _) = error "Internal error: cannot calculate a concrete prefix of an open expression"
+    go _ (CopySlice _ _ _ _ _) = error $ internalError "cannot compute a concrete prefix length for nested copySlice expressions"
+    go _ (GVar _) = error $ internalError "cannot calculate a concrete prefix of an open expression"
 concPrefix (ConcreteBuf b) = Just (num . BS.length $ b)
-concPrefix e = error $ "Internal error: cannot compute a concrete prefix length for: " <> show e
+concPrefix e = error $ internalError "cannot compute a concrete prefix length for: " <> show e
 
 
 -- | Return the minimum possible length of a buffer. In the case of an
@@ -489,7 +489,7 @@ toList (ConcreteBuf bs) = Just $ V.fromList $ LitByte <$> BS.unpack bs
 toList buf = case bufLength buf of
   Lit l -> if l <= num (maxBound :: Int)
               then Just $ V.generate (num l) (\i -> readByte (Lit $ num i) buf)
-              else error "Internal Error: overflow when converting buffer to list"
+              else error $ internalError "overflow when converting buffer to list"
   _ -> Nothing
 
 fromList :: V.Vector (Expr Byte) -> Expr Buf
@@ -553,7 +553,7 @@ stripWrites off size = \case
   WriteByte i v prev -> WriteByte i v (stripWrites off size prev)
   WriteWord i v prev -> WriteWord i v (stripWrites off size prev)
   CopySlice srcOff dstOff size' src dst -> CopySlice srcOff dstOff size' src dst
-  GVar _ ->  error "unexpected GVar in stripWrites"
+  GVar _ ->  error $ internalError "unexpected GVar in stripWrites"
 
 
 -- ** Storage ** -----------------------------------------------------------------------------------
@@ -590,7 +590,7 @@ readStorage addr' slot' s@(SStore addr slot val prev) =
     (Lit _, Lit _) -> readStorage addr' slot' prev
     -- if the the addresses don't match syntactically and are abstract then we can't skip this write
     _ -> Just $ SLoad addr' slot' s
-readStorage _ _ (GVar _) = error "Can't read from a GVar"
+readStorage _ _ (GVar _) = error $ internalError "Can't read from a GVar"
 
 readStorage' :: Expr EWord -> Expr EWord -> Expr Storage -> Expr EWord
 readStorage' addr loc store = case readStorage addr loc store of

--- a/src/EVM/Facts.hs
+++ b/src/EVM/Facts.hs
@@ -139,7 +139,7 @@ vmFacts vm = Set.fromList $ do
   case vm.env.storage of
     EmptyStore -> contractFacts k v Map.empty
     ConcreteStore s -> contractFacts k v s
-    _ -> error "cannot serialize an abstract store"
+    _ -> error $ internalError "cannot serialize an abstract store"
 
 -- Somewhat stupidly, this function demands that for each contract,
 -- the code fact for that contract comes before the other facts for

--- a/src/EVM/Facts.hs
+++ b/src/EVM/Facts.hs
@@ -139,7 +139,7 @@ vmFacts vm = Set.fromList $ do
   case vm.env.storage of
     EmptyStore -> contractFacts k v Map.empty
     ConcreteStore s -> contractFacts k v s
-    _ -> error $ internalError "cannot serialize an abstract store"
+    _ -> internalError "cannot serialize an abstract store"
 
 -- Somewhat stupidly, this function demands that for each contract,
 -- the code fact for that contract comes before the other facts for

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -125,7 +125,7 @@ parseBlock j = do
      (Just p, _, _) -> p
      (Nothing, Just mh, Just 0x0) -> mh
      (Nothing, Just _, Just d) -> d
-     _ -> error $ internalError "block contains both difficulty and prevRandao"
+     _ -> internalError "block contains both difficulty and prevRandao"
   -- default codesize, default gas limit, default feescedule
   pure $ Block coinbase timestamp number prd gasLimit (fromMaybe 0 baseFee) 0xffffffff FeeSchedule.berlin
 
@@ -200,7 +200,7 @@ oracle solvers info q = do
           (_, stdout', _) <- readProcessWithExitCode cmd args ""
           pure . continue . encodeAbiValue $
             AbiTuple (RegularVector.fromList [ AbiBytesDynamic . hexText . pack $ stdout'])
-       _ -> error $ internalError (show vals)
+       _ -> internalError (show vals)
 
     PleaseAskSMT branchcondition pathconditions continue -> do
          let pathconds = foldl' PAnd (PBool True) pathconditions
@@ -215,7 +215,7 @@ oracle solvers info q = do
                     Just (n, url) -> fetchContractFrom n url addr
       case contract of
         Just x -> pure $ continue x
-        Nothing -> error $ internalError "oracle error: " ++ show q
+        Nothing -> internalError $ "oracle error: " ++ show q
 
     PleaseFetchSlot addr slot continue ->
       case info of
@@ -224,7 +224,7 @@ oracle solvers info q = do
          fetchSlotFrom n url addr (fromIntegral slot) >>= \case
            Just x  -> pure (continue x)
            Nothing ->
-             error $ internalError "oracle error: " ++ show q
+             internalError $ "oracle error: " ++ show q
 
 type Fetcher = Query -> IO (EVM ())
 
@@ -251,4 +251,4 @@ checkBranch solvers branchcondition pathconditions = do
         Error e -> error $ "Internal Error: SMT Solver pureed with an error: " <> T.unpack e
     -- If the query times out, we simply explore both paths
     EVM.Solvers.Unknown -> pure EVM.Types.Unknown
-    Error e -> error $ internalError "SMT Solver pureed with an error: " <> T.unpack e
+    Error e -> internalError $ "SMT Solver pureed with an error: " <> T.unpack e

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -125,7 +125,7 @@ parseBlock j = do
      (Just p, _, _) -> p
      (Nothing, Just mh, Just 0x0) -> mh
      (Nothing, Just _, Just d) -> d
-     _ -> error "Internal Error: block contains both difficulty and prevRandao"
+     _ -> error $ internalError "block contains both difficulty and prevRandao"
   -- default codesize, default gas limit, default feescedule
   pure $ Block coinbase timestamp number prd gasLimit (fromMaybe 0 baseFee) 0xffffffff FeeSchedule.berlin
 
@@ -200,7 +200,7 @@ oracle solvers info q = do
           (_, stdout', _) <- readProcessWithExitCode cmd args ""
           pure . continue . encodeAbiValue $
             AbiTuple (RegularVector.fromList [ AbiBytesDynamic . hexText . pack $ stdout'])
-       _ -> error (show vals)
+       _ -> error $ internalError (show vals)
 
     PleaseAskSMT branchcondition pathconditions continue -> do
          let pathconds = foldl' PAnd (PBool True) pathconditions
@@ -215,7 +215,7 @@ oracle solvers info q = do
                     Just (n, url) -> fetchContractFrom n url addr
       case contract of
         Just x -> pure $ continue x
-        Nothing -> error ("oracle error: " ++ show q)
+        Nothing -> error $ internalError "oracle error: " ++ show q
 
     PleaseFetchSlot addr slot continue ->
       case info of
@@ -224,7 +224,7 @@ oracle solvers info q = do
          fetchSlotFrom n url addr (fromIntegral slot) >>= \case
            Just x  -> pure (continue x)
            Nothing ->
-             error ("oracle error: " ++ show q)
+             error $ internalError "oracle error: " ++ show q
 
 type Fetcher = Query -> IO (EVM ())
 
@@ -251,4 +251,4 @@ checkBranch solvers branchcondition pathconditions = do
         Error e -> error $ "Internal Error: SMT Solver pureed with an error: " <> T.unpack e
     -- If the query times out, we simply explore both paths
     EVM.Solvers.Unknown -> pure EVM.Types.Unknown
-    Error e -> error $ "Internal Error: SMT Solver pureed with an error: " <> T.unpack e
+    Error e -> error $ internalError "SMT Solver pureed with an error: " <> T.unpack e

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -184,7 +184,7 @@ formatBinary =
 formatSBinary :: Expr Buf -> Text
 formatSBinary (ConcreteBuf bs) = formatBinary bs
 formatSBinary (AbstractBuf t) = "<" <> t <> " abstract buf>"
-formatSBinary _ = error "formatSBinary: implement me"
+formatSBinary _ = error $ internalError "formatSBinary: implement me"
 
 showTraceTree :: DappInfo -> VM -> Text
 showTraceTree dapp vm =
@@ -398,7 +398,7 @@ prettyvmresult (Success _ _ _ _) =
   "Return: <symbolic>"
 prettyvmresult (Failure _ _ err) = prettyError err
 prettyvmresult (Partial _ _ p) = T.unpack $ formatPartial p
-prettyvmresult r = error $ "Internal Error: Invalid result: " <> show r
+prettyvmresult r = error $ internalError "Invalid result: " <> show r
 
 indent :: Int -> Text -> Text
 indent n = rstrip . T.unlines . fmap (T.replicate n (T.pack [' ']) <>) . T.lines
@@ -592,13 +592,13 @@ hexByteString :: String -> ByteString -> ByteString
 hexByteString msg bs =
   case BS16.decodeBase16 bs of
     Right x -> x
-    _ -> error ("invalid hex bytestring for " ++ msg)
+    _ -> error $ internalError "invalid hex bytestring for " ++ msg
 
 hexText :: Text -> ByteString
 hexText t =
   case BS16.decodeBase16 (T.encodeUtf8 (T.drop 2 t)) of
     Right x -> x
-    _ -> error ("invalid hex bytestring " ++ show t)
+    _ -> error $ internalError "invalid hex bytestring " ++ show t
 
 bsToHex :: ByteString -> String
 bsToHex bs = concatMap (paddedShowHex 2) (BS.unpack bs)

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -184,7 +184,7 @@ formatBinary =
 formatSBinary :: Expr Buf -> Text
 formatSBinary (ConcreteBuf bs) = formatBinary bs
 formatSBinary (AbstractBuf t) = "<" <> t <> " abstract buf>"
-formatSBinary _ = error $ internalError "formatSBinary: implement me"
+formatSBinary _ = internalError "formatSBinary: implement me"
 
 showTraceTree :: DappInfo -> VM -> Text
 showTraceTree dapp vm =
@@ -398,7 +398,7 @@ prettyvmresult (Success _ _ _ _) =
   "Return: <symbolic>"
 prettyvmresult (Failure _ _ err) = prettyError err
 prettyvmresult (Partial _ _ p) = T.unpack $ formatPartial p
-prettyvmresult r = error $ internalError "Invalid result: " <> show r
+prettyvmresult r = internalError $ "Invalid result: " <> show r
 
 indent :: Int -> Text -> Text
 indent n = rstrip . T.unlines . fmap (T.replicate n (T.pack [' ']) <>) . T.lines
@@ -592,13 +592,13 @@ hexByteString :: String -> ByteString -> ByteString
 hexByteString msg bs =
   case BS16.decodeBase16 bs of
     Right x -> x
-    _ -> error $ internalError "invalid hex bytestring for " ++ msg
+    _ -> internalError $ "invalid hex bytestring for " ++ msg
 
 hexText :: Text -> ByteString
 hexText t =
   case BS16.decodeBase16 (T.encodeUtf8 (T.drop 2 t)) of
     Right x -> x
-    _ -> error $ internalError "invalid hex bytestring " ++ show t
+    _ -> internalError $ "invalid hex bytestring " ++ show t
 
 bsToHex :: ByteString -> String
 bsToHex bs = concatMap (paddedShowHex 2) (BS.unpack bs)

--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -51,12 +51,12 @@ combine lst = combine' lst []
 
 minProp :: Expr EWord -> Prop
 minProp k@(Keccak _) = PGT k (Lit 50)
-minProp _ = error $ internalError "expected keccak expression"
+minProp _ = internalError "expected keccak expression"
 
 injProp :: (Expr EWord, Expr EWord) -> Prop
 injProp (k1@(Keccak b1), k2@(Keccak b2)) =
   POr (PEq b1 b2) (PNeg (PEq k1 k2))
-injProp _ = error $ internalError "expected keccak expression"
+injProp _ = internalError "expected keccak expression"
 
 -- Takes a list of props, find all keccak occurences and generates two kinds of assumptions:
 --   1. Minimum output value: That the output of the invocation is greater than

--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -51,12 +51,12 @@ combine lst = combine' lst []
 
 minProp :: Expr EWord -> Prop
 minProp k@(Keccak _) = PGT k (Lit 50)
-minProp _ = error "Internal error: expected keccak expression"
+minProp _ = error $ internalError "expected keccak expression"
 
 injProp :: (Expr EWord, Expr EWord) -> Prop
 injProp (k1@(Keccak b1), k2@(Keccak b2)) =
   POr (PEq b1 b2) (PNeg (PEq k1 k2))
-injProp _ = error "Internal error: expected keccak expression"
+injProp _ = error $ internalError "expected keccak expression"
 
 -- Takes a list of props, find all keccak occurences and generates two kinds of assumptions:
 --   1. Minimum output value: That the output of the invocation is greater than

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -205,9 +205,9 @@ referencedFrameContextGo = \case
   CallValue a -> [(fromLazyText $ T.append "callvalue_" (T.pack . show $ a), [])]
   Caller a -> [(fromLazyText $ T.append "caller_" (T.pack . show $ a), [inRange 160 (Caller a)])]
   Address a -> [(fromLazyText $ T.append "address_" (T.pack . show $ a), [inRange 160 (Address a)])]
-  Balance {} -> error $ internalError "TODO: BALANCE"
-  SelfBalance {} -> error $ internalError "TODO: SELFBALANCE"
-  Gas {} -> error $ internalError "TODO: GAS"
+  Balance {} -> internalError "TODO: BALANCE"
+  SelfBalance {} -> internalError "TODO: SELFBALANCE"
+  Gas {} -> internalError "TODO: GAS"
   _ -> []
 
 referencedFrameContext :: Expr a -> [(Builder, [Prop])]
@@ -272,7 +272,7 @@ assertReads props benv senv = concatMap assertRead allReads
     assertRead :: (Expr EWord, Expr EWord, Expr Buf) -> [Prop]
     assertRead (idx, Lit 32, buf) = [PImpl (PGEq idx (bufLength buf)) (PEq (ReadWord idx buf) (Lit 0))]
     assertRead (idx, Lit sz, buf) = fmap (\s -> PImpl (PGEq idx (bufLength buf)) (PEq (ReadByte idx buf) (LitByte (num s)))) [(0::Int)..num sz-1]
-    assertRead (_, _, _) = error $ internalError "Cannot generate assertions for accesses of symbolic size"
+    assertRead (_, _, _) = internalError "Cannot generate assertions for accesses of symbolic size"
 
     allReads = filter keepRead $ nubOrd $ findBufferAccess props <> findBufferAccess (Map.elems benv) <> findBufferAccess (Map.elems senv)
 
@@ -305,7 +305,7 @@ discoverMaxReads props benv senv = bufMap
     baseBuf (GVar (BufVar a)) =
       case Map.lookup a benv of
         Just b -> baseBuf b
-        Nothing -> error $ internalError "could not find buffer variable"
+        Nothing -> internalError "could not find buffer variable"
     baseBuf (WriteByte _ _ b) = baseBuf b
     baseBuf (WriteWord _ _ b) = baseBuf b
     baseBuf (CopySlice _ _ _ _ dst)= baseBuf dst
@@ -583,7 +583,7 @@ exprToSMT = \case
   Mul a b -> op2 "bvmul" a b
   Exp a b -> case b of
                Lit b' -> expandExp a b'
-               _ -> error $ internalError "cannot encode symbolic exponentation into SMT"
+               _ -> internalError "cannot encode symbolic exponentation into SMT"
   Min a b ->
     let aenc = exprToSMT a
         benc = exprToSMT b in
@@ -711,7 +711,7 @@ exprToSMT = \case
     "(sstore" `sp` encAddr `sp` encIdx `sp` encVal `sp` encPrev <> ")"
   SLoad addr idx store -> op3 "sload" addr idx store
 
-  a -> error $ internalError "TODO: implement: " <> show a
+  a -> internalError $ "TODO: implement: " <> show a
   where
     op1 op a =
       let enc =  exprToSMT a in
@@ -783,7 +783,7 @@ copySlice srcOffset dstOffset size@(Lit _) src dst
         encSrcOff = exprToSMT (Expr.add srcOffset size')
         child = copySlice srcOffset dstOffset size' src dst in
     "(store " <> child `sp` encDstOff `sp` "(select " <> src `sp` encSrcOff <> "))"
-copySlice _ _ _ _ _ = error $ internalError "TODO: implement copySlice with a symbolically sized region"
+copySlice _ _ _ _ _ = internalError "TODO: implement copySlice with a symbolically sized region"
 
 -- | Unrolls an exponentiation into a series of multiplications
 expandExp :: Expr EWord -> W256 -> Builder
@@ -847,10 +847,10 @@ parseW8 = parseSC
 parseSC :: (Num a, Eq a) => SpecConstant -> a
 parseSC (SCHexadecimal a) = fst . head . Numeric.readHex . T.unpack . T.fromStrict $ a
 parseSC (SCBinary a) = fst . head . Numeric.readBin . T.unpack . T.fromStrict $ a
-parseSC sc = error $ internalError "cannot parse: " <> show sc
+parseSC sc = internalError $ "cannot parse: " <> show sc
 
 parseErr :: (Show a) => a -> b
-parseErr res = error $ internalError "cannot parse solver response: " <> show res
+parseErr res = internalError $ "cannot parse solver response: " <> show res
 
 parseVar :: TS.Text -> Expr EWord
 parseVar = Var
@@ -864,14 +864,14 @@ parseBlockCtx "prevrandao" = PrevRandao
 parseBlockCtx "gaslimit" = GasLimit
 parseBlockCtx "chainid" = ChainId
 parseBlockCtx "basefee" = BaseFee
-parseBlockCtx t = error $ internalError "cannot parse " <> (TS.unpack t) <> " into an Expr"
+parseBlockCtx t = internalError $ "cannot parse " <> (TS.unpack t) <> " into an Expr"
 
 parseFrameCtx :: TS.Text -> Expr EWord
 parseFrameCtx name = case TS.unpack name of
   ('c':'a':'l':'l':'v':'a':'l':'u':'e':'_':frame) -> CallValue (read frame)
   ('c':'a':'l':'l':'e':'r':'_':frame) -> Caller (read frame)
   ('a':'d':'d':'r':'e':'s':'s':'_':frame) -> Address (read frame)
-  t -> error $ internalError "cannot parse " <> t <> " into an Expr"
+  t -> internalError $ "cannot parse " <> t <> " into an Expr"
 
 getVars :: (TS.Text -> Expr EWord) -> (Text -> IO Text) -> [TS.Text] -> IO (Map (Expr EWord) W256)
 getVars parseFn getVal names = Map.mapKeys parseFn <$> foldM getOne mempty names
@@ -889,7 +889,7 @@ getVars parseFn getVal names = Map.mapKeys parseFn <$> foldM getOne mempty names
             TermSpecConstant sc)
               -> if symbol == name
                  then parseW256 sc
-                 else error $ internalError "solver did not return model for requested value"
+                 else internalError "solver did not return model for requested value"
           r -> parseErr r
       pure $ Map.insert name val acc
 
@@ -910,7 +910,7 @@ getBufs getVal bufs = foldM getBuf mempty bufs
           (TermQualIdentifier (Unqualified (IdSymbol symbol)), (TermSpecConstant sc))
             -> if symbol == (T.toStrict $ name <> "_length")
                then parseW256 sc
-               else error $ internalError "solver did not return model for requested value"
+               else internalError "solver did not return model for requested value"
           res -> parseErr res
         res -> parseErr res
 
@@ -924,9 +924,9 @@ getBufs getVal bufs = foldM getBuf mempty bufs
           (TermQualIdentifier (Unqualified (IdSymbol symbol)), term)
             -> if (T.fromStrict symbol) == name
                then pure $ parseBuf len term
-               else error $ internalError "solver did not return model for requested value"
-          res -> error $ internalError "cannot parse solver response: " <> show res
-        res -> error $ internalError "cannot parse solver response: " <> show res
+               else internalError "solver did not return model for requested value"
+          res -> internalError $ "cannot parse solver response: " <> show res
+        res -> internalError $ "cannot parse solver response: " <> show res
       pure $ Map.insert (AbstractBuf $ T.toStrict name) buf acc
 
     parseBuf :: W256 -> Term -> BufModel
@@ -963,7 +963,7 @@ getBufs getVal bufs = foldM getBuf mempty bufs
           -- looking up a bound name
           (TermQualIdentifier (Unqualified (IdSymbol name))) -> case Map.lookup name env of
             Just t -> t
-            Nothing -> error $ internalError "could not find "
+            Nothing -> internalError $ "could not find "
                             <> (TS.unpack name)
                             <> " in environment mapping"
           p -> parseErr p
@@ -979,7 +979,7 @@ getStore getVal sreads = do
               (TermQualIdentifier (Unqualified (IdSymbol symbol)), term) ->
                 if symbol == "abstractStore"
                 then interpret2DArray Map.empty term
-                else error $ internalError "solver did not return model for requested value"
+                else internalError "solver did not return model for requested value"
               r -> parseErr r
 
   -- then create a map by adding only the locations that are read by the program
@@ -1006,7 +1006,7 @@ queryValue getVal w = do
     Right (ResSpecific (valParsed :| [])) ->
       case valParsed of
         (_, TermSpecConstant sc) -> pure $ parseW256 sc
-        _ -> error $ internalError "cannot parse model for: " <> show w
+        _ -> internalError $ "cannot parse model for: " <> show w
     r -> parseErr r
 
 
@@ -1019,7 +1019,7 @@ interpretNDArray interp env = \case
   TermQualIdentifier (Unqualified (IdSymbol s)) ->
     case Map.lookup s env of
       Just t -> interpretNDArray interp env t
-      Nothing -> error $ internalError "unknown identifier, cannot parse array"
+      Nothing -> internalError "unknown identifier, cannot parse array"
   -- (let (x t') t)
   TermLet (VarBinding x t' :| []) t -> interpretNDArray interp (Map.insert x t' env) t
   TermLet (VarBinding x t' :| lets) t -> interpretNDArray interp (Map.insert x t' env) (TermLet (NonEmpty.fromList lets) t)
@@ -1029,7 +1029,7 @@ interpretNDArray interp env = \case
   -- (store arr ind val)
   TermApplication store (arr :| [TermSpecConstant ind, val]) | isStore store ->
     \x -> if x == parseW256 ind then interp env val else interpretNDArray interp env arr x
-  t -> error $ internalError "cannot parse array value. Unexpected term: " <> (show t)
+  t -> internalError $ "cannot parse array value. Unexpected term: " <> (show t)
 
   where
     isArrConst :: QualIdentifier -> Bool
@@ -1050,8 +1050,8 @@ interpret1DArray = interpretNDArray interpretW256
     interpretW256 env (TermQualIdentifier (Unqualified (IdSymbol s))) =
       case Map.lookup s env of
         Just t -> interpretW256 env t
-        Nothing -> error $ internalError "unknown identifier, cannot parse array"
-    interpretW256 _ t = error $ internalError "cannot parse array value. Unexpected term: " <> (show t)
+        Nothing -> internalError "unknown identifier, cannot parse array"
+    interpretW256 _ t = internalError $ "cannot parse array value. Unexpected term: " <> (show t)
 
 -- | Interpret an 2-dimensional array as a function
 interpret2DArray :: (Map Symbol Term) -> Term -> (W256 -> W256 -> W256)

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -205,9 +205,9 @@ referencedFrameContextGo = \case
   CallValue a -> [(fromLazyText $ T.append "callvalue_" (T.pack . show $ a), [])]
   Caller a -> [(fromLazyText $ T.append "caller_" (T.pack . show $ a), [inRange 160 (Caller a)])]
   Address a -> [(fromLazyText $ T.append "address_" (T.pack . show $ a), [inRange 160 (Address a)])]
-  Balance {} -> error "TODO: BALANCE"
-  SelfBalance {} -> error "TODO: SELFBALANCE"
-  Gas {} -> error "TODO: GAS"
+  Balance {} -> error $ internalError "TODO: BALANCE"
+  SelfBalance {} -> error $ internalError "TODO: SELFBALANCE"
+  Gas {} -> error $ internalError "TODO: GAS"
   _ -> []
 
 referencedFrameContext :: Expr a -> [(Builder, [Prop])]
@@ -272,7 +272,7 @@ assertReads props benv senv = concatMap assertRead allReads
     assertRead :: (Expr EWord, Expr EWord, Expr Buf) -> [Prop]
     assertRead (idx, Lit 32, buf) = [PImpl (PGEq idx (bufLength buf)) (PEq (ReadWord idx buf) (Lit 0))]
     assertRead (idx, Lit sz, buf) = fmap (\s -> PImpl (PGEq idx (bufLength buf)) (PEq (ReadByte idx buf) (LitByte (num s)))) [(0::Int)..num sz-1]
-    assertRead (_, _, _) = error "Cannot generate assertions for accesses of symbolic size"
+    assertRead (_, _, _) = error $ internalError "Cannot generate assertions for accesses of symbolic size"
 
     allReads = filter keepRead $ nubOrd $ findBufferAccess props <> findBufferAccess (Map.elems benv) <> findBufferAccess (Map.elems senv)
 
@@ -305,7 +305,7 @@ discoverMaxReads props benv senv = bufMap
     baseBuf (GVar (BufVar a)) =
       case Map.lookup a benv of
         Just b -> baseBuf b
-        Nothing -> error "Internal error: could not find buffer variable"
+        Nothing -> error $ internalError "could not find buffer variable"
     baseBuf (WriteByte _ _ b) = baseBuf b
     baseBuf (WriteWord _ _ b) = baseBuf b
     baseBuf (CopySlice _ _ _ _ dst)= baseBuf dst
@@ -583,7 +583,7 @@ exprToSMT = \case
   Mul a b -> op2 "bvmul" a b
   Exp a b -> case b of
                Lit b' -> expandExp a b'
-               _ -> error "cannot encode symbolic exponentation into SMT"
+               _ -> error $ internalError "cannot encode symbolic exponentation into SMT"
   Min a b ->
     let aenc = exprToSMT a
         benc = exprToSMT b in
@@ -711,7 +711,7 @@ exprToSMT = \case
     "(sstore" `sp` encAddr `sp` encIdx `sp` encVal `sp` encPrev <> ")"
   SLoad addr idx store -> op3 "sload" addr idx store
 
-  a -> error $ "TODO: implement: " <> show a
+  a -> error $ internalError "TODO: implement: " <> show a
   where
     op1 op a =
       let enc =  exprToSMT a in
@@ -783,7 +783,7 @@ copySlice srcOffset dstOffset size@(Lit _) src dst
         encSrcOff = exprToSMT (Expr.add srcOffset size')
         child = copySlice srcOffset dstOffset size' src dst in
     "(store " <> child `sp` encDstOff `sp` "(select " <> src `sp` encSrcOff <> "))"
-copySlice _ _ _ _ _ = error "TODO: implement copySlice with a symbolically sized region"
+copySlice _ _ _ _ _ = error $ internalError "TODO: implement copySlice with a symbolically sized region"
 
 -- | Unrolls an exponentiation into a series of multiplications
 expandExp :: Expr EWord -> W256 -> Builder
@@ -847,10 +847,10 @@ parseW8 = parseSC
 parseSC :: (Num a, Eq a) => SpecConstant -> a
 parseSC (SCHexadecimal a) = fst . head . Numeric.readHex . T.unpack . T.fromStrict $ a
 parseSC (SCBinary a) = fst . head . Numeric.readBin . T.unpack . T.fromStrict $ a
-parseSC sc = error $ "Internal Error: cannot parse: " <> show sc
+parseSC sc = error $ internalError "cannot parse: " <> show sc
 
 parseErr :: (Show a) => a -> b
-parseErr res = error $ "Internal Error: cannot parse solver response: " <> show res
+parseErr res = error $ internalError "cannot parse solver response: " <> show res
 
 parseVar :: TS.Text -> Expr EWord
 parseVar = Var
@@ -864,14 +864,14 @@ parseBlockCtx "prevrandao" = PrevRandao
 parseBlockCtx "gaslimit" = GasLimit
 parseBlockCtx "chainid" = ChainId
 parseBlockCtx "basefee" = BaseFee
-parseBlockCtx t = error $ "Internal Error: cannot parse " <> (TS.unpack t) <> " into an Expr"
+parseBlockCtx t = error $ internalError "cannot parse " <> (TS.unpack t) <> " into an Expr"
 
 parseFrameCtx :: TS.Text -> Expr EWord
 parseFrameCtx name = case TS.unpack name of
   ('c':'a':'l':'l':'v':'a':'l':'u':'e':'_':frame) -> CallValue (read frame)
   ('c':'a':'l':'l':'e':'r':'_':frame) -> Caller (read frame)
   ('a':'d':'d':'r':'e':'s':'s':'_':frame) -> Address (read frame)
-  t -> error $ "Internal Error: cannot parse " <> t <> " into an Expr"
+  t -> error $ internalError "cannot parse " <> t <> " into an Expr"
 
 getVars :: (TS.Text -> Expr EWord) -> (Text -> IO Text) -> [TS.Text] -> IO (Map (Expr EWord) W256)
 getVars parseFn getVal names = Map.mapKeys parseFn <$> foldM getOne mempty names
@@ -889,7 +889,7 @@ getVars parseFn getVal names = Map.mapKeys parseFn <$> foldM getOne mempty names
             TermSpecConstant sc)
               -> if symbol == name
                  then parseW256 sc
-                 else error "Internal Error: solver did not return model for requested value"
+                 else error $ internalError "solver did not return model for requested value"
           r -> parseErr r
       pure $ Map.insert name val acc
 
@@ -910,7 +910,7 @@ getBufs getVal bufs = foldM getBuf mempty bufs
           (TermQualIdentifier (Unqualified (IdSymbol symbol)), (TermSpecConstant sc))
             -> if symbol == (T.toStrict $ name <> "_length")
                then parseW256 sc
-               else error "Internal Error: solver did not return model for requested value"
+               else error $ internalError "solver did not return model for requested value"
           res -> parseErr res
         res -> parseErr res
 
@@ -924,9 +924,9 @@ getBufs getVal bufs = foldM getBuf mempty bufs
           (TermQualIdentifier (Unqualified (IdSymbol symbol)), term)
             -> if (T.fromStrict symbol) == name
                then pure $ parseBuf len term
-               else error "Internal Error: solver did not return model for requested value"
-          res -> error $ "Internal Error: cannot parse solver response: " <> show res
-        res -> error $ "Internal Error: cannot parse solver response: " <> show res
+               else error $ internalError "solver did not return model for requested value"
+          res -> error $ internalError "cannot parse solver response: " <> show res
+        res -> error $ internalError "cannot parse solver response: " <> show res
       pure $ Map.insert (AbstractBuf $ T.toStrict name) buf acc
 
     parseBuf :: W256 -> Term -> BufModel
@@ -963,7 +963,7 @@ getBufs getVal bufs = foldM getBuf mempty bufs
           -- looking up a bound name
           (TermQualIdentifier (Unqualified (IdSymbol name))) -> case Map.lookup name env of
             Just t -> t
-            Nothing -> error $ "Internal error: could not find "
+            Nothing -> error $ internalError "could not find "
                             <> (TS.unpack name)
                             <> " in environment mapping"
           p -> parseErr p
@@ -979,7 +979,7 @@ getStore getVal sreads = do
               (TermQualIdentifier (Unqualified (IdSymbol symbol)), term) ->
                 if symbol == "abstractStore"
                 then interpret2DArray Map.empty term
-                else error "Internal Error: solver did not return model for requested value"
+                else error $ internalError "solver did not return model for requested value"
               r -> parseErr r
 
   -- then create a map by adding only the locations that are read by the program
@@ -1006,7 +1006,7 @@ queryValue getVal w = do
     Right (ResSpecific (valParsed :| [])) ->
       case valParsed of
         (_, TermSpecConstant sc) -> pure $ parseW256 sc
-        _ -> error $ "Internal Error: cannot parse model for: " <> show w
+        _ -> error $ internalError "cannot parse model for: " <> show w
     r -> parseErr r
 
 
@@ -1019,7 +1019,7 @@ interpretNDArray interp env = \case
   TermQualIdentifier (Unqualified (IdSymbol s)) ->
     case Map.lookup s env of
       Just t -> interpretNDArray interp env t
-      Nothing -> error "Internal error: unknown identifier, cannot parse array"
+      Nothing -> error $ internalError "unknown identifier, cannot parse array"
   -- (let (x t') t)
   TermLet (VarBinding x t' :| []) t -> interpretNDArray interp (Map.insert x t' env) t
   TermLet (VarBinding x t' :| lets) t -> interpretNDArray interp (Map.insert x t' env) (TermLet (NonEmpty.fromList lets) t)
@@ -1029,7 +1029,7 @@ interpretNDArray interp env = \case
   -- (store arr ind val)
   TermApplication store (arr :| [TermSpecConstant ind, val]) | isStore store ->
     \x -> if x == parseW256 ind then interp env val else interpretNDArray interp env arr x
-  t -> error $ "Internal error: cannot parse array value. Unexpected term: " <> (show t)
+  t -> error $ internalError "cannot parse array value. Unexpected term: " <> (show t)
 
   where
     isArrConst :: QualIdentifier -> Bool
@@ -1050,8 +1050,8 @@ interpret1DArray = interpretNDArray interpretW256
     interpretW256 env (TermQualIdentifier (Unqualified (IdSymbol s))) =
       case Map.lookup s env of
         Just t -> interpretW256 env t
-        Nothing -> error "Internal error: unknown identifier, cannot parse array"
-    interpretW256 _ t = error $ "Internal error: cannot parse array value. Unexpected term: " <> (show t)
+        Nothing -> error $ internalError "unknown identifier, cannot parse array"
+    interpretW256 _ t = error $ internalError "cannot parse array value. Unexpected term: " <> (show t)
 
 -- | Interpret an 2-dimensional array as a function
 interpret2DArray :: (Map Symbol Term) -> Term -> (W256 -> W256 -> W256)

--- a/src/EVM/Sign.hs
+++ b/src/EVM/Sign.hs
@@ -39,7 +39,7 @@ sign hash sk = (v, r, s)
     curve = getCurveByName SEC_p256k1
     priv = PrivateKey curve sk
     digest = fromMaybe
-      (error $ internalError "could produce a digest from " <> show hash)
+      (internalError $ "could produce a digest from " <> show hash)
       (Crypto.digestFromByteString (word256Bytes hash))
 
     -- sign message

--- a/src/EVM/Sign.hs
+++ b/src/EVM/Sign.hs
@@ -39,7 +39,7 @@ sign hash sk = (v, r, s)
     curve = getCurveByName SEC_p256k1
     priv = PrivateKey curve sk
     digest = fromMaybe
-      (error $ "Internal Error: could produce a digest from " <> show hash)
+      (error $ internalError "could produce a digest from " <> show hash)
       (Crypto.digestFromByteString (word256Bytes hash))
 
     -- sign message

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -120,12 +120,12 @@ instance Read SlotType where
   readsPrec _ t@('m':'a':'p':'p':'i':'n':'g':'(':s) =
     let (lhs,rhs) = case T.splitOn " => " (pack s) of
           (l:r) -> (l,r)
-          _ -> error $ "could not parse storage item: " <> t
+          _ -> error $ internalError "could not parse storage item: " <> t
         first = fromJust $ parseTypeName mempty lhs
         target = fromJust $ parseTypeName mempty (T.replace ")" "" (last rhs))
         rest = fmap (fromJust . (parseTypeName mempty . (T.replace "mapping(" ""))) (take (length rhs - 1) rhs)
     in [(StorageMapping (first NonEmpty.:| rest) target, "")]
-  readsPrec _ s = [(StorageValue $ fromMaybe (error $ "could not parse storage item: " <> s) (parseTypeName mempty (pack s)),"")]
+  readsPrec _ s = [(StorageValue $ fromMaybe (error $ internalError "could not parse storage item: " <> s) (parseTypeName mempty (pack s)),"")]
 
 data SolcContract = SolcContract
   { runtimeCodehash  :: W256
@@ -285,7 +285,7 @@ makeSrcMaps = (\case (_, Fe, _) -> Nothing; x -> Just (done x))
     go ';' (xs, F5 a b c j ds, _)              = let p' = SM a b c j (readR ds) in -- solc >=0.6
                                                  (xs |> p', F1 [] 1, p')
 
-    go c (xs, state, p)                        = (xs, error ("srcmap: y u " ++ show c ++ " in state" ++ show state ++ "?!?"), p)
+    go c (xs, state, p)                        = (xs, error $ internalError ("srcmap: y u " ++ show c ++ " in state" ++ show state ++ "?!?"), p)
 
 -- | Reads all solc ouput json files found under the provided filepath and returns them merged into a BuildOutput
 readBuildOutput :: FilePath -> ProjectType -> IO (Either String BuildOutput)
@@ -389,10 +389,10 @@ functionAbi f = do
   let (Contracts sol, _, _) = fromJust $ readStdJSON json
   case Map.toList $ (fromJust (Map.lookup (path <> ":ABI") sol)).abiMap of
      [(_,b)] -> pure b
-     _ -> error "hevm internal error: unexpected abi format"
+     _ -> error $ internalError "unexpected abi format"
 
 force :: String -> Maybe a -> a
-force s = fromMaybe (error s)
+force s = fromMaybe (error $ internalError s)
 
 readJSON :: ProjectType -> Text -> Text -> Maybe (Contracts, Asts, Sources)
 readJSON DappTools _ json = readStdJSON json
@@ -454,7 +454,7 @@ readStdJSON json = do
   where
     f :: (AsValue s) => HMap.HashMap Text s -> (Map Text (SolcContract, (HMap.HashMap Text Text)))
     f x = Map.fromList . (concatMap g) . HMap.toList $ x
-    g (s, x) = h s <$> HMap.toList (KeyMap.toHashMapText (fromMaybe (error "Could not parse json object") (preview _Object x)))
+    g (s, x) = h s <$> HMap.toList (KeyMap.toHashMapText (fromMaybe (error $ internalError "Could not parse json object") (preview _Object x)))
     h :: Text -> (Text, Value) -> (Text, (SolcContract, HMap.HashMap Text Text))
     h s (c, x) =
       let
@@ -467,7 +467,7 @@ readStdJSON json = do
         srcContents = do metadata <- x ^? key "metadata" % _String
                          srcs <- KeyMap.toHashMapText <$> metadata ^? key "sources" % _Object
                          pure $ fmap
-                           (fromMaybe (error "Internal Error: could not parse contents field into a string") . preview (key "content" % _String))
+                           (fromMaybe (error $ internalError "could not parse contents field into a string") . preview (key "content" % _String))
                            (HMap.filter (isJust . preview (key "content")) srcs)
         abis = force ("abi key not found in " <> show x) $
           toList <$> x ^? key "abi" % _Array
@@ -476,8 +476,8 @@ readStdJSON json = do
         creationCode     = theCreationCode,
         runtimeCodehash  = keccak' (stripBytecodeMetadata theRuntimeCode),
         creationCodehash = keccak' (stripBytecodeMetadata theCreationCode),
-        runtimeSrcmap    = force "internal error: srcmap-runtime" (makeSrcMaps (runtime ^?! key "sourceMap" % _String)),
-        creationSrcmap   = force "internal error: srcmap" (makeSrcMaps (creation ^?! key "sourceMap" % _String)),
+        runtimeSrcmap    = force "srcmap-runtime" (makeSrcMaps (runtime ^?! key "sourceMap" % _String)),
+        creationSrcmap   = force "srcmap" (makeSrcMaps (creation ^?! key "sourceMap" % _String)),
         contractName = s <> ":" <> c,
         constructorInputs = mkConstructor abis,
         abiMap        = mkAbiMap abis,
@@ -558,7 +558,7 @@ mkEventMap abis = Map.fromList $
          False -> NotAnonymous)
        (map (\y ->
         ( y ^?! key "name" % _String
-        , force "internal error: type" (parseTypeName' y)
+        , force "type" (parseTypeName' y)
         , if y ^?! key "indexed" % _Bool
           then Indexed
           else NotIndexed
@@ -592,7 +592,7 @@ mkConstructor abis =
     case filter isConstructor abis of
       [abi] -> map parseMethodInput (toList (abi ^?! key "inputs" % _Array))
       [] -> [] -- default constructor has zero inputs
-      _  -> error "strange: contract has multiple constructors"
+      _  -> error $ internalError "strange: contract has multiple constructors"
 
 mkStorageLayout :: Maybe Value -> Maybe (Map Text StorageItem)
 mkStorageLayout Nothing = Nothing
@@ -633,13 +633,13 @@ parseMutability "view" = View
 parseMutability "pure" = Pure
 parseMutability "nonpayable" = NonPayable
 parseMutability "payable" = Payable
-parseMutability _ = error "unknown function mutability"
+parseMutability _ = error $ internalError "unknown function mutability"
 
 -- This actually can also parse a method output! :O
 parseMethodInput :: AsValue s => s -> (Text, AbiType)
 parseMethodInput x =
   ( x ^?! key "name" % _String
-  , force "internal error: method type" (parseTypeName' x)
+  , force "method type" (parseTypeName' x)
   )
 
 containsLinkerHole :: Text -> Bool
@@ -649,8 +649,8 @@ toCode :: Text -> ByteString
 toCode t = case BS16.decodeBase16 (encodeUtf8 t) of
   Right d -> d
   Left e -> if containsLinkerHole t
-            then error "unlinked libraries detected in bytecode"
-            else error $ T.unpack e
+            then error "Error: unlinked libraries detected in bytecode"
+            else error $ internalError $ T.unpack e
 
 solidity' :: Text -> IO (Text, Text)
 solidity' src = withSystemTempFile "hevm.sol" $ \path handle -> do

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -650,7 +650,7 @@ toCode t = case BS16.decodeBase16 (encodeUtf8 t) of
   Right d -> d
   Left e -> if containsLinkerHole t
             then error "Error: unlinked libraries detected in bytecode"
-            else internalError $ T.unpack e
+            else error $ T.unpack e
 
 solidity' :: Text -> IO (Text, Text)
 solidity' src = withSystemTempFile "hevm.sol" $ \path handle -> do

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -167,10 +167,10 @@ getModel inst cexvars = do
         AbstractBuf b -> do
           let name = T.fromStrict b
               hint = fromMaybe
-                       (error $ "Internal Error: Could not find hint for buffer: " <> T.unpack name)
+                       (error $ internalError "Could not find hint for buffer: " <> T.unpack name)
                        (Map.lookup name hints)
           shrinkBuf name hint
-        _ -> error "Internal Error: Received model from solver for non AbstractBuf"
+        _ -> error $ internalError "Received model from solver for non AbstractBuf"
 
     -- starting with some guess at the max useful size for a buffer, cap
     -- it's size to that value, and ask the solver to check satisfiability. If
@@ -191,12 +191,12 @@ getModel inst cexvars = do
         "unsat" -> do
           liftIO $ sendLine' inst "(pop)"
           shrinkBuf buf (if hint == 0 then hint + 1 else hint * 2)
-        _ -> error "TODO: HANDLE ERRORS"
+        _ -> error $ internalError "SMT solver returned unexpected result (neither sat/unsat), which HEVM currently cannot handle"
 
     -- Collapses the abstract description of a models buffers down to a bytestring
     mkConcrete :: SMTCex -> SMTCex
     mkConcrete c = fromMaybe
-      (error $ "Internal Error: counterexample contains buffers that are too large to be represented as a ByteString: " <> show c)
+      (error $ internalError "counterexample contains buffers that are too large to be represented as a ByteString: " <> show c)
       (flattenBufs c)
 
     -- we set a pretty arbitrary upper limit (of 1024) to decide if we need to do some shrinking
@@ -217,7 +217,7 @@ mkTimeout t = T.pack $ show $ (1000 *)$ case t of
 -- | Arguments used when spawing a solver instance
 solverArgs :: Solver -> Maybe Natural -> [Text]
 solverArgs solver timeout = case solver of
-  Bitwuzla -> error "TODO: Bitwuzla args"
+  Bitwuzla -> error $ internalError "TODO: Bitwuzla args"
   Z3 ->
     [ "-in" ]
   CVC5 ->
@@ -320,8 +320,8 @@ getSExpr :: Text -> (Text, Text)
 getSExpr l = go LPar l 0 []
   where
     go _ text 0 prev@(_:_) = (T.intercalate "" (reverse prev), text)
-    go _ _ r _ | r < 0 = error "Internal error: Unbalanced SExpression"
-    go _ "" _ _  = error "Internal error: Unbalanced SExpression"
+    go _ _ r _ | r < 0 = error $ internalError "Unbalanced SExpression"
+    go _ "" _ _  = error $ internalError "Unbalanced SExpression"
     -- find the next left parenthesis
     go LPar line r prev = -- r is how many right parentheses we are missing
       let (before, after) = T.breakOn "(" line in

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -24,7 +24,7 @@ import Data.Text.Lazy.Builder
 import System.Process (createProcess, cleanupProcess, proc, ProcessHandle, std_in, std_out, std_err, StdStream(..))
 
 import EVM.SMT
-import EVM.Types (W256, Expr(AbstractBuf))
+import EVM.Types (W256, Expr(AbstractBuf), internalError)
 
 -- | Supported solvers
 data Solver
@@ -167,10 +167,10 @@ getModel inst cexvars = do
         AbstractBuf b -> do
           let name = T.fromStrict b
               hint = fromMaybe
-                       (error $ internalError "Could not find hint for buffer: " <> T.unpack name)
+                       (internalError $ "Could not find hint for buffer: " <> T.unpack name)
                        (Map.lookup name hints)
           shrinkBuf name hint
-        _ -> error $ internalError "Received model from solver for non AbstractBuf"
+        _ -> internalError "Received model from solver for non AbstractBuf"
 
     -- starting with some guess at the max useful size for a buffer, cap
     -- it's size to that value, and ask the solver to check satisfiability. If
@@ -191,12 +191,12 @@ getModel inst cexvars = do
         "unsat" -> do
           liftIO $ sendLine' inst "(pop)"
           shrinkBuf buf (if hint == 0 then hint + 1 else hint * 2)
-        _ -> error $ internalError "SMT solver returned unexpected result (neither sat/unsat), which HEVM currently cannot handle"
+        _ -> internalError "SMT solver returned unexpected result (neither sat/unsat), which HEVM currently cannot handle"
 
     -- Collapses the abstract description of a models buffers down to a bytestring
     mkConcrete :: SMTCex -> SMTCex
     mkConcrete c = fromMaybe
-      (error $ internalError "counterexample contains buffers that are too large to be represented as a ByteString: " <> show c)
+      (internalError $ "counterexample contains buffers that are too large to be represented as a ByteString: " <> show c)
       (flattenBufs c)
 
     -- we set a pretty arbitrary upper limit (of 1024) to decide if we need to do some shrinking
@@ -217,7 +217,7 @@ mkTimeout t = T.pack $ show $ (1000 *)$ case t of
 -- | Arguments used when spawing a solver instance
 solverArgs :: Solver -> Maybe Natural -> [Text]
 solverArgs solver timeout = case solver of
-  Bitwuzla -> error $ internalError "TODO: Bitwuzla args"
+  Bitwuzla -> internalError "TODO: Bitwuzla args"
   Z3 ->
     [ "-in" ]
   CVC5 ->
@@ -320,8 +320,8 @@ getSExpr :: Text -> (Text, Text)
 getSExpr l = go LPar l 0 []
   where
     go _ text 0 prev@(_:_) = (T.intercalate "" (reverse prev), text)
-    go _ _ r _ | r < 0 = error $ internalError "Unbalanced SExpression"
-    go _ "" _ _  = error $ internalError "Unbalanced SExpression"
+    go _ _ r _ | r < 0 = internalError "Unbalanced SExpression"
+    go _ "" _ _  = internalError "Unbalanced SExpression"
     -- find the next left parenthesis
     go LPar line r prev = -- r is how many right parentheses we are missing
       let (before, after) = T.breakOn "(" line in

--- a/src/EVM/Stepper.hs
+++ b/src/EVM/Stepper.hs
@@ -89,14 +89,14 @@ execFully =
     VMSuccess x ->
       pure (Right x)
     Unfinished x
-      -> error $ internalError "partial execution encountered during concrete execution: " <> show x
+      -> internalError $ "partial execution encountered during concrete execution: " <> show x
 
 -- | Run the VM until its final state
 runFully :: Stepper VM
 runFully = do
   vm <- run
   case vm.result of
-    Nothing -> error $ internalError "should not occur"
+    Nothing -> internalError "should not occur"
     Just (HandleEffect (Query q)) ->
       wait q >> runFully
     Just (HandleEffect (Choose q)) ->
@@ -135,7 +135,7 @@ interpret fetcher vm = eval . view
           let vm' = execState m vm
           interpret fetcher vm' (k ())
         Ask _ ->
-          error $ internalError "cannot make choices with this interpreter"
+          internalError "cannot make choices with this interpreter"
         IOAct m -> do
           (r, vm') <- runStateT m vm
           interpret fetcher vm' (k r)

--- a/src/EVM/Stepper.hs
+++ b/src/EVM/Stepper.hs
@@ -89,14 +89,14 @@ execFully =
     VMSuccess x ->
       pure (Right x)
     Unfinished x
-      -> error $ "Internal Error: partial execution encountered during concrete execution: " <> show x
+      -> error $ internalError "partial execution encountered during concrete execution: " <> show x
 
 -- | Run the VM until its final state
 runFully :: Stepper VM
 runFully = do
   vm <- run
   case vm.result of
-    Nothing -> error "should not occur"
+    Nothing -> error $ internalError "should not occur"
     Just (HandleEffect (Query q)) ->
       wait q >> runFully
     Just (HandleEffect (Choose q)) ->
@@ -135,7 +135,7 @@ interpret fetcher vm = eval . view
           let vm' = execState m vm
           interpret fetcher vm' (k ())
         Ask _ ->
-          error "cannot make choices with this interpreter"
+          error $ internalError "cannot make choices with this interpreter"
         IOAct m -> do
           (r, vm') <- runStateT m vm
           interpret fetcher vm' (k r)

--- a/src/EVM/StorageLayout.hs
+++ b/src/EVM/StorageLayout.hs
@@ -53,11 +53,11 @@ storageLayout dapp solc =
       Just ((reverse . toList) -> linearizedBaseContracts) ->
         flip concatMap linearizedBaseContracts
           (\case
-             Number i -> fromMaybe (error $ internalError "malformed AST JSON") $
+             Number i -> fromMaybe (internalError "malformed AST JSON") $
                storageVariablesForContract =<<
                  Map.lookup (floor i) dapp.astIdMap
              _ ->
-               error $ internalError "malformed AST JSON")
+               internalError "malformed AST JSON")
 
 storageVariablesForContract :: Value -> Maybe [Text]
 storageVariablesForContract node = do
@@ -78,7 +78,7 @@ storageVariablesForContract node = do
             , pack $ show (slotTypeForDeclaration x)
             ]
         Nothing ->
-          error $ internalError "malformed variable declaration"
+          internalError "malformed variable declaration"
 
 nodeIs :: Text -> Value -> Bool
 nodeIs t x = isSourceNode && hasRightName
@@ -99,7 +99,7 @@ slotTypeForDeclaration node =
     Just (x:_) ->
       grokDeclarationType x
     _ ->
-      error $ internalError "malformed AST"
+      internalError "malformed AST"
 
 grokDeclarationType :: Value -> SlotType
 grokDeclarationType x =
@@ -109,11 +109,11 @@ grokDeclarationType x =
         Just (toList -> xs) ->
           grokMappingType xs
         _ ->
-          error $ internalError "malformed AST"
+          internalError "malformed AST"
     Just _ ->
       StorageValue (grokValueType x)
     _ ->
-      error $ internalError ("malformed AST " ++ show x)
+      internalError ("malformed AST " ++ show x)
 
 grokMappingType :: [Value] -> SlotType
 grokMappingType [s, t] =
@@ -123,9 +123,9 @@ grokMappingType [s, t] =
     (StorageValue s', StorageValue t') ->
       StorageMapping (pure s') t'
     (StorageMapping _ _, _) ->
-      error $ internalError "unexpected mapping as mapping key"
+      internalError "unexpected mapping as mapping key"
 grokMappingType _ =
-  error $ internalError "unexpected AST child count for mapping"
+  internalError "unexpected AST child count for mapping"
 
 grokValueType :: Value -> AbiType
 grokValueType x =
@@ -134,7 +134,7 @@ grokValueType x =
        , preview (key "attributes" % key "type" % _String) x
        ) of
     (Just "ElementaryTypeName", _, Just typeName) ->
-      fromMaybe (error $ internalError "ungrokked value type: " ++ show typeName)
+      fromMaybe (internalError $ "ungrokked value type: " ++ show typeName)
         (parseTypeName mempty (head (words typeName)))
     (Just "UserDefinedTypeName", _, _) ->
       AbiAddressType
@@ -147,6 +147,6 @@ grokValueType x =
         (Just "Literal", Just ((read . unpack) -> i)) ->
           AbiArrayType i (grokValueType t)
         _ ->
-          error $ internalError "malformed AST"
+          internalError "malformed AST"
     _ ->
-      error $ internalError ("unknown value type " ++ show x)
+      internalError ("unknown value type " ++ show x)

--- a/src/EVM/StorageLayout.hs
+++ b/src/EVM/StorageLayout.hs
@@ -15,6 +15,7 @@ import Data.Map qualified as Map
 import Data.Maybe (fromMaybe, isJust)
 import Data.Sequence qualified as Seq
 import Data.Text (Text, unpack, pack, words)
+import EVM.Types (internalError)
 
 import Prelude hiding (words)
 
@@ -52,11 +53,11 @@ storageLayout dapp solc =
       Just ((reverse . toList) -> linearizedBaseContracts) ->
         flip concatMap linearizedBaseContracts
           (\case
-             Number i -> fromMaybe (error "malformed AST JSON") $
+             Number i -> fromMaybe (error $ internalError "malformed AST JSON") $
                storageVariablesForContract =<<
                  Map.lookup (floor i) dapp.astIdMap
              _ ->
-               error "malformed AST JSON")
+               error $ internalError "malformed AST JSON")
 
 storageVariablesForContract :: Value -> Maybe [Text]
 storageVariablesForContract node = do
@@ -77,7 +78,7 @@ storageVariablesForContract node = do
             , pack $ show (slotTypeForDeclaration x)
             ]
         Nothing ->
-          error "malformed variable declaration"
+          error $ internalError "malformed variable declaration"
 
 nodeIs :: Text -> Value -> Bool
 nodeIs t x = isSourceNode && hasRightName
@@ -98,7 +99,7 @@ slotTypeForDeclaration node =
     Just (x:_) ->
       grokDeclarationType x
     _ ->
-      error "malformed AST"
+      error $ internalError "malformed AST"
 
 grokDeclarationType :: Value -> SlotType
 grokDeclarationType x =
@@ -108,11 +109,11 @@ grokDeclarationType x =
         Just (toList -> xs) ->
           grokMappingType xs
         _ ->
-          error "malformed AST"
+          error $ internalError "malformed AST"
     Just _ ->
       StorageValue (grokValueType x)
     _ ->
-      error ("malformed AST " ++ show x)
+      error $ internalError ("malformed AST " ++ show x)
 
 grokMappingType :: [Value] -> SlotType
 grokMappingType [s, t] =
@@ -122,9 +123,9 @@ grokMappingType [s, t] =
     (StorageValue s', StorageValue t') ->
       StorageMapping (pure s') t'
     (StorageMapping _ _, _) ->
-      error "unexpected mapping as mapping key"
+      error $ internalError "unexpected mapping as mapping key"
 grokMappingType _ =
-  error "unexpected AST child count for mapping"
+  error $ internalError "unexpected AST child count for mapping"
 
 grokValueType :: Value -> AbiType
 grokValueType x =
@@ -133,7 +134,7 @@ grokValueType x =
        , preview (key "attributes" % key "type" % _String) x
        ) of
     (Just "ElementaryTypeName", _, Just typeName) ->
-      fromMaybe (error ("ungrokked value type: " ++ show typeName))
+      fromMaybe (error $ internalError "ungrokked value type: " ++ show typeName)
         (parseTypeName mempty (head (words typeName)))
     (Just "UserDefinedTypeName", _, _) ->
       AbiAddressType
@@ -146,6 +147,6 @@ grokValueType x =
         (Just "Literal", Just ((read . unpack) -> i)) ->
           AbiArrayType i (grokValueType t)
         _ ->
-          error "malformed AST"
+          error $ internalError "malformed AST"
     _ ->
-      error ("unknown value type " ++ show x)
+      error $ internalError ("unknown value type " ++ show x)

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -111,21 +111,21 @@ symAbiArg name = \case
   AbiUIntType n ->
     if n `mod` 8 == 0 && n <= 256
     then let v = Var name in St [Expr.inRange n v] v
-    else error "bad type"
+    else error $ internalError "bad type"
   AbiIntType n ->
     if n `mod` 8 == 0 && n <= 256
     -- TODO: is this correct?
     then let v = Var name in St [Expr.inRange n v] v
-    else error "bad type"
+    else error $ internalError "bad type"
   AbiBoolType -> let v = Var name in St [bool v] v
   AbiAddressType -> let v = Var name in St [Expr.inRange 160 v] v
   AbiBytesType n ->
     if n > 0 && n <= 32
     then let v = Var name in St [Expr.inRange (n * 8) v] v
-    else error "bad type"
+    else error $ internalError "bad type"
   AbiArrayType sz tp ->
     Comp $ fmap (\n -> symAbiArg (name <> n) tp) [T.pack (show n) | n <- [0..sz-1]]
-  t -> error $ "TODO: symbolic abi encoding for " <> show t
+  t -> error $ internalError "TODO: symbolic abi encoding for " <> show t
 
 data CalldataFragment
   = St [Prop] (Expr EWord)
@@ -149,7 +149,7 @@ symCalldata sig typesignature concreteArgs base =
         AbiInt _ w -> St [] . Lit . num $ w
         AbiAddress w -> St [] . Lit . num $ w
         AbiBool w -> St [] . Lit $ if w then 1 else 0
-        _ -> error "TODO"
+        _ -> error $ internalError "TODO"
     calldatas = zipWith3 mkArg typesignature args [1..]
     (cdBuf, props) = combineFragments calldatas base
     withSelector = writeSelector cdBuf sig
@@ -165,7 +165,7 @@ cdLen = go (Lit 4)
       [] -> acc
       (hd:tl) -> case hd of
                    St _ _ -> go (Expr.add acc (Lit 32)) tl
-                   _ -> error "unsupported"
+                   _ -> error $ internalError "unsupported"
 
 writeSelector :: Expr Buf -> Text -> Expr Buf
 writeSelector buf sig =
@@ -182,7 +182,7 @@ combineFragments fragments base = go (Lit 4) fragments (base, [])
     go idx (f:rest) (buf, ps) =
       case f of
         St p w -> go (Expr.add idx (Lit 32)) rest (Expr.writeWord idx w buf, p <> ps)
-        s -> error $ "unsupported cd fragment: " <> show s
+        s -> error $ internalError "unsupported cd fragment: " <> show s
 
 
 abstractVM
@@ -442,7 +442,7 @@ runExpr = do
     Just (VMSuccess buf) -> Success asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) buf vm.env.storage
     Just (VMFailure e) -> Failure asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) e
     Just (Unfinished p) -> Partial asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) p
-    _ -> error "Internal Error: vm in intermediate state after call to runFully"
+    _ -> error $ internalError "vm in intermediate state after call to runFully"
 
 -- | Converts a given top level expr into a list of final states and the
 -- associated path conditions for each state.
@@ -455,7 +455,7 @@ flattenExpr = go []
       Success ps trace msg store -> [Success (ps <> pcs) trace msg store]
       Failure ps trace e -> [Failure (ps <> pcs) trace e]
       Partial ps trace p -> [Partial (ps <> pcs) trace p]
-      GVar _ -> error "cannot flatten an Expr containing a GVar"
+      GVar _ -> error $ internalError "cannot flatten an Expr containing a GVar"
 
 -- | Strips unreachable branches from a given expr
 -- Returns a list of executed SMT queries alongside the reduced expression for debugging purposes
@@ -469,7 +469,7 @@ flattenExpr = go []
 reachable :: SolverGroup -> Expr End -> IO ([SMT2], Expr End)
 reachable solvers e = do
   res <- go [] e
-  pure $ second (fromMaybe (error "Internal Error: no reachable paths found")) res
+  pure $ second (fromMaybe (error $ internalError "no reachable paths found")) res
   where
     {-
        Walk down the tree and collect pcs.
@@ -495,7 +495,7 @@ reachable solvers e = do
         case res of
           Sat _ -> pure ([query], Just leaf)
           Unsat -> pure ([query], Nothing)
-          r -> error $ "Invalid solver result: " <> show r
+          r -> error $ internalError "Invalid solver result: " <> show r
 
 
 -- | Evaluate the provided proposition down to its most concrete result
@@ -538,7 +538,7 @@ extractProps = \case
   Success asserts _ _ _ -> asserts
   Failure asserts _ _ -> asserts
   Partial asserts _ _ -> asserts
-  GVar _ -> error "cannot extract props from a GVar"
+  GVar _ -> error $ internalError "cannot extract props from a GVar"
 
 isPartial :: Expr a -> Bool
 isPartial (Partial _ _ _) = True
@@ -612,7 +612,7 @@ verify solvers opts preState maybepost = do
       Sat model -> Cex (leaf, model)
       EVM.Solvers.Unknown -> Timeout leaf
       Unsat -> Qed ()
-      Error e -> error $ "Internal Error: solver responded with error: " <> show e
+      Error e -> error $ internalError "solver responded with error: " <> show e
 
 type UnsatCache = TVar [Set Prop]
 
@@ -713,7 +713,7 @@ equivalenceCheck' solvers branchesA branchesB opts = do
               atomically $ readTVar knownUnsat >>= writeTVar knownUnsat . (props :)
               pure (Qed (), False)
         (_, EVM.Solvers.Unknown) -> pure (Timeout (), False)
-        (_, Error txt) -> error $ "Error while running solver: `" <> T.unpack txt -- <> "` SMT file was: `" <> filename <> "`"
+        (_, Error txt) -> error $ internalError "issue while running solver: `" <> T.unpack txt -- <> "` SMT file was: `" <> filename <> "`"
 
     -- Allows us to run it in parallel. Note that this (seems to) run it
     -- from left-to-right, and with a max of K threads. This is in contrast to
@@ -743,8 +743,8 @@ equivalenceCheck' solvers branchesA branchesB opts = do
           -- partial end states can't be compared to actual end states, so we always ignore them
           (Partial {}, _) -> PBool False
           (_, Partial {}) -> PBool False
-          (ITE _ _ _, _) -> error "Expressions must be flattened"
-          (_, ITE _ _ _) -> error "Expressions must be flattened"
+          (ITE _ _ _, _) -> error $ internalError "Expressions must be flattened"
+          (_, ITE _ _ _) -> error $ internalError "Expressions must be flattened"
           (a, b) -> if a == b
                     then PBool False
                     else PBool True
@@ -777,7 +777,7 @@ showModel :: Expr Buf -> (Expr End, CheckSatResult) -> IO ()
 showModel cd (expr, res) = do
   case res of
     Unsat -> pure () -- ignore unreachable branches
-    Error e -> error $ "Internal error: smt solver returned an error: " <> show e
+    Error e -> error $ internalError "smt solver returned an error: " <> show e
     EVM.Solvers.Unknown -> do
       putStrLn "--- Branch ---"
       putStrLn ""
@@ -855,9 +855,9 @@ formatCex cd m@(SMTCex _ _ store blockContext txContext) = T.unlines $
         go (CallValue x) _ = x == 0
         go (Caller x) _ = x == 0
         go (Address x) _ = x == 0
-        go (Balance {}) _ = error "TODO: BALANCE"
-        go (SelfBalance {}) _ = error "TODO: SELFBALANCE"
-        go (Gas {}) _ = error "TODO: Gas"
+        go (Balance {}) _ = error $ internalError "TODO: BALANCE"
+        go (SelfBalance {}) _ = error $ internalError "TODO: SELFBALANCE"
+        go (Gas {}) _ = error $ internalError "TODO: Gas"
         go _ _ = False
 
     blockCtx :: [Text]
@@ -885,7 +885,7 @@ subModel c expr =
   where
     forceFlattened (SMT.Flat bs) = bs
     forceFlattened b@(SMT.Comp _) = forceFlattened $
-      fromMaybe (error $ "Internal Error: cannot flatten buffer: " <> show b)
+      fromMaybe (error $ internalError "cannot flatten buffer: " <> show b)
                 (SMT.collapse b)
 
     subVars model b = Map.foldlWithKey subVar b model

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -111,21 +111,21 @@ symAbiArg name = \case
   AbiUIntType n ->
     if n `mod` 8 == 0 && n <= 256
     then let v = Var name in St [Expr.inRange n v] v
-    else error $ internalError "bad type"
+    else internalError "bad type"
   AbiIntType n ->
     if n `mod` 8 == 0 && n <= 256
     -- TODO: is this correct?
     then let v = Var name in St [Expr.inRange n v] v
-    else error $ internalError "bad type"
+    else internalError "bad type"
   AbiBoolType -> let v = Var name in St [bool v] v
   AbiAddressType -> let v = Var name in St [Expr.inRange 160 v] v
   AbiBytesType n ->
     if n > 0 && n <= 32
     then let v = Var name in St [Expr.inRange (n * 8) v] v
-    else error $ internalError "bad type"
+    else internalError "bad type"
   AbiArrayType sz tp ->
     Comp $ fmap (\n -> symAbiArg (name <> n) tp) [T.pack (show n) | n <- [0..sz-1]]
-  t -> error $ internalError "TODO: symbolic abi encoding for " <> show t
+  t -> internalError $ "TODO: symbolic abi encoding for " <> show t
 
 data CalldataFragment
   = St [Prop] (Expr EWord)
@@ -149,7 +149,7 @@ symCalldata sig typesignature concreteArgs base =
         AbiInt _ w -> St [] . Lit . num $ w
         AbiAddress w -> St [] . Lit . num $ w
         AbiBool w -> St [] . Lit $ if w then 1 else 0
-        _ -> error $ internalError "TODO"
+        _ -> internalError "TODO"
     calldatas = zipWith3 mkArg typesignature args [1..]
     (cdBuf, props) = combineFragments calldatas base
     withSelector = writeSelector cdBuf sig
@@ -165,7 +165,7 @@ cdLen = go (Lit 4)
       [] -> acc
       (hd:tl) -> case hd of
                    St _ _ -> go (Expr.add acc (Lit 32)) tl
-                   _ -> error $ internalError "unsupported"
+                   _ -> internalError "unsupported"
 
 writeSelector :: Expr Buf -> Text -> Expr Buf
 writeSelector buf sig =
@@ -182,7 +182,7 @@ combineFragments fragments base = go (Lit 4) fragments (base, [])
     go idx (f:rest) (buf, ps) =
       case f of
         St p w -> go (Expr.add idx (Lit 32)) rest (Expr.writeWord idx w buf, p <> ps)
-        s -> error $ internalError "unsupported cd fragment: " <> show s
+        s -> internalError $ "unsupported cd fragment: " <> show s
 
 
 abstractVM
@@ -442,7 +442,7 @@ runExpr = do
     Just (VMSuccess buf) -> Success asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) buf vm.env.storage
     Just (VMFailure e) -> Failure asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) e
     Just (Unfinished p) -> Partial asserts (Traces (Zipper.toForest vm.traces) vm.env.contracts) p
-    _ -> error $ internalError "vm in intermediate state after call to runFully"
+    _ -> internalError "vm in intermediate state after call to runFully"
 
 -- | Converts a given top level expr into a list of final states and the
 -- associated path conditions for each state.
@@ -455,7 +455,7 @@ flattenExpr = go []
       Success ps trace msg store -> [Success (ps <> pcs) trace msg store]
       Failure ps trace e -> [Failure (ps <> pcs) trace e]
       Partial ps trace p -> [Partial (ps <> pcs) trace p]
-      GVar _ -> error $ internalError "cannot flatten an Expr containing a GVar"
+      GVar _ -> internalError "cannot flatten an Expr containing a GVar"
 
 -- | Strips unreachable branches from a given expr
 -- Returns a list of executed SMT queries alongside the reduced expression for debugging purposes
@@ -469,7 +469,7 @@ flattenExpr = go []
 reachable :: SolverGroup -> Expr End -> IO ([SMT2], Expr End)
 reachable solvers e = do
   res <- go [] e
-  pure $ second (fromMaybe (error $ internalError "no reachable paths found")) res
+  pure $ second (fromMaybe (internalError "no reachable paths found")) res
   where
     {-
        Walk down the tree and collect pcs.
@@ -495,7 +495,7 @@ reachable solvers e = do
         case res of
           Sat _ -> pure ([query], Just leaf)
           Unsat -> pure ([query], Nothing)
-          r -> error $ internalError "Invalid solver result: " <> show r
+          r -> internalError $ "Invalid solver result: " <> show r
 
 
 -- | Evaluate the provided proposition down to its most concrete result
@@ -538,7 +538,7 @@ extractProps = \case
   Success asserts _ _ _ -> asserts
   Failure asserts _ _ -> asserts
   Partial asserts _ _ -> asserts
-  GVar _ -> error $ internalError "cannot extract props from a GVar"
+  GVar _ -> internalError "cannot extract props from a GVar"
 
 isPartial :: Expr a -> Bool
 isPartial (Partial _ _ _) = True
@@ -612,7 +612,7 @@ verify solvers opts preState maybepost = do
       Sat model -> Cex (leaf, model)
       EVM.Solvers.Unknown -> Timeout leaf
       Unsat -> Qed ()
-      Error e -> error $ internalError "solver responded with error: " <> show e
+      Error e -> internalError $ "solver responded with error: " <> show e
 
 type UnsatCache = TVar [Set Prop]
 
@@ -713,7 +713,7 @@ equivalenceCheck' solvers branchesA branchesB opts = do
               atomically $ readTVar knownUnsat >>= writeTVar knownUnsat . (props :)
               pure (Qed (), False)
         (_, EVM.Solvers.Unknown) -> pure (Timeout (), False)
-        (_, Error txt) -> error $ internalError "issue while running solver: `" <> T.unpack txt -- <> "` SMT file was: `" <> filename <> "`"
+        (_, Error txt) -> internalError $ "issue while running solver: `" <> T.unpack txt -- <> "` SMT file was: `" <> filename <> "`"
 
     -- Allows us to run it in parallel. Note that this (seems to) run it
     -- from left-to-right, and with a max of K threads. This is in contrast to
@@ -743,8 +743,8 @@ equivalenceCheck' solvers branchesA branchesB opts = do
           -- partial end states can't be compared to actual end states, so we always ignore them
           (Partial {}, _) -> PBool False
           (_, Partial {}) -> PBool False
-          (ITE _ _ _, _) -> error $ internalError "Expressions must be flattened"
-          (_, ITE _ _ _) -> error $ internalError "Expressions must be flattened"
+          (ITE _ _ _, _) -> internalError "Expressions must be flattened"
+          (_, ITE _ _ _) -> internalError "Expressions must be flattened"
           (a, b) -> if a == b
                     then PBool False
                     else PBool True
@@ -777,7 +777,7 @@ showModel :: Expr Buf -> (Expr End, CheckSatResult) -> IO ()
 showModel cd (expr, res) = do
   case res of
     Unsat -> pure () -- ignore unreachable branches
-    Error e -> error $ internalError "smt solver returned an error: " <> show e
+    Error e -> internalError $ "smt solver returned an error: " <> show e
     EVM.Solvers.Unknown -> do
       putStrLn "--- Branch ---"
       putStrLn ""
@@ -855,9 +855,9 @@ formatCex cd m@(SMTCex _ _ store blockContext txContext) = T.unlines $
         go (CallValue x) _ = x == 0
         go (Caller x) _ = x == 0
         go (Address x) _ = x == 0
-        go (Balance {}) _ = error $ internalError "TODO: BALANCE"
-        go (SelfBalance {}) _ = error $ internalError "TODO: SELFBALANCE"
-        go (Gas {}) _ = error $ internalError "TODO: Gas"
+        go (Balance {}) _ = internalError "TODO: BALANCE"
+        go (SelfBalance {}) _ = internalError "TODO: SELFBALANCE"
+        go (Gas {}) _ = internalError "TODO: Gas"
         go _ _ = False
 
     blockCtx :: [Text]
@@ -885,7 +885,7 @@ subModel c expr =
   where
     forceFlattened (SMT.Flat bs) = bs
     forceFlattened b@(SMT.Comp _) = forceFlattened $
-      fromMaybe (error $ internalError "cannot flatten buffer: " <> show b)
+      fromMaybe (internalError $ "cannot flatten buffer: " <> show b)
                 (SMT.collapse b)
 
     subVars model b = Map.foldlWithKey subVar b model

--- a/src/EVM/TTY.hs
+++ b/src/EVM/TTY.hs
@@ -243,9 +243,9 @@ runFromVM solvers rpcInfo maxIter' dappinfo vm = do
       , maxDepth      = Nothing
       , match         = ""
       , fuzzRuns      = 1
-      , replay        = error $ internalError "irrelevant"
+      , replay        = internalError "irrelevant"
       , vmModifier    = id
-      , testParams    = error $ internalError "irrelevant"
+      , testParams    = internalError "irrelevant"
       , dapp          = dappinfo
       , ffiAllowed    = False
       , covMatch       = Nothing
@@ -256,7 +256,7 @@ runFromVM solvers rpcInfo maxIter' dappinfo vm = do
   ui2 <- customMain v mkVty Nothing (app opts) (ViewVm ui0)
   case ui2 of
     ViewVm ui -> pure ui.vm
-    _ -> error $ internalError "customMain returned prematurely"
+    _ -> internalError "customMain returned prematurely"
 
 
 initUiVmState :: VM -> UnitTestOptions -> Stepper () -> UiVmState
@@ -381,7 +381,7 @@ backstep s =
       in
         runStateT (interpret (Step stepsToTake) stepper) s1 >>= \case
           (Continue steps, ui') -> pure $ ui' & set #stepper steps
-          _ -> error $ internalError "unexpected end"
+          _ -> internalError "unexpected end"
 
 appEvent
   :: (?fetcher::Fetcher, ?maxIter :: Maybe Integer) =>
@@ -449,7 +449,7 @@ appEvent (VtyEvent (V.EvKey V.KEnter [])) = get >>= \case
       }
   ViewPicker s ->
     case listSelectedElement s.tests of
-      Nothing -> error $ internalError "nothing selected"
+      Nothing -> internalError "nothing selected"
       Just (_, x) -> do
         let initVm  = initialUiVmStateForTest s.opts x
         put (ViewVm initVm)
@@ -615,7 +615,7 @@ initialUiVmStateForTest opts@UnitTestOptions{..} (theContractName, theTestName) 
   where
     cd = case test of
       SymbolicTest _ -> symCalldata theTestName types [] (AbstractBuf "txdata")
-      _ -> (error $ internalError "unreachable", error $ internalError "unreachable")
+      _ -> (internalError "unreachable", error $ internalError "unreachable")
     (test, types) = fromJust $ find (\(test',_) -> extractSig test' == theTestName) $ unitTestMethods testContract
     testContract = fromJust $ Map.lookup theContractName dapp.solcByName
     vm0 =
@@ -749,7 +749,7 @@ drawVmBrowser ui =
     dapp = ui.vm.testOpts.dapp
     (_, (_, c)) = fromJust $ listSelectedElement ui.contracts
 --        currentContract  = view (dappSolcByHash . ix ) dapp
-    maybeHash ch = fromJust (error $ internalError "cannot find concrete codehash for partially symbolic code") (maybeLitWord ch.codehash)
+    maybeHash ch = fromJust (internalError "cannot find concrete codehash for partially symbolic code") (maybeLitWord ch.codehash)
 
 drawVm :: UiVmState -> [UiWidget]
 drawVm ui =
@@ -975,7 +975,7 @@ solidityList vm dapp =
         Nothing -> mempty
         Just x ->
           fromMaybe
-            (error $ internalError "unable to find line for source map")
+            (internalError "unable to find line for source map")
             (preview (
               ix x.file
               % to (Vec.imap (,)))

--- a/src/EVM/TTY.hs
+++ b/src/EVM/TTY.hs
@@ -243,9 +243,9 @@ runFromVM solvers rpcInfo maxIter' dappinfo vm = do
       , maxDepth      = Nothing
       , match         = ""
       , fuzzRuns      = 1
-      , replay        = error "irrelevant"
+      , replay        = error $ internalError "irrelevant"
       , vmModifier    = id
-      , testParams    = error "irrelevant"
+      , testParams    = error $ internalError "irrelevant"
       , dapp          = dappinfo
       , ffiAllowed    = False
       , covMatch       = Nothing
@@ -256,7 +256,7 @@ runFromVM solvers rpcInfo maxIter' dappinfo vm = do
   ui2 <- customMain v mkVty Nothing (app opts) (ViewVm ui0)
   case ui2 of
     ViewVm ui -> pure ui.vm
-    _ -> error "internal error: customMain returned prematurely"
+    _ -> error $ internalError "customMain returned prematurely"
 
 
 initUiVmState :: VM -> UnitTestOptions -> Stepper () -> UiVmState
@@ -381,7 +381,7 @@ backstep s =
       in
         runStateT (interpret (Step stepsToTake) stepper) s1 >>= \case
           (Continue steps, ui') -> pure $ ui' & set #stepper steps
-          _ -> error "unexpected end"
+          _ -> error $ internalError "unexpected end"
 
 appEvent
   :: (?fetcher::Fetcher, ?maxIter :: Maybe Integer) =>
@@ -449,7 +449,7 @@ appEvent (VtyEvent (V.EvKey V.KEnter [])) = get >>= \case
       }
   ViewPicker s ->
     case listSelectedElement s.tests of
-      Nothing -> error "nothing selected"
+      Nothing -> error $ internalError "nothing selected"
       Just (_, x) -> do
         let initVm  = initialUiVmStateForTest s.opts x
         put (ViewVm initVm)
@@ -615,7 +615,7 @@ initialUiVmStateForTest opts@UnitTestOptions{..} (theContractName, theTestName) 
   where
     cd = case test of
       SymbolicTest _ -> symCalldata theTestName types [] (AbstractBuf "txdata")
-      _ -> (error "unreachable", error "unreachable")
+      _ -> (error $ internalError "unreachable", error $ internalError "unreachable")
     (test, types) = fromJust $ find (\(test',_) -> extractSig test' == theTestName) $ unitTestMethods testContract
     testContract = fromJust $ Map.lookup theContractName dapp.solcByName
     vm0 =
@@ -749,7 +749,7 @@ drawVmBrowser ui =
     dapp = ui.vm.testOpts.dapp
     (_, (_, c)) = fromJust $ listSelectedElement ui.contracts
 --        currentContract  = view (dappSolcByHash . ix ) dapp
-    maybeHash ch = fromJust (error "Internal error: cannot find concrete codehash for partially symbolic code") (maybeLitWord ch.codehash)
+    maybeHash ch = fromJust (error $ internalError "cannot find concrete codehash for partially symbolic code") (maybeLitWord ch.codehash)
 
 drawVm :: UiVmState -> [UiWidget]
 drawVm ui =
@@ -975,7 +975,7 @@ solidityList vm dapp =
         Nothing -> mempty
         Just x ->
           fromMaybe
-            (error "Internal Error: unable to find line for source map")
+            (error $ internalError "unable to find line for source map")
             (preview (
               ix x.file
               % to (Vec.imap (,)))

--- a/src/EVM/Transaction.hs
+++ b/src/EVM/Transaction.hs
@@ -270,7 +270,7 @@ initTx vm = let
 
     resetStore (ConcreteStore s) = ConcreteStore (resetConcreteStore s)
     resetStore (SStore a@(Lit _) k v s) = if creation && a == (litAddr toAddr) then resetStore s else (SStore a k v (resetStore s))
-    resetStore (SStore {}) = error "cannot reset storage if it contains symbolic addresses"
+    resetStore (SStore {}) = error $ internalError "cannot reset storage if it contains symbolic addresses"
     resetStore s = s
     in
       vm & #env % #contracts .~ initState

--- a/src/EVM/Transaction.hs
+++ b/src/EVM/Transaction.hs
@@ -270,7 +270,7 @@ initTx vm = let
 
     resetStore (ConcreteStore s) = ConcreteStore (resetConcreteStore s)
     resetStore (SStore a@(Lit _) k v s) = if creation && a == (litAddr toAddr) then resetStore s else (SStore a k v (resetStore s))
-    resetStore (SStore {}) = error $ internalError "cannot reset storage if it contains symbolic addresses"
+    resetStore (SStore {}) = internalError "cannot reset storage if it contains symbolic addresses"
     resetStore s = s
     in
       vm & #env % #contracts .~ initState

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -1140,7 +1140,7 @@ word256 xs | BS.length xs == 1 =
   -- optimize one byte pushes
   Word256 (Word128 0 0) (Word128 0 (fromIntegral $ BS.head xs))
 word256 xs = case Cereal.runGet m (padLeft 32 xs) of
-               Left _ -> error $ internalError "should not happen"
+               Left _ -> internalError "should not happen"
                Right x -> x
   where
     m = do a <- Cereal.getWord64be
@@ -1186,7 +1186,7 @@ unpackNibbles bs = BS.unpack bs >>= unpackByte
 packNibbles :: [Nibble] -> ByteString
 packNibbles [] = mempty
 packNibbles (n1:n2:ns) = BS.singleton (toByte n1 n2) <> packNibbles ns
-packNibbles _ = error $ internalError "can't pack odd number of nibbles"
+packNibbles _ = internalError "can't pack odd number of nibbles"
 
 toWord64 :: W256 -> Maybe Word64
 toWord64 n =
@@ -1238,8 +1238,8 @@ abiKeccak =
 
 -- Utils -------------------------------------------------------------------------------------------
 
-internalError:: [Char] -> [Char]
-internalError a = "internalError " ++ a
+internalError:: [Char] -> a
+internalError m = error $ "internalError " ++ m
 
 concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
 concatMapM f xs = fmap concat (mapM f xs)

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -1140,7 +1140,7 @@ word256 xs | BS.length xs == 1 =
   -- optimize one byte pushes
   Word256 (Word128 0 0) (Word128 0 (fromIntegral $ BS.head xs))
 word256 xs = case Cereal.runGet m (padLeft 32 xs) of
-               Left _ -> error "internal error"
+               Left _ -> error $ internalError "should not happen"
                Right x -> x
   where
     m = do a <- Cereal.getWord64be
@@ -1186,7 +1186,7 @@ unpackNibbles bs = BS.unpack bs >>= unpackByte
 packNibbles :: [Nibble] -> ByteString
 packNibbles [] = mempty
 packNibbles (n1:n2:ns) = BS.singleton (toByte n1 n2) <> packNibbles ns
-packNibbles _ = error "can't pack odd number of nibbles"
+packNibbles _ = error $ internalError "can't pack odd number of nibbles"
 
 toWord64 :: W256 -> Maybe Word64
 toWord64 n =
@@ -1238,6 +1238,8 @@ abiKeccak =
 
 -- Utils -------------------------------------------------------------------------------------------
 
+internalError:: [Char] -> [Char]
+internalError a = "internalError " ++ a
 
 concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
 concatMapM f xs = fmap concat (mapM f xs)

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -6,6 +6,7 @@
 
 module EVM.Types where
 
+import GHC.Stack (HasCallStack, prettyCallStack, callStack)
 import Control.Arrow ((>>>))
 import Control.Monad.State.Strict (State, mzero)
 import Crypto.Hash (hash, Keccak_256, Digest)
@@ -1238,8 +1239,8 @@ abiKeccak =
 
 -- Utils -------------------------------------------------------------------------------------------
 
-internalError:: [Char] -> a
-internalError m = error $ "Internal error: " ++ m
+internalError:: HasCallStack => [Char] -> a
+internalError m = error $ "Internal error: " ++ m ++ " -- " ++ (prettyCallStack callStack)
 
 concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
 concatMapM f xs = fmap concat (mapM f xs)

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -1239,7 +1239,7 @@ abiKeccak =
 -- Utils -------------------------------------------------------------------------------------------
 
 internalError:: [Char] -> a
-internalError m = error $ "internalError " ++ m
+internalError m = error $ "Internal error: " ++ m
 
 concatMapM :: Monad m => (a -> m [b]) -> [a] -> m [b]
 concatMapM f xs = fmap concat (mapM f xs)

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -206,10 +206,10 @@ exploreStep UnitTestOptions{..} bs = do
   Stepper.evm $ do
     cs <- use (#env % #contracts)
     abiCall testParams (Right bs)
-    let (Method _ inputs sig _ _) = fromMaybe (error "unknown abi call") $ Map.lookup (num $ word $ BS.take 4 bs) dapp.abiMap
+    let (Method _ inputs sig _ _) = fromMaybe (error $ internalError "unknown abi call") $ Map.lookup (num $ word $ BS.take 4 bs) dapp.abiMap
         types = snd <$> inputs
     let ?context = DappContext dapp cs
-    this <- fromMaybe (error "unknown target") <$> (use (#env % #contracts % at testParams.address))
+    this <- fromMaybe (error $ internalError "unknown target") <$> (use (#env % #contracts % at testParams.address))
     let name = maybe "" (contractNamePart . (.contractName)) $ lookupCode this.contractcode dapp
     pushTrace (EntryTrace (name <> "." <> sig <> "(" <> intercalate "," ((pack . show) <$> types) <> ")" <> showCall types (ConcreteBuf bs)))
   -- Try running the test method
@@ -234,9 +234,9 @@ checkFailures UnitTestOptions { .. } method bailed = do
       Right (ConcreteBuf r) ->
         let failed = case decodeAbiValue AbiBoolType (BSLazy.fromStrict r) of
               AbiBool f -> f
-              _ -> error "fix me with better types"
+              _ -> error $ internalError "fix me with better types"
         in pure (shouldFail == failed)
-      c -> error $ "internal error: unexpected failure code: " <> show c
+      c -> error $ internalError "unexpected failure code: " <> show c
 
 -- | Randomly generates the calldata arguments and runs the test
 fuzzTest :: UnitTestOptions -> Text -> [AbiType] -> VM -> Property
@@ -268,11 +268,11 @@ currentOpLocation :: VM -> OpLocation
 currentOpLocation vm =
   case currentContract vm of
     Nothing ->
-      error "internal error: why no contract?"
+      error $ internalError "why no contract?"
     Just c ->
       OpLocation
         c
-        (fromMaybe (error "internal error: op ix") (vmOpIx vm))
+        (fromMaybe (error $ internalError "op ix") (vmOpIx vm))
 
 execWithCoverage :: StateT CoverageState IO VMResult
 execWithCoverage = do _ <- runWithCoverage
@@ -318,7 +318,7 @@ interpretWithCoverage opts@UnitTestOptions{..} =
           do m <- liftIO ((Fetch.oracle solvers rpcInfo) q)
              zoom _1 (State.state (runState m)) >> interpretWithCoverage opts (k ())
         Stepper.Ask _ ->
-          error "cannot make choice in this interpreter"
+          error $ internalError "cannot make choice in this interpreter"
         Stepper.IOAct q ->
           zoom _1 (StateT (runStateT q)) >>= interpretWithCoverage opts . k
         Stepper.EVM m ->
@@ -381,7 +381,7 @@ coverageForUnitTestContract
   case Map.lookup name contractMap of
     Nothing ->
       -- Fail if there's no such contract
-      error $ "Contract " ++ unpack name ++ " not found"
+      error $ internalError "Contract " ++ unpack name ++ " not found"
 
     Just theContract -> do
       -- Construct the initial VM and begin the contract's constructor
@@ -425,7 +425,7 @@ runUnitTestContract
   case Map.lookup name contractMap of
     Nothing ->
       -- Fail if there's no such contract
-      error $ "Contract " ++ unpack name ++ " not found"
+      error $ internalError "Contract " ++ unpack name ++ " not found"
 
     Just theContract -> do
       -- Construct the initial VM and begin the contract's constructor
@@ -465,7 +465,7 @@ runUnitTestContract
             tick (Text.unlines bailing)
 
           pure [(isRight r, vm) | (r, vm) <- details]
-        _ -> error "internal error: setUp() did not end with a result"
+        _ -> error $ internalError "setUp() did not end with a result"
 
 
 runTest :: UnitTestOptions -> VM -> (Test, [AbiType]) -> IO (Text, Either Text Text, VM)
@@ -484,19 +484,19 @@ runTest opts@UnitTestOptions{..} vm (InvariantTest testName, []) = liftIO $ case
     if sig == testName
     then exploreRun opts vm testName (decodeCalls cds)
     else exploreRun opts vm testName []
-runTest _ _ (InvariantTest _, types) = error $ "invariant testing with arguments: " <> show types <> " is not implemented (yet!)"
+runTest _ _ (InvariantTest _, types) = error $ internalError "invariant testing with arguments: " <> show types <> " is not implemented (yet!)"
 runTest opts vm (SymbolicTest testName, types) = symRun opts vm testName types
 
 type ExploreTx = (Addr, Addr, ByteString, W256)
 
 decodeCalls :: BSLazy.ByteString -> [ExploreTx]
-decodeCalls b = fromMaybe (error "could not decode replay data") $ do
+decodeCalls b = fromMaybe (error $ internalError "could not decode replay data") $ do
   List v <- rlpdecode $ BSLazy.toStrict b
   pure $ unList <$> v
   where
     unList (List [BS caller', BS target, BS cd, BS ts]) =
       (num (word caller'), num (word target), cd, word ts)
-    unList _ = error "fix me with better types"
+    unList _ = error $ internalError "fix me with better types"
 
 -- | Runs an invariant test, calls the invariant before execution begins
 initialExplorationStepper :: UnitTestOptions -> ABIMethod -> [ExploreTx] -> [Addr] -> Int -> Stepper (Bool, RLP)
@@ -533,8 +533,8 @@ explorationStepper opts@UnitTestOptions{..} testName replayData targets (List hi
              -- pick all contracts with known compiler artifacts
              fmap fromJust (Map.filter isJust $ Map.fromList [(addr, lookupCode c.contractcode dapp) | (addr, c)  <- Map.toList cs])
            selected = [(addr,
-                        fromMaybe (error ("no src found for: " <> show addr)) $
-                          lookupCode (fromMaybe (error $ "contract not found: " <> show addr) $
+                        fromMaybe (error $ internalError "no src found for: " <> show addr) $
+                          lookupCode (fromMaybe (error $ internalError "contract not found: " <> show addr) $
                             Map.lookup addr cs).contractcode dapp)
                        | addr  <- targets]
        -- go to IO and generate a random valid call to any known contract
@@ -558,7 +558,7 @@ explorationStepper opts@UnitTestOptions{..} testName replayData targets (List hi
          let cd = abiMethod (sig <> "(" <> intercalate "," ((pack . show) <$> types) <> ")") args
          -- increment timestamp with random amount
          timepassed <- num <$> generate (arbitrarySizedNatural :: Gen Word32)
-         let ts = fromMaybe (error "symbolic timestamp not supported here") $ maybeLitWord vm.block.timestamp
+         let ts = fromMaybe (error $ internalError "symbolic timestamp not supported here") $ maybeLitWord vm.block.timestamp
          pure (caller', target, cd, num ts + timepassed)
  let opts' = opts { testParams = testParams {address = target, caller = caller', timestamp = timestamp'}}
      thisCallRLP = List [BS $ word160Bytes caller', BS $ word160Bytes target, BS cd, BS $ word256Bytes timestamp']
@@ -578,7 +578,7 @@ explorationStepper opts@UnitTestOptions{..} testName replayData targets (List hi
       if x
       then carryOn
       else pure (False, List (thisCallRLP:history))
-explorationStepper _ _ _ _ _ _  = error "malformed rlp"
+explorationStepper _ _ _ _ _ _  = error $ internalError "malformed rlp"
 
 getTargetContracts :: UnitTestOptions -> Stepper [Addr]
 getTargetContracts UnitTestOptions{..} = do
@@ -595,15 +595,15 @@ getTargetContracts UnitTestOptions{..} = do
         Right (ConcreteBuf r) ->
           let vs = case decodeAbiValue (AbiTupleType (Vector.fromList [AbiArrayDynamicType AbiAddressType])) (BSLazy.fromStrict r) of
                 AbiTuple v -> v
-                _ -> error "fix me with better types"
+                _ -> error $ internalError "fix me with better types"
               targets = case Vector.toList vs of
                 [AbiArrayDynamic AbiAddressType ts] ->
                   let unAbiAddress (AbiAddress a) = a
-                      unAbiAddress _ = error "fix me with better types"
+                      unAbiAddress _ = error $ internalError "fix me with better types"
                   in unAbiAddress <$> Vector.toList ts
-                _ -> error "fix me with better types"
+                _ -> error $ internalError "fix me with better types"
           in pure targets
-        _ -> error "internal error: unexpected failure code"
+        _ -> error $ internalError "internal error: unexpected failure code"
 
 exploreRun :: UnitTestOptions -> VM -> ABIMethod -> [ExploreTx] -> IO (Text, Either Text Text, VM)
 exploreRun opts@UnitTestOptions{..} initialVm testName replayTxs = do
@@ -732,7 +732,7 @@ symRun opts@UnitTestOptions{..} vm testName types = do
                                    Success _ _ _ store -> PNeg (failed store)
                                    Failure _ _ _ -> PBool False
                                    Partial _ _ _ -> PBool True
-                                   _ -> error "Internal Error: Invalid leaf node"
+                                   _ -> error $ internalError "Invalid leaf node"
 
     vm' <- EVM.Stepper.interpret (Fetch.oracle solvers rpcInfo) vm $
       Stepper.evm $ do
@@ -791,7 +791,7 @@ showCalldata cex tps buf = "(" <> intercalate "," (fmap showVal vals) <> ")"
     argdata = Expr.drop 4 $ simplify $ subModel cex buf
     vals = case decodeBuf tps argdata of
              CAbi v -> v
-             _ -> error $ "Internal Error: unable to abi decode function arguments:\n" <> (Text.unpack $ formatExpr argdata)
+             _ -> error $ internalError "unable to abi decode function arguments:\n" <> (Text.unpack $ formatExpr argdata)
 
 showVal :: AbiValue -> Text
 showVal (AbiBytes _ bs) = formatBytes bs
@@ -861,7 +861,7 @@ formatTestLogs events xs =
 -- regular trace output.
 formatTestLog :: (?context :: DappContext) => Map W256 Event -> Expr Log -> Maybe Text
 formatTestLog _ (LogEntry _ _ []) = Nothing
-formatTestLog _ (GVar _) = error "unexpected global variable"
+formatTestLog _ (GVar _) = error $ internalError "unexpected global variable"
 formatTestLog events (LogEntry _ args (topic:_)) =
   case maybeLitWord topic >>= \t1 -> (Map.lookup t1 events) of
     Nothing -> Nothing
@@ -906,7 +906,7 @@ formatTestLog events (LogEntry _ args (topic:_)) =
           log_named =
             let (key, val) = case take 2 (textValues ts args) of
                   [k, v] -> (k, v)
-                  _ -> error "shouldn't happen"
+                  _ -> error $ internalError "shouldn't happen"
             in Just $ unquote key <> ": " <> val
           showDecimal dec val =
             pack $ show $ Decimal (num dec) val
@@ -939,7 +939,7 @@ makeTxCall params (cd, cdProps) = do
   assign (#state % #gas) params.gasCall
   origin' <- fromMaybe (initialContract (RuntimeCode (ConcreteRuntimeCode ""))) <$> use (#env % #contracts % at params.origin)
   let originBal = origin'.balance
-  when (originBal < params.gasprice * (num params.gasCall)) $ error "insufficient balance for gas cost"
+  when (originBal < params.gasprice * (num params.gasCall)) $ error $ internalError "insufficient balance for gas cost"
   vm <- get
   put $ initTx vm
 
@@ -987,7 +987,7 @@ getParametersFromEnvironmentVariables rpc = do
     case rpc of
       Nothing  -> pure (0,Lit 0,0,0,0,0)
       Just url -> Fetch.fetchBlockFrom block' url >>= \case
-        Nothing -> error "Could not fetch block"
+        Nothing -> error $ internalError "Could not fetch block"
         Just Block{..} -> pure ( coinbase
                                , timestamp
                                , number
@@ -998,7 +998,7 @@ getParametersFromEnvironmentVariables rpc = do
   let
     getWord s def = maybe def read <$> lookupEnv s
     getAddr s def = maybe def read <$> lookupEnv s
-    ts' = fromMaybe (error "Internal Error: received unexpected symbolic timestamp via rpc") (maybeLitWord ts)
+    ts' = fromMaybe (error $ internalError "received unexpected symbolic timestamp via rpc") (maybeLitWord ts)
 
   TestVMParams
     <$> getAddr "DAPP_TEST_ADDRESS" (createAddress ethrunAddress 1)

--- a/test/EVM/Test/BlockchainTests.hs
+++ b/test/EVM/Test/BlockchainTests.hs
@@ -144,7 +144,7 @@ debugVMTest file test = do
   Right allTests <- parseBCSuite <$> LazyByteString.readFile (repo </> file)
   let x = case filter (\(name, _) -> name == test) $ Map.toList allTests of
         [(_, x')] -> x'
-        _ -> error "test not found"
+        _ -> error $ internalError "test not found"
   let vm0 = vmForCase x
   result <- withSolvers Z3 0 Nothing $ \solvers ->
     TTY.runFromVM solvers Nothing Nothing emptyDapp vm0
@@ -214,7 +214,7 @@ checkExpectation diff x vm = do
     storageEqual = s1 == s2
     codeEqual = case (c1 ^. #contractcode, c2 ^. #contractcode) of
       (RuntimeCode a', RuntimeCode b') -> a' == b'
-      _ -> error "unexpected code"
+      _ -> error $ internalError "unexpected code"
 
 checkExpectedContracts :: VM -> Map Addr (Contract, Storage) -> (Bool, Bool, Bool, Bool, Bool)
 checkExpectedContracts vm expected =
@@ -234,7 +234,7 @@ checkExpectedContracts vm expected =
       EmptyStore -> mempty
       AbstractStore -> mempty -- error "AbstractStore, should this be handled?"
       SStore {} -> mempty -- error "SStore, should this be handled?"
-      GVar _ -> error "unexpected global variable"
+      GVar _ -> error $ internalError "unexpected global variable"
 
 clearStorage :: (Contract, Storage) -> (Contract, Storage)
 clearStorage (c, _) = (c, mempty)

--- a/test/EVM/Test/BlockchainTests.hs
+++ b/test/EVM/Test/BlockchainTests.hs
@@ -144,7 +144,7 @@ debugVMTest file test = do
   Right allTests <- parseBCSuite <$> LazyByteString.readFile (repo </> file)
   let x = case filter (\(name, _) -> name == test) $ Map.toList allTests of
         [(_, x')] -> x'
-        _ -> error $ internalError "test not found"
+        _ -> internalError "test not found"
   let vm0 = vmForCase x
   result <- withSolvers Z3 0 Nothing $ \solvers ->
     TTY.runFromVM solvers Nothing Nothing emptyDapp vm0
@@ -214,7 +214,7 @@ checkExpectation diff x vm = do
     storageEqual = s1 == s2
     codeEqual = case (c1 ^. #contractcode, c2 ^. #contractcode) of
       (RuntimeCode a', RuntimeCode b') -> a' == b'
-      _ -> error $ internalError "unexpected code"
+      _ -> internalError "unexpected code"
 
 checkExpectedContracts :: VM -> Map Addr (Contract, Storage) -> (Bool, Bool, Bool, Bool, Bool)
 checkExpectedContracts vm expected =
@@ -234,7 +234,7 @@ checkExpectedContracts vm expected =
       EmptyStore -> mempty
       AbstractStore -> mempty -- error "AbstractStore, should this be handled?"
       SStore {} -> mempty -- error "SStore, should this be handled?"
-      GVar _ -> error $ internalError "unexpected global variable"
+      GVar _ -> internalError "unexpected global variable"
 
 clearStorage :: (Contract, Storage) -> (Contract, Storage)
 clearStorage (c, _) = (c, mempty)

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -157,7 +157,7 @@ instance JSON.ToJSON EVMToolEnv where
                 tstamp :: W256
                 tstamp = case (b.timestamp) of
                               Lit a -> a
-                              _ -> error $ internalError "Timestamp needs to be a Lit"
+                              _ -> internalError "Timestamp needs to be a Lit"
 
 emptyEvmToolEnv :: EVMToolEnv
 emptyEvmToolEnv = EVMToolEnv { coinbase = 0
@@ -254,7 +254,7 @@ evmSetup contr txData gaslimitExec = (txn, evmEnv, contrAlloc, fromAddress, toAd
     contrLits = assemble $ getOpData contr
     toW8fromLitB :: Expr 'Byte -> Word8
     toW8fromLitB (LitByte a) = a
-    toW8fromLitB _ = error $ internalError "Cannot convert non-litB"
+    toW8fromLitB _ = internalError "Cannot convert non-litB"
 
     bitcode = BS.pack . Vector.toList $ toW8fromLitB <$> contrLits
     contrAlloc = EVMToolAlloc{ balance = 0xa493d65e20984bc
@@ -514,7 +514,7 @@ vmres vm =
     gasUsed' = vm.tx.gaslimit - vm.state.gas
     res = case vm.result of
       Just (VMSuccess (ConcreteBuf b)) -> (ByteStringS b)
-      Just (VMSuccess x) -> error $ internalError "unhandled: " <> (show x)
+      Just (VMSuccess x) -> internalError "unhandled: " <> (show x)
       Just (VMFailure (Revert (ConcreteBuf b))) -> (ByteStringS b)
       Just (VMFailure _) -> ByteStringS mempty
       _ -> ByteStringS mempty
@@ -577,7 +577,7 @@ interpretWithTrace fetcher =
             m <- liftIO (fetcher q)
             zoom _1 (State.state (runState m)) >> interpretWithTrace fetcher (k ())
         Stepper.Ask _ ->
-          error $ internalError "cannot make choice in this interpreter"
+          internalError "cannot make choice in this interpreter"
         Stepper.IOAct q ->
           zoom _1 (StateT (runStateT q)) >>= interpretWithTrace fetcher . k
         Stepper.EVM m ->
@@ -800,9 +800,9 @@ getOp vm =
   let pcpos  = vm ^. #state % #pc
       code' = vm ^. #state % #code
       xs = case code' of
-        InitCode _ _ -> error $ internalError "InitCode instead of RuntimeCode"
+        InitCode _ _ -> internalError "InitCode instead of RuntimeCode"
         RuntimeCode (ConcreteRuntimeCode xs') -> BS.drop pcpos xs'
-        RuntimeCode (SymbolicRuntimeCode _) -> error $ internalError "RuntimeCode is symbolic"
+        RuntimeCode (SymbolicRuntimeCode _) -> internalError "RuntimeCode is symbolic"
   in if xs == BS.empty then 0
                        else BS.head xs
 

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -514,7 +514,7 @@ vmres vm =
     gasUsed' = vm.tx.gaslimit - vm.state.gas
     res = case vm.result of
       Just (VMSuccess (ConcreteBuf b)) -> (ByteStringS b)
-      Just (VMSuccess x) -> internalError "unhandled: " <> (show x)
+      Just (VMSuccess x) -> internalError $ "unhandled: " <> (show x)
       Just (VMFailure (Revert (ConcreteBuf b))) -> (ByteStringS b)
       Just (VMFailure _) -> ByteStringS mempty
       _ -> ByteStringS mempty

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -157,7 +157,7 @@ instance JSON.ToJSON EVMToolEnv where
                 tstamp :: W256
                 tstamp = case (b.timestamp) of
                               Lit a -> a
-                              _ -> error "Timestamp needs to be a Lit"
+                              _ -> error $ internalError "Timestamp needs to be a Lit"
 
 emptyEvmToolEnv :: EVMToolEnv
 emptyEvmToolEnv = EVMToolEnv { coinbase = 0
@@ -254,7 +254,7 @@ evmSetup contr txData gaslimitExec = (txn, evmEnv, contrAlloc, fromAddress, toAd
     contrLits = assemble $ getOpData contr
     toW8fromLitB :: Expr 'Byte -> Word8
     toW8fromLitB (LitByte a) = a
-    toW8fromLitB _ = error "Cannot convert non-litB"
+    toW8fromLitB _ = error $ internalError "Cannot convert non-litB"
 
     bitcode = BS.pack . Vector.toList $ toW8fromLitB <$> contrLits
     contrAlloc = EVMToolAlloc{ balance = 0xa493d65e20984bc
@@ -514,7 +514,7 @@ vmres vm =
     gasUsed' = vm.tx.gaslimit - vm.state.gas
     res = case vm.result of
       Just (VMSuccess (ConcreteBuf b)) -> (ByteStringS b)
-      Just (VMSuccess x) -> error $ "unhandled: " <> (show x)
+      Just (VMSuccess x) -> error $ internalError "unhandled: " <> (show x)
       Just (VMFailure (Revert (ConcreteBuf b))) -> (ByteStringS b)
       Just (VMFailure _) -> ByteStringS mempty
       _ -> ByteStringS mempty
@@ -577,7 +577,7 @@ interpretWithTrace fetcher =
             m <- liftIO (fetcher q)
             zoom _1 (State.state (runState m)) >> interpretWithTrace fetcher (k ())
         Stepper.Ask _ ->
-          error "cannot make choice in this interpreter"
+          error $ internalError "cannot make choice in this interpreter"
         Stepper.IOAct q ->
           zoom _1 (StateT (runStateT q)) >>= interpretWithTrace fetcher . k
         Stepper.EVM m ->
@@ -800,9 +800,9 @@ getOp vm =
   let pcpos  = vm ^. #state % #pc
       code' = vm ^. #state % #code
       xs = case code' of
-        InitCode _ _ -> error "InitCode instead of RuntimeCode"
+        InitCode _ _ -> error $ internalError "InitCode instead of RuntimeCode"
         RuntimeCode (ConcreteRuntimeCode xs') -> BS.drop pcpos xs'
-        RuntimeCode (SymbolicRuntimeCode _) -> error "RuntimeCode is symbolic"
+        RuntimeCode (SymbolicRuntimeCode _) -> error $ internalError "RuntimeCode is symbolic"
   in if xs == BS.empty then 0
                        else BS.head xs
 

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -30,7 +30,7 @@ tests = testGroup "rpc"
     [ testCase "pre-merge-block" $ do
         let block = BlockNumber 15537392
         (cb, numb, basefee, prevRan) <- fetchBlockFrom block testRpc >>= \case
-                      Nothing -> error "Could not fetch block"
+                      Nothing -> error $ internalError "Could not fetch block"
                       Just Block{..} -> return ( coinbase
                                                    , number
                                                    , baseFee
@@ -44,7 +44,7 @@ tests = testGroup "rpc"
     , testCase "post-merge-block" $ do
         let block = BlockNumber 16184420
         (cb, numb, basefee, prevRan) <- fetchBlockFrom block testRpc >>= \case
-                      Nothing -> error "Could not fetch block"
+                      Nothing -> error $ internalError "Could not fetch block"
                       Just Block{..} -> return ( coinbase
                                                    , number
                                                    , baseFee
@@ -75,12 +75,12 @@ tests = testGroup "rpc"
         let
           postStore = case postVm.env.storage of
             ConcreteStore s -> s
-            _ -> error "ConcreteStore expected"
+            _ -> error $ internalError "ConcreteStore expected"
           wethStore = fromJust $ Map.lookup 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 postStore
           receiverBal = fromJust $ Map.lookup (keccak' (word256Bytes 0xdead <> word256Bytes 0x3)) wethStore
           msg = case postVm.result of
             Just (VMSuccess m) -> m
-            _ -> error "VMSuccess expected"
+            _ -> error $ internalError "VMSuccess expected"
         assertEqual "should succeed" msg (ConcreteBuf $ word256Bytes 0x1)
         assertEqual "should revert" receiverBal (W256 $ 2595433725034301 + wad)
 
@@ -111,11 +111,11 @@ weth9VM blockNum calldata' = do
 vmFromRpc :: W256 -> (Expr Buf, [Prop]) -> Expr EWord -> Expr EWord -> Addr -> IO VM
 vmFromRpc blockNum calldata' callvalue' caller' address' = do
   ctrct <- fetchContractFrom (BlockNumber blockNum) testRpc address' >>= \case
-        Nothing -> error $ "contract not found: " <> show address'
+        Nothing -> error $ internalError "contract not found: " <> show address'
         Just contract' -> return contract'
 
   blk <- fetchBlockFrom (BlockNumber blockNum) testRpc >>= \case
-    Nothing -> error "could not fetch block"
+    Nothing -> error $ internalError "could not fetch block"
     Just b -> pure b
 
   pure $ makeVm $ VMOpts

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -111,7 +111,7 @@ weth9VM blockNum calldata' = do
 vmFromRpc :: W256 -> (Expr Buf, [Prop]) -> Expr EWord -> Expr EWord -> Addr -> IO VM
 vmFromRpc blockNum calldata' callvalue' caller' address' = do
   ctrct <- fetchContractFrom (BlockNumber blockNum) testRpc address' >>= \case
-        Nothing -> internalError "contract not found: " <> show address'
+        Nothing -> internalError $ "contract not found: " <> show address'
         Just contract' -> return contract'
 
   blk <- fetchBlockFrom (BlockNumber blockNum) testRpc >>= \case

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -30,7 +30,7 @@ tests = testGroup "rpc"
     [ testCase "pre-merge-block" $ do
         let block = BlockNumber 15537392
         (cb, numb, basefee, prevRan) <- fetchBlockFrom block testRpc >>= \case
-                      Nothing -> error $ internalError "Could not fetch block"
+                      Nothing -> internalError "Could not fetch block"
                       Just Block{..} -> return ( coinbase
                                                    , number
                                                    , baseFee
@@ -44,7 +44,7 @@ tests = testGroup "rpc"
     , testCase "post-merge-block" $ do
         let block = BlockNumber 16184420
         (cb, numb, basefee, prevRan) <- fetchBlockFrom block testRpc >>= \case
-                      Nothing -> error $ internalError "Could not fetch block"
+                      Nothing -> internalError "Could not fetch block"
                       Just Block{..} -> return ( coinbase
                                                    , number
                                                    , baseFee
@@ -75,12 +75,12 @@ tests = testGroup "rpc"
         let
           postStore = case postVm.env.storage of
             ConcreteStore s -> s
-            _ -> error $ internalError "ConcreteStore expected"
+            _ -> internalError "ConcreteStore expected"
           wethStore = fromJust $ Map.lookup 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 postStore
           receiverBal = fromJust $ Map.lookup (keccak' (word256Bytes 0xdead <> word256Bytes 0x3)) wethStore
           msg = case postVm.result of
             Just (VMSuccess m) -> m
-            _ -> error $ internalError "VMSuccess expected"
+            _ -> internalError "VMSuccess expected"
         assertEqual "should succeed" msg (ConcreteBuf $ word256Bytes 0x1)
         assertEqual "should revert" receiverBal (W256 $ 2595433725034301 + wad)
 
@@ -111,11 +111,11 @@ weth9VM blockNum calldata' = do
 vmFromRpc :: W256 -> (Expr Buf, [Prop]) -> Expr EWord -> Expr EWord -> Addr -> IO VM
 vmFromRpc blockNum calldata' callvalue' caller' address' = do
   ctrct <- fetchContractFrom (BlockNumber blockNum) testRpc address' >>= \case
-        Nothing -> error $ internalError "contract not found: " <> show address'
+        Nothing -> internalError "contract not found: " <> show address'
         Just contract' -> return contract'
 
   blk <- fetchBlockFrom (BlockNumber blockNum) testRpc >>= \case
-    Nothing -> error $ internalError "could not fetch block"
+    Nothing -> internalError "could not fetch block"
     Just b -> pure b
 
   pure $ makeVm $ VMOpts

--- a/test/test.hs
+++ b/test/test.hs
@@ -102,12 +102,12 @@ tests = testGroup "hevm"
             vm2 = case vm1.result of
                     Just (HandleEffect (Query (PleaseFetchContract _addr continue))) ->
                       execState (continue dummyContract) vm1
-                    _ -> error $ internalError "unexpected result"
+                    _ -> internalError "unexpected result"
             -- then it should fetch the slow
             vm3 = case vm2.result of
                     Just (HandleEffect (Query (PleaseFetchSlot _addr _slot continue))) ->
                       execState (continue 1337) vm2
-                    _ -> error $ internalError "unexpected result"
+                    _ -> internalError "unexpected result"
             -- perform the same access as for vm1
             vm4 = execState (EVM.accessStorage 0 (Lit 0) (pure . pure ())) vm3
 
@@ -370,7 +370,7 @@ tests = testGroup "hevm"
             [y] AbiBytesDynamicType
           let solidityEncoded = case decodeAbiValue (AbiTupleType $ Vector.fromList [AbiBytesDynamicType]) (BS.fromStrict encoded) of
                 AbiTuple (Vector.toList -> [e]) -> e
-                _ -> error $ internalError "AbiTuple expected"
+                _ -> internalError "AbiTuple expected"
           let hevmEncoded = encodeAbiValue (AbiTuple $ Vector.fromList [y])
           assertEqual "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmEncoded)
 
@@ -380,7 +380,7 @@ tests = testGroup "hevm"
             [x', y'] AbiBytesDynamicType
           let solidityEncoded = case decodeAbiValue (AbiTupleType $ Vector.fromList [AbiBytesDynamicType]) (BS.fromStrict encoded) of
                 AbiTuple (Vector.toList -> [e]) -> e
-                _ -> error $ internalError "AbiTuple expected"
+                _ -> internalError "AbiTuple expected"
           let hevmEncoded = encodeAbiValue (AbiTuple $ Vector.fromList [x',y'])
           assertEqual "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmEncoded)
 
@@ -394,7 +394,7 @@ tests = testGroup "hevm"
             |] (abiMethod "foo(function)" (AbiTuple (Vector.singleton y)))
           let solidityEncoded = case decodeAbiValue (AbiTupleType $ Vector.fromList [AbiBytesDynamicType]) (BS.fromStrict encoded) of
                 AbiTuple (Vector.toList -> [e]) -> e
-                _ -> error $ internalError "AbiTuple expected"
+                _ -> internalError "AbiTuple expected"
           let hevmEncoded = encodeAbiValue (AbiTuple $ Vector.fromList [y])
           assertEqual "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmEncoded)
     ]
@@ -1169,14 +1169,14 @@ tests = testGroup "hevm"
           |]
         let pre preVM = let (x, y) = case getStaticAbiArgs 2 preVM of
                                        [x', y'] -> (x', y')
-                                       _ -> error $ internalError "expected 2 args"
+                                       _ -> internalError "expected 2 args"
                         in (x .<= Expr.add x y)
                         -- TODO check if it's needed
                            .&& preVM.state.callvalue .== Lit 0
             post prestate leaf =
               let (x, y) = case getStaticAbiArgs 2 prestate of
                              [x', y'] -> (x', y')
-                             _ -> error $ internalError "expected 2 args"
+                             _ -> internalError "expected 2 args"
               in case leaf of
                    Success _ _ b _ -> (ReadWord (Lit 0) b) .== (Add x y)
                    _ -> PBool True
@@ -1195,14 +1195,14 @@ tests = testGroup "hevm"
           |]
         let pre preVM = let (x, y) = case getStaticAbiArgs 2 preVM of
                                        [x', y'] -> (x', y')
-                                       _ -> error $ internalError "expected 2 args"
+                                       _ -> internalError "expected 2 args"
                         in (x .<= Expr.add x y)
                            .&& (x .== y)
                            .&& preVM.state.callvalue .== Lit 0
             post prestate leaf =
               let (_, y) = case getStaticAbiArgs 2 prestate of
                              [x', y'] -> (x', y')
-                             _ -> error $ internalError "expected 2 args"
+                             _ -> internalError "expected 2 args"
               in case leaf of
                    Success _ _ b _ -> (ReadWord (Lit 0) b) .== (Mul (Lit 2) y)
                    _ -> PBool True
@@ -1227,7 +1227,7 @@ tests = testGroup "hevm"
             post prestate leaf =
               let y = case getStaticAbiArgs 1 prestate of
                         [y'] -> y'
-                        _ -> error $ internalError "expected 1 arg"
+                        _ -> internalError "expected 1 arg"
                   this = Expr.litAddr $ prestate.state.codeContract
                   prex = Expr.readStorage' this (Lit 0) prestate.env.storage
               in case leaf of
@@ -1281,7 +1281,7 @@ tests = testGroup "hevm"
               post prestate poststate =
                 let (x,y) = case getStaticAbiArgs 2 prestate of
                         [x',y'] -> (x',y')
-                        _ -> error $ internalError "expected 2 args"
+                        _ -> internalError "expected 2 args"
                     this = Expr.litAddr $ prestate.state.codeContract
                     prestore = prestate.env.storage
                     prex = Expr.readStorage' this x prestore
@@ -1315,7 +1315,7 @@ tests = testGroup "hevm"
               post prestate poststate =
                 let (x,y) = case getStaticAbiArgs 2 prestate of
                         [x',y'] -> (x',y')
-                        _ -> error $ internalError "expected 2 args"
+                        _ -> internalError "expected 2 args"
                     this = Expr.litAddr $ prestate.state.codeContract
                     prestore =  prestate.env.storage
                     prex = Expr.readStorage' this x prestore
@@ -2202,7 +2202,7 @@ tests = testGroup "hevm"
                     , "reasoningBasedSimplifier/signed_division.yul" -- ACTUAL bug, SDIV
                     ]
 
-        solcRepo <- fromMaybe (error $ internalError "cannot find solidity repo") <$> (lookupEnv "HEVM_SOLIDITY_REPO")
+        solcRepo <- fromMaybe (internalError "cannot find solidity repo") <$> (lookupEnv "HEVM_SOLIDITY_REPO")
         let testDir = solcRepo <> "/test/libyul/yulOptimizerTests"
         dircontents <- System.Directory.listDirectory testDir
         let
@@ -2240,7 +2240,7 @@ tests = testGroup "hevm"
                                       let a2 = replaceAll "a calldatacopy(0,0,1024)" $ a *=~ [re|code {|]
                                       in (a2:ax)
                                     else replaceOnce [re|^ *{|] "{\ncalldatacopy(0,0,1024)" $ onlyAfter [re|^ *{|] (a:ax)
-            symbolicMem _ = error $ internalError "Program too short"
+            symbolicMem _ = internalError "Program too short"
 
             unfiltered = lines origcont
             filteredASym = symbolicMem [ x | x <- unfiltered, (not $ x =~ [re|^//|]) && (not $ x =~ [re|^$|]) ]
@@ -2267,10 +2267,10 @@ tests = testGroup "hevm"
                 let timeouts = filter isTimeout res
                 unless (null timeouts) $ do
                   putStrLn $ "But " <> (show $ length timeouts) <> " timeout(s) occurred"
-                  error $ internalError "Encountered timeouts"
+                  internalError "Encountered timeouts"
               True -> do
                 putStrLn $ "Not OK: " <> show f <> " Got: " <> show res
-                error $ internalError "Was NOT equivalent"
+                internalError "Was NOT equivalent"
            )
     ]
   ]
@@ -2307,7 +2307,7 @@ runSimpleVM x ins = do
      res <- Stepper.interpret (Fetch.zero 0 Nothing) vm' Stepper.execFully
      case res of
        (Right (ConcreteBuf bs)) -> pure $ Just bs
-       s -> error $ internalError $ show s
+       s -> internalError $ show s
 
 -- | Takes a creation code and returns a vm with the result of executing the creation code
 loadVM :: ByteString -> IO (Maybe VM)
@@ -2330,7 +2330,7 @@ hex :: ByteString -> ByteString
 hex s =
   case BS16.decodeBase16 s of
     Right x -> x
-    Left e -> error $ internalError $ T.unpack e
+    Left e -> internalError $ T.unpack e
 
 singleContract :: Text -> Text -> IO (Maybe ByteString)
 singleContract x s =
@@ -2385,7 +2385,7 @@ decodeAbiValues :: [AbiType] -> ByteString -> [AbiValue]
 decodeAbiValues types bs =
   let xy = case decodeAbiValue (AbiTupleType $ Vector.fromList types) (BS.fromStrict (BS.drop 4 bs)) of
         AbiTuple xy' -> xy'
-        _ -> error $ internalError "AbiTuple expected"
+        _ -> internalError "AbiTuple expected"
   in Vector.toList xy
 
 newtype Bytes = Bytes ByteString

--- a/test/test.hs
+++ b/test/test.hs
@@ -102,12 +102,12 @@ tests = testGroup "hevm"
             vm2 = case vm1.result of
                     Just (HandleEffect (Query (PleaseFetchContract _addr continue))) ->
                       execState (continue dummyContract) vm1
-                    _ -> error "unexpected result"
+                    _ -> error $ internalError "unexpected result"
             -- then it should fetch the slow
             vm3 = case vm2.result of
                     Just (HandleEffect (Query (PleaseFetchSlot _addr _slot continue))) ->
                       execState (continue 1337) vm2
-                    _ -> error "unexpected result"
+                    _ -> error $ internalError "unexpected result"
             -- perform the same access as for vm1
             vm4 = execState (EVM.accessStorage 0 (Lit 0) (pure . pure ())) vm3
 
@@ -370,7 +370,7 @@ tests = testGroup "hevm"
             [y] AbiBytesDynamicType
           let solidityEncoded = case decodeAbiValue (AbiTupleType $ Vector.fromList [AbiBytesDynamicType]) (BS.fromStrict encoded) of
                 AbiTuple (Vector.toList -> [e]) -> e
-                _ -> error "AbiTuple expected"
+                _ -> error $ internalError "AbiTuple expected"
           let hevmEncoded = encodeAbiValue (AbiTuple $ Vector.fromList [y])
           assertEqual "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmEncoded)
 
@@ -380,7 +380,7 @@ tests = testGroup "hevm"
             [x', y'] AbiBytesDynamicType
           let solidityEncoded = case decodeAbiValue (AbiTupleType $ Vector.fromList [AbiBytesDynamicType]) (BS.fromStrict encoded) of
                 AbiTuple (Vector.toList -> [e]) -> e
-                _ -> error "AbiTuple expected"
+                _ -> error $ internalError "AbiTuple expected"
           let hevmEncoded = encodeAbiValue (AbiTuple $ Vector.fromList [x',y'])
           assertEqual "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmEncoded)
 
@@ -394,7 +394,7 @@ tests = testGroup "hevm"
             |] (abiMethod "foo(function)" (AbiTuple (Vector.singleton y)))
           let solidityEncoded = case decodeAbiValue (AbiTupleType $ Vector.fromList [AbiBytesDynamicType]) (BS.fromStrict encoded) of
                 AbiTuple (Vector.toList -> [e]) -> e
-                _ -> error "AbiTuple expected"
+                _ -> error $ internalError "AbiTuple expected"
           let hevmEncoded = encodeAbiValue (AbiTuple $ Vector.fromList [y])
           assertEqual "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmEncoded)
     ]
@@ -1169,14 +1169,14 @@ tests = testGroup "hevm"
           |]
         let pre preVM = let (x, y) = case getStaticAbiArgs 2 preVM of
                                        [x', y'] -> (x', y')
-                                       _ -> error "expected 2 args"
+                                       _ -> error $ internalError "expected 2 args"
                         in (x .<= Expr.add x y)
                         -- TODO check if it's needed
                            .&& preVM.state.callvalue .== Lit 0
             post prestate leaf =
               let (x, y) = case getStaticAbiArgs 2 prestate of
                              [x', y'] -> (x', y')
-                             _ -> error "expected 2 args"
+                             _ -> error $ internalError "expected 2 args"
               in case leaf of
                    Success _ _ b _ -> (ReadWord (Lit 0) b) .== (Add x y)
                    _ -> PBool True
@@ -1195,14 +1195,14 @@ tests = testGroup "hevm"
           |]
         let pre preVM = let (x, y) = case getStaticAbiArgs 2 preVM of
                                        [x', y'] -> (x', y')
-                                       _ -> error "expected 2 args"
+                                       _ -> error $ internalError "expected 2 args"
                         in (x .<= Expr.add x y)
                            .&& (x .== y)
                            .&& preVM.state.callvalue .== Lit 0
             post prestate leaf =
               let (_, y) = case getStaticAbiArgs 2 prestate of
                              [x', y'] -> (x', y')
-                             _ -> error "expected 2 args"
+                             _ -> error $ internalError "expected 2 args"
               in case leaf of
                    Success _ _ b _ -> (ReadWord (Lit 0) b) .== (Mul (Lit 2) y)
                    _ -> PBool True
@@ -1227,7 +1227,7 @@ tests = testGroup "hevm"
             post prestate leaf =
               let y = case getStaticAbiArgs 1 prestate of
                         [y'] -> y'
-                        _ -> error "expected 1 arg"
+                        _ -> error $ internalError "expected 1 arg"
                   this = Expr.litAddr $ prestate.state.codeContract
                   prex = Expr.readStorage' this (Lit 0) prestate.env.storage
               in case leaf of
@@ -1281,7 +1281,7 @@ tests = testGroup "hevm"
               post prestate poststate =
                 let (x,y) = case getStaticAbiArgs 2 prestate of
                         [x',y'] -> (x',y')
-                        _ -> error "expected 2 args"
+                        _ -> error $ internalError "expected 2 args"
                     this = Expr.litAddr $ prestate.state.codeContract
                     prestore = prestate.env.storage
                     prex = Expr.readStorage' this x prestore
@@ -1315,7 +1315,7 @@ tests = testGroup "hevm"
               post prestate poststate =
                 let (x,y) = case getStaticAbiArgs 2 prestate of
                         [x',y'] -> (x',y')
-                        _ -> error "expected 2 args"
+                        _ -> error $ internalError "expected 2 args"
                     this = Expr.litAddr $ prestate.state.codeContract
                     prestore =  prestate.env.storage
                     prex = Expr.readStorage' this x prestore
@@ -2202,7 +2202,7 @@ tests = testGroup "hevm"
                     , "reasoningBasedSimplifier/signed_division.yul" -- ACTUAL bug, SDIV
                     ]
 
-        solcRepo <- fromMaybe (error "cannot find solidity repo") <$> (lookupEnv "HEVM_SOLIDITY_REPO")
+        solcRepo <- fromMaybe (error $ internalError "cannot find solidity repo") <$> (lookupEnv "HEVM_SOLIDITY_REPO")
         let testDir = solcRepo <> "/test/libyul/yulOptimizerTests"
         dircontents <- System.Directory.listDirectory testDir
         let
@@ -2240,7 +2240,7 @@ tests = testGroup "hevm"
                                       let a2 = replaceAll "a calldatacopy(0,0,1024)" $ a *=~ [re|code {|]
                                       in (a2:ax)
                                     else replaceOnce [re|^ *{|] "{\ncalldatacopy(0,0,1024)" $ onlyAfter [re|^ *{|] (a:ax)
-            symbolicMem _ = error "Program too short"
+            symbolicMem _ = error $ internalError "Program too short"
 
             unfiltered = lines origcont
             filteredASym = symbolicMem [ x | x <- unfiltered, (not $ x =~ [re|^//|]) && (not $ x =~ [re|^$|]) ]
@@ -2267,10 +2267,10 @@ tests = testGroup "hevm"
                 let timeouts = filter isTimeout res
                 unless (null timeouts) $ do
                   putStrLn $ "But " <> (show $ length timeouts) <> " timeout(s) occurred"
-                  error "Encountered timeouts, error"
+                  error $ internalError "Encountered timeouts"
               True -> do
                 putStrLn $ "Not OK: " <> show f <> " Got: " <> show res
-                error "Was NOT equivalent, error"
+                error $ internalError "Was NOT equivalent"
            )
     ]
   ]
@@ -2307,7 +2307,7 @@ runSimpleVM x ins = do
      res <- Stepper.interpret (Fetch.zero 0 Nothing) vm' Stepper.execFully
      case res of
        (Right (ConcreteBuf bs)) -> pure $ Just bs
-       s -> error $ show s
+       s -> error $ internalError $ show s
 
 -- | Takes a creation code and returns a vm with the result of executing the creation code
 loadVM :: ByteString -> IO (Maybe VM)
@@ -2330,7 +2330,7 @@ hex :: ByteString -> ByteString
 hex s =
   case BS16.decodeBase16 s of
     Right x -> x
-    Left e -> error $ T.unpack e
+    Left e -> error $ internalError $ T.unpack e
 
 singleContract :: Text -> Text -> IO (Maybe ByteString)
 singleContract x s =
@@ -2385,7 +2385,7 @@ decodeAbiValues :: [AbiType] -> ByteString -> [AbiValue]
 decodeAbiValues types bs =
   let xy = case decodeAbiValue (AbiTupleType $ Vector.fromList types) (BS.fromStrict (BS.drop 4 bs)) of
         AbiTuple xy' -> xy'
-        _ -> error "AbiTuple expected"
+        _ -> error $ internalError "AbiTuple expected"
   in Vector.toList xy
 
 newtype Bytes = Bytes ByteString


### PR DESCRIPTION
## Description

Errors were not consistently marked with "Internal error" -- and sometimes it was spelled differently as well. This tries to unify all error messages. Some of the errors in `hevm-cli.hs` were changed to have a consistent `Error:` printed in front, when it's likely not an "internal" error.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
