### PR TITLE
Removing unused sha3Crack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SMT encoding of Expr now has assertions for the range of environment values that are less than word size (256 bits).
 - Trace now contains the cheat code calls
+- Removed sha3Crack which has been deprecated for keccakEqs
 
 ## Changed
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -140,8 +140,7 @@ makeVm o =
     , static = False
     }
   , env = Env
-    { sha3Crack = mempty
-    , chainId = o.chainId
+    { chainId = o.chainId
     , storage = o.initialStorage
     , origStorage = mempty
     , contracts = Map.fromList
@@ -333,17 +332,16 @@ exec1 = do
                 \xOffset -> forceConcrete xSize' "sha3 size must be concrete" $ \xSize ->
                   burn (g_sha3 + g_sha3word * ceilDiv (num xSize) 32) $
                     accessMemoryRange xOffset xSize $ do
-                      (hash, invMap) <- case readMemory xOffset' xSize' vm of
+                      hash <- case readMemory xOffset' xSize' vm of
                                           ConcreteBuf bs -> do
                                             let hash' = keccak' bs
                                             eqs <- use #keccakEqs
                                             assign #keccakEqs $
                                               PEq (Lit hash') (Keccak (ConcreteBuf bs)):eqs
-                                            pure (Lit hash', Map.singleton hash' bs)
-                                          buf -> pure (Keccak buf, mempty)
+                                            pure $ Lit hash'
+                                          buf -> pure $ Keccak buf
                       next
                       assign (#state % #stack) (hash : xs)
-                      modifying (#env % #sha3Crack) ((<>) invMap)
             _ -> underrun
 
         OpAddress ->

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -682,7 +682,6 @@ data Env = Env
   , chainId      :: W256
   , storage      :: Expr Storage
   , origStorage  :: Map W256 (Map W256 W256)
-  , sha3Crack    :: Map W256 ByteString
   }
   deriving (Show, Generic)
 


### PR DESCRIPTION
## Description
Removes the old `sha3Crack` which is collected but never used. It has been replaced with the actually used `keccakEqs`

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
