### PR TITLE
Fix stripwrites bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SMT encoding of Expr now has assertions for the range of environment values that are less than word size (256 bits).
 - Trace now contains the cheat code calls
 - More consistent error messages
+- Fixed overflow issue in stripWrites
 
 ## Changed
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -125,6 +125,12 @@ tests = testGroup "hevm"
         let e = ReadWord (Lit 0x0) (CopySlice (Lit 0x0) (Lit 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc) (Lit 0x6) (ConcreteBuf "\255\255\255\255\255\255") (ConcreteBuf ""))
         b <- checkEquiv e (Expr.simplify e)
         assertBool "Simplifier failed" b
+    , testCase "stripWrites-overflow" $ do
+        let
+          a = ReadByte (Lit 0xf0000000000000000000000000000000000000000000000000000000000000) (WriteByte (And (SHA256 (ConcreteBuf "")) (Lit 0x1)) (LitByte 0) (ConcreteBuf ""))
+          b = Expr.simplify a
+        ret <- checkEquiv a b
+        assertBool "must be equivalent" ret
     ]
   -- These tests fuzz the simplifier by generating a random expression,
   -- applying some simplification rules, and then using the smt encoding to

--- a/test/test.hs
+++ b/test/test.hs
@@ -126,6 +126,9 @@ tests = testGroup "hevm"
         b <- checkEquiv e (Expr.simplify e)
         assertBool "Simplifier failed" b
     , testCase "stripWrites-overflow" $ do
+        -- below eventually boils down to
+        -- unsafeInto (0xf0000000000000000000000000000000000000000000000000000000000000+1) :: Int
+        -- which failed before
         let
           a = ReadByte (Lit 0xf0000000000000000000000000000000000000000000000000000000000000) (WriteByte (And (SHA256 (ConcreteBuf "")) (Lit 0x1)) (LitByte 0) (ConcreteBuf ""))
           b = Expr.simplify a


### PR DESCRIPTION
## Description
This fixes a bug in stripWrites that overflew the Int on addition. This was discovered due to `unsafeInto`.

Fixes issue https://github.com/ethereum/hevm/issues/304

## Checklist

- [x] tested locally
- [ x added automated tests
- [ ] updated the docs
- [x]updated the changelog
