### PR TITLE
flake.nix: disable foundry if on darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
           z3-latest
           cvc5
           git
+        ] ++ lib.optional (!pkgs.stdenv.isDarwin) [
           foundry.defaultPackage.${system}
         ];
 


### PR DESCRIPTION
## Description
This is so that `nix develop` can work on darwin. Note that currently some upstream problems with ormolu still need to be resolved, but that is not related.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
