### PR TITLE
Fix nonreproducible errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SMT encoding of Expr now has assertions for the range of environment values that are less than word size (256 bits).
 - Trace now contains the cheat code calls
 - More consistent error messages
+- Automatic tests are now more reproducible
 
 ## Changed
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -185,7 +185,6 @@ tests = testGroup "hevm"
         checkEquiv simplified full
     , testProperty "indexWord-equivalence" $ \(src) -> idempotentIOProperty $ do
         idx <- generate (genLit 50)
-        putStrLn $ show idx
         let simplified = Expr.indexWord idx src
             full = IndexWord idx src
         checkEquiv simplified full

--- a/test/test.hs
+++ b/test/test.hs
@@ -140,7 +140,7 @@ tests = testGroup "hevm"
     , testProperty "byte-simplification" $ \(expr :: Expr Byte) -> ioProperty $ do
         let simplified = Expr.simplify expr
         checkEquiv expr simplified
-    , testProperty "word-simplification" $ \((GenWordSimplifyExpr expr) :: GenWordSimplifyExpr(Expr EWord)) -> ioProperty $ do
+    , testProperty "word-simplification" $ \(GenWordSimplifyExpr expr) -> ioProperty $ do
           let simplified = Expr.simplify expr
           checkEquiv expr simplified
     , testProperty "readStorage-equivalance" $ \(store, addr, slot) -> ioProperty $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -147,7 +147,7 @@ tests = testGroup "hevm"
         let simplified = Expr.readStorage' addr slot store
             full = SLoad addr slot store
         checkEquiv simplified full
-    , testProperty "writeStorage-equivalance" $ \(val, GenWriteStorageExpr (addr, slot, store) :: GenWriteStorageExpr (Expr EWord, Expr EWord, Expr Storage)) -> ioProperty $ do
+    , testProperty "writeStorage-equivalance" $ \(val, GenWriteStorageExpr (addr, slot, store)) -> ioProperty $ do
         putStrLn $ "e: " <> show store <> " a: " <> show addr <> " s: " <> show slot
         let simplified = Expr.writeStorage addr slot val store
             full = SStore addr slot val store

--- a/test/test.hs
+++ b/test/test.hs
@@ -140,7 +140,7 @@ tests = testGroup "hevm"
     , testProperty "byte-simplification" $ \(expr :: Expr Byte) -> ioProperty $ do
         let simplified = Expr.simplify expr
         checkEquiv expr simplified
-    , testProperty "word-simplification" $ \(GenWordSimplifyExpr expr) -> ioProperty $ do
+    , testProperty "word-simplification" $ \((GenWordSimplifyExpr expr) :: GenWordSimplifyExpr(Expr EWord)) -> ioProperty $ do
           let simplified = Expr.simplify expr
           checkEquiv expr simplified
     , testProperty "readStorage-equivalance" $ \(store, addr, slot) -> ioProperty $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -139,10 +139,9 @@ tests = testGroup "hevm"
     , testProperty "byte-simplification" $ \(expr :: Expr Byte) -> ioProperty $ do
         let simplified = Expr.simplify expr
         checkEquiv expr simplified
-    , testProperty "word-simplification" $ \(_ :: Int) -> ioProperty $ do
-        expr <- generate . sized $ genWord 0 -- we want a lower frequency of lits for this test
-        let simplified = Expr.simplify expr
-        checkEquiv expr simplified
+    , testProperty "word-simplification" $ \((WordSimplifyExpr expr) :: WordSimplifyExpr(Expr EWord)) -> ioProperty $ do
+          let simplified = Expr.simplify expr
+          checkEquiv expr simplified
     , testProperty "readStorage-equivalance" $ \(store, addr, slot) -> ioProperty $ do
         let simplified = Expr.readStorage' addr slot store
             full = SLoad addr slot store
@@ -2436,6 +2435,7 @@ instance Arbitrary (Expr Buf) where
 instance Arbitrary (Expr End) where
   arbitrary = sized genEnd
 
+-- LitOnly
 newtype LitOnly a = LitOnly a
   deriving (Show, Eq)
 
@@ -2447,6 +2447,14 @@ instance Arbitrary (LitOnly (Expr EWord)) where
 
 instance Arbitrary (LitOnly (Expr Buf)) where
   arbitrary = LitOnly . ConcreteBuf <$> arbitrary
+
+-- WordSimplifyExpr
+newtype WordSimplifyExpr a = WordSimplifyExpr a
+  deriving (Show, Eq)
+
+instance Arbitrary (WordSimplifyExpr (Expr EWord)) where
+  arbitrary = do
+    fmap WordSimplifyExpr . sized $ genWord 0
 
 genByte :: Int -> Gen (Expr Byte)
 genByte 0 = fmap LitByte arbitrary

--- a/test/test.hs
+++ b/test/test.hs
@@ -148,7 +148,6 @@ tests = testGroup "hevm"
             full = SLoad addr slot store
         checkEquiv simplified full
     , testProperty "writeStorage-equivalance" $ \(val, GenWriteStorageExpr (addr, slot, store)) -> ioProperty $ do
-        putStrLn $ "e: " <> show store <> " a: " <> show addr <> " s: " <> show slot
         let simplified = Expr.writeStorage addr slot val store
             full = SStore addr slot val store
         checkEquiv simplified full

--- a/test/test.hs
+++ b/test/test.hs
@@ -156,7 +156,7 @@ tests = testGroup "hevm"
         let simplified = Expr.readWord idx buf
             full = ReadWord idx buf
         checkEquiv simplified full
-    , testProperty "writeWord-equivalance" $ \(idx, val, (GenWriteWordBuf buf) :: GenWriteWordBuf (Expr Buf)) -> ioProperty $ do
+    , testProperty "writeWord-equivalance" $ \(idx, val, GenWriteWordBuf buf) -> ioProperty $ do
         let simplified = Expr.writeWord idx val buf
             full = WriteWord idx val buf
         checkEquiv simplified full


### PR DESCRIPTION
## Description

Some automated tests were not reproducible due to the use of `generate`. This type-wraps a number of these generators and makes them reproducible

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
