### PR TITLE
Add git version to `hevm version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SMT2 scripts are now being reprocessed to put one sexpr per line. Having sepxrs that span across multiple lines trigers a bug in CVC5. 
 - Removing long-running tests so we can finish all unit tests in approx 10 minutes on a current-gen laptop CPU
+- Added git revision to `hevm version`
 
 ## Added
 

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -260,8 +260,7 @@ main = do
   cmd <- Options.unwrapRecord "hevm -- Ethereum evaluator"
   case cmd of
     Version {} -> putStrLn (showVersion Paths.version <> " " <> gitversion)
-      where gitversion =
-              concat [ "[git rev: ", giBranch gi, "@", giHash gi, "]" ]
+      where gitversion = concat [ "[git rev: ", giBranch gi, "@", giHash gi, "]" ]
             gi = $$tGitInfoCwd
     Symbolic {} -> do
       root <- getRoot cmd

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -261,9 +261,7 @@ main = do
   case cmd of
     Version {} -> putStrLn (showVersion Paths.version <> " " <> gitversion)
       where gitversion =
-              concat [ "[git rev: ", giBranch gi, "@", giHash gi, dirty, "] " ]
-            dirty | giDirty gi = " (uncommitted files present)"
-                  | otherwise   = ""
+              concat [ "[git rev: ", giBranch gi, "@", giHash gi, "]" ]
             gi = $$tGitInfoCwd
     Symbolic {} -> do
       root <- getRoot cmd

--- a/hevm-cli/hevm-cli.hs
+++ b/hevm-cli/hevm-cli.hs
@@ -2,6 +2,7 @@
 
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Main where
 
@@ -38,6 +39,7 @@ import EVM.Debug (Mode(..))
 import EVM.Expr qualified as Expr
 import EVM.Facts qualified as Facts
 import EVM.Facts.Git qualified as Git
+import GitHash
 import EVM.FeeSchedule qualified as FeeSchedule
 import EVM.Fetch qualified
 import EVM.Format (hexByteString, strip0x, showTraceTree, formatExpr)
@@ -257,7 +259,12 @@ main :: IO ()
 main = do
   cmd <- Options.unwrapRecord "hevm -- Ethereum evaluator"
   case cmd of
-    Version {} -> putStrLn (showVersion Paths.version)
+    Version {} -> putStrLn (showVersion Paths.version <> " " <> gitversion)
+      where gitversion =
+              concat [ "[git rev: ", giBranch gi, "@", giHash gi, dirty, "] " ]
+            dirty | giDirty gi = " (uncommitted files present)"
+                  | otherwise   = ""
+            gi = $$tGitInfoCwd
     Symbolic {} -> do
       root <- getRoot cmd
       withCurrentDirectory root $ assert cmd

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -241,7 +241,8 @@ executable hevm
     vty,
     stm,
     spawn,
-    optics-core
+    optics-core,
+    githash                       >= 0.1.6 && < 0.2
   if os(windows)
     buildable: False
 


### PR DESCRIPTION
## Description

Print the git revision when issuing `hevm version`. This will now look like:

```
0.51.1 [git rev: add_git_version@4a4076a8c97c07a73f343f60d33d028de2420f27]
```

Where `add_git_version` is the branch, and `4a4076a8c97c07a73f343f60d33d028de2420f27` is the SHA1 hash of the commit.


## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
