### PR TITLE
Bump nixpkgs to GHC 9.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -72,11 +72,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1683191603,
-        "narHash": "sha256-KdSKdwz3+VJQIHc8sCDwPo2OQtPs5jbxwrLXseHLlfc=",
+        "lastModified": 1688462028,
+        "narHash": "sha256-+43L9rwbNC1cO0LrinxjaolmyIH/STpL67uf2s6+6C0=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "5a53423b983f623420733f62c01fa69d1f4cdda9",
+        "rev": "e8fb5553c880942ac5215fb210ada54841605c62",
         "type": "github"
       },
       "original": {
@@ -102,15 +102,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1685010270,
-        "narHash": "sha256-szQuu3p4FcO38Sh/EKwHlyOeXuSyZWUIwu8onxP/Y1U=",
+        "lastModified": 1688961476,
+        "narHash": "sha256-oYcCy27BdAfU5H5DDQ7vWdrhaIgRCZ5XASORrwrQAAg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "832deaa0483b1aa392b41b26cacbddfea047e15e",
+        "rev": "3ba086a64b3997ee82e331abaf3af7049e3fc742",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs";
+    nixpkgs.url = "github:nixos/nixpkgs/haskell-updates";
     foundry.url = "github:shazow/foundry.nix/monthly";
     flake-compat = {
       url = "github:edolstra/flake-compat";

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -138,17 +138,17 @@ library
     Decimal                           >= 0.5.1 && < 0.6,
     containers                        >= 0.6.0 && < 0.7,
     deepseq                           >= 1.4.4 && < 1.5,
-    time                              >= 1.11.1.1 && < 1.12,
+    time                              >= 1.11 && < 1.14,
     transformers                      >= 0.5.6 && < 0.6,
     tree-view                         >= 0.5 && < 0.6,
     abstract-par                      >= 0.3.3 && < 0.4,
-    aeson                             >= 2.0.0 && < 2.1,
+    aeson                             >= 2.0.0 && < 2.2,
     bytestring                        >= 0.11.3.1 && < 0.12,
     scientific                        >= 0.3.6 && < 0.4,
     binary                            >= 0.8.6 && < 0.9,
-    text                              >= 1.2.3 && < 1.3,
+    text                              >= 1.2.3 && < 2.1,
     unordered-containers              >= 0.2.10 && < 0.3,
-    vector                            >= 0.12.1 && < 0.13,
+    vector                            >= 0.12.1 && < 0.14,
     ansi-wl-pprint                    >= 0.6.9 && < 0.7,
     base16                            >= 0.3.2.0 && < 0.3.3.0,
     megaparsec                        >= 9.0.0 && < 10.0,
@@ -190,8 +190,8 @@ library
     witch                             >= 1.1 && < 1.3
   if !os(windows)
     build-depends:
-      brick                           >= 1.4 && < 1.5,
-      vty                             >= 5.37 && < 5.38
+      brick                           >= 1.4 && < 2.0,
+      vty                             >= 5.37 && < 5.39
   hs-source-dirs:
     src
 


### PR DESCRIPTION
## Description
It looks like `haskell-updates` branch is already quite good so it only required dependency bounds adjustment. I'll bump it again once [the PR](https://github.com/NixOS/nixpkgs/pull/240387) is merged.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
