### PR TITLE
Generalize abstractVM so that it can be used for contract creation and add keccak computation pass

### DIFF
--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -4,7 +4,7 @@
     Module: EVM.Keccak
     Description: Expr passes to determine Keccak assumptions
 -}
-module EVM.Keccak (keccakAssumptions) where
+module EVM.Keccak (keccakAssumptions, keccakCompute) where
 
 import Control.Monad.State
 import Data.Set (Set)
@@ -12,6 +12,7 @@ import Data.Set qualified as Set
 
 import EVM.Traversals
 import EVM.Types
+import EVM.Expr
 
 data BuilderState = BuilderState
   { keccaks :: Set (Expr EWord) }
@@ -72,3 +73,24 @@ keccakAssumptions ps bufs stores = injectivity <> minValue
 
     injectivity = fmap injProp $ combine (Set.toList st.keccaks)
     minValue = fmap minProp (Set.toList st.keccaks)
+
+compute :: forall a. Expr a -> [Prop]
+compute = \case
+  e@(Keccak buf) -> do
+    let b = simplify buf
+    case keccak b of
+      lit@(Lit _) -> [PEq e lit]
+      _ -> []
+  _ -> []
+
+computeKeccakExpr :: forall a. Expr a -> [Prop]
+computeKeccakExpr e = foldExpr compute [] e
+
+computeKeccakProp :: Prop -> [Prop]
+computeKeccakProp p = foldProp compute [] p
+
+keccakCompute :: [Prop] -> [Expr Buf] -> [Expr Storage] -> [Prop]
+keccakCompute ps buf stores = 
+  concatMap computeKeccakProp ps <>
+  concatMap computeKeccakExpr buf <>
+  concatMap computeKeccakExpr stores

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -34,7 +34,7 @@ import Witch (into, unsafeInto)
 import EVM.CSE
 import EVM.Expr (writeByte, bufLengthEnv, containsNode, bufLength, minLength, inRange)
 import EVM.Expr qualified as Expr
-import EVM.Keccak (keccakAssumptions)
+import EVM.Keccak (keccakAssumptions, keccakCompute)
 import EVM.Traversals
 import EVM.Types
 
@@ -174,6 +174,9 @@ assertProps ps =
     keccakAssumes
       = SMT2 ["; keccak assumptions"] mempty
       <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakAssumptions ps_elim bufVals storeVals)) mempty
+      <> SMT2 ["; keccak computations"] mempty
+      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakCompute ps_elim bufVals storeVals)) mempty
+      
 
     readAssumes
       = SMT2 ["; read assumptions"] mempty

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -199,7 +199,7 @@ abstractVM cd contractCode maybepre store create = finalVm
     value = CallValue 0
     code = if create then InitCode contractCode mempty
            else RuntimeCode (ConcreteRuntimeCode contractCode)
-    vm' = loadSymVM code store caller value cd create
+    vm' = loadSymVM code store caller value  (if create then mempty else cd)  create
     precond = case maybepre of
                 Nothing -> []
                 Just p -> [p vm']

--- a/test/test.hs
+++ b/test/test.hs
@@ -1733,7 +1733,7 @@ tests = testGroup "hevm"
           Just c <- solcRuntime "C" code'
           Just a <- solcRuntime "A" code'
           (_, [Cex (_, cex)]) <- withSolvers Z3 1 Nothing $ \s -> do
-            let vm0 = abstractVM (mkCalldata (Just (Sig "call_A()" [])) []) c Nothing AbstractStore
+            let vm0 = abstractVM (mkCalldata (Just (Sig "call_A()" [])) []) c Nothing AbstractStore False
             let vm = vm0
                   & set (#state % #callvalue) (Lit 0)
                   & over (#env % #contracts)
@@ -1801,7 +1801,7 @@ tests = testGroup "hevm"
         ,
         ignoreTest $ testCase "safemath distributivity (yul)" $ do
           let yulsafeDistributivity = hex "6355a79a6260003560e01c14156016576015601f565b5b60006000fd60a1565b603d602d604435600435607c565b6039602435600435607c565b605d565b6052604b604435602435605d565b600435607c565b141515605a57fe5b5b565b6000828201821115151560705760006000fd5b82820190505b92915050565b6000818384048302146000841417151560955760006000fd5b82820290505b92915050565b"
-          let vm =  abstractVM (mkCalldata (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) []) yulsafeDistributivity Nothing AbstractStore
+          let vm =  abstractVM (mkCalldata (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) []) yulsafeDistributivity Nothing AbstractStore False
           (_, [Qed _]) <-  withSolvers Z3 1 Nothing $ \s -> verify s defaultVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
           putStrLn "Proven"
         ,


### PR DESCRIPTION
## Description

This PR adds two functionalities useful for Act:

1) Generalises the `abstractVm` function so that it can be used for contract creation. 
2) Adds a pass that simplifies arguments of Keccak calls, checking it a call can be computed to a concrete call. If so it adds an equation of the form `Peq (Keccak bs) concrete_hash` to the asserted propositions. This is useful for Act because the Act translation will not compute keccak by default so it is missing some information compared to the EVM code.

## Checklist

- [X] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
