### PR TITLE
Bring back combined JSON loading

### DIFF
--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -75,6 +75,7 @@ compile DappTools root src = do
   createDirectory (root <> "/out")
   T.writeFile (root <> "/out/dapp.sol.json") json
   readBuildOutput root DappTools
+compile CombinedJSON _root _src = error "unsupported"
 compile Foundry root src = do
   createDirectory (root <> "/src")
   writeFile (root <> "/src/unit-tests.t.sol") =<< readFile =<< Paths.getDataFileName src


### PR DESCRIPTION
## Description
Combined JSON is still used by some projects (like Echidna) and the recent removal of support made it hard to migrate to newer hevm versions. While the ultimate goal is to get rid of it, it is good to have it still around.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
