### PR TITLE
Adding debug flags and tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SMT2 scripts are now being reprocessed to put one sexpr per line. Having sepxrs that span across multiple lines trigers a bug in CVC5. 
 - Removing long-running tests so we can finish all unit tests in approx 10 minutes on a current-gen laptop CPU
+- Added flag `-f debug` to add debug flags to cabal/GHC
 
 ## Added
 

--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,7 @@
               mdbook
               yarn
               haskellPackages.cabal-install
+              haskellPackages.eventlog2html
               haskellPackages.haskell-language-server
             ] ++ testDeps;
             withHoogle = true;

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -61,6 +61,13 @@ common shared
     ghc-options: -Werror
   if flag(devel)
     ghc-options: -j
+  if flag(debug)
+    ghc-options:
+      -j
+      -g3
+      -fdistinct-constructor-tables
+      -finfo-table-map
+      -eventlog
   ghc-options:
     -Wall
     -Wno-unticked-promoted-constructors
@@ -241,7 +248,8 @@ executable hevm
     vty,
     stm,
     spawn,
-    optics-core
+    optics-core,
+    eventlog2html
   if os(windows)
     buildable: False
 

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -52,6 +52,11 @@ flag devel
   default:     False
   manual:      True
 
+flag debug
+  description: Sets flags for compilation with extensive debug symbols and eventlog
+  default:     False
+  manual:      True
+
 source-repository head
   type:     git
   location: https://github.com/ethereum/hevm.git

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -253,8 +253,7 @@ executable hevm
     vty,
     stm,
     spawn,
-    optics-core,
-    eventlog2html
+    optics-core
   if os(windows)
     buildable: False
 


### PR DESCRIPTION
## Description
Allows to give `-f debug` flag to `cabal` so it builds with extensive debug information and eventlog enabled. We now also include `eventlog2html` as part of our cabal. This should aid in debugging in the future.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
