### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: haskell/actions/setup@v2
         id: cabal
         with:
-          ghc-version: '9.4.5'
+          ghc-version: '9.2.8'
       - name: run cabal check
         run: cabal check --verbose=3
       - name: build and install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: "Build"
 on:
   pull_request:
   push:
+    branches:
+      main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: "Build"
 on:
   pull_request:
   push:
-    branches:
-      main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: "Build"
 on:
   pull_request:
   push:
+    branches:
+      main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -71,10 +73,11 @@ jobs:
             gmp:p
             openssl:p
       - uses: haskell/actions/setup@v2
-        id: cabal
+        id: setup
         with:
           ghc-version: '9.2.8'
-      - name: build and install dependencies
+
+      - name: build and install c dependencies
         run: |
           echo "::group::Installing libsecp256k1"
           ./.github/scripts/install-libsecp256k1.sh
@@ -82,6 +85,34 @@ jobs:
           echo "::group::Installing libff"
           ./.github/scripts/install-libff.sh
           echo "::endgroup::"
+      - name: Configure the build
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build --dry-run
+          # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install haskell dependencies
+        run: cabal build all --only-dependencies
+
+      # Cache dependencies already, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v3
+        # Caches are immutable, trying to save with the same key would error.
+        if: ${{ steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
       - name: build hevm library
         run: |
           cabal build --extra-include-dirs="$HOME/.local/include" --extra-lib-dirs="$HOME/.local/lib"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,4 +86,4 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: run cabal check
-        run: nix-shell --pure --command "cabal check --verbose=3"
+        run: nix develop -c cabal check --verbose=3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ jobs:
           path: result/bin/hevm
       - name: run rpc tests
         run: nix-shell --pure --command "cabal run rpc-tests"
-      - name: run ethereum tests
-        run: nix-shell --command "cabal run ethereum-tests"
 
   build-windows:
     name: build (windows-latest)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: build hevm
-        run: nix build .#withTests -L
+        run: nix build .#ci -L
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -85,7 +85,7 @@ jobs:
           echo "::endgroup::"
       - name: Configure the build
         run: |
-          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal configure --disable-tests --disable-benchmarks --disable-documentation
           cabal build --dry-run
           # The last step generates dist-newstyle/cache/plan.json for the cache key.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: run cabal check
-        run: nix-shell --pure --command "cabal check --verbose=3"
       - name: build hevm
         run: nix build .#withTests -L
       - name: Upload artifacts
@@ -38,6 +36,7 @@ jobs:
         run: nix-shell --pure --command "cabal run rpc-tests"
       - name: run ethereum tests
         run: nix-shell --command "cabal run ethereum-tests"
+
   build-windows:
     name: build (windows-latest)
     runs-on: windows-latest
@@ -68,8 +67,6 @@ jobs:
         id: cabal
         with:
           ghc-version: '9.2.8'
-      - name: run cabal check
-        run: cabal check --verbose=3
       - name: build and install dependencies
         run: |
           echo "::group::Installing libsecp256k1"
@@ -81,3 +78,12 @@ jobs:
       - name: build hevm library
         run: |
           cabal build --extra-include-dirs="$HOME/.local/include" --extra-lib-dirs="$HOME/.local/lib"
+
+  cabal-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: run cabal check
+        run: nix-shell --pure --command "cabal check --verbose=3"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,7 @@ jobs:
           path: result/bin/hevm
 
   rpc-tests:
-    strategy:
-      matrix:
-       os: [ ubuntu-latest, macos-latest ]
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,31 +16,23 @@ jobs:
        # the attribute names defined in release.nix
        include:
          - os: ubuntu-latest
-           os_attr: linux
+           os_attr: x86_64-linux
          - os: macos-latest
-           os_attr: darwin
+           os_attr: x86_64-macos
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v22
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: cachix/cachix-action@v12
-        with:
-          name: hevm
-          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: run cabal check
         run: nix-shell --pure --command "cabal check --verbose=3"
       - name: build hevm
         run: nix build .#withTests -L
       - name: Upload artifacts
-        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v3
         with:
-          name: hevm-x86_64-linux
+          name: hevm-${{ matrix.os_attr }}
           path: result/bin/hevm
       - name: run rpc tests
         run: nix-shell --pure --command "cabal run rpc-tests"
@@ -75,7 +67,7 @@ jobs:
       - uses: haskell/actions/setup@v2
         id: cabal
         with:
-          ghc-version: '9.2'
+          ghc-version: '9.4.5'
       - name: run cabal check
         run: cabal check --verbose=3
       - name: build and install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ jobs:
     strategy:
       matrix:
        os: [ ubuntu-latest, macos-latest ]
-       # we need this to map platform names as used by github to
-       # the attribute names defined in release.nix
        include:
          - os: ubuntu-latest
            os_attr: x86_64-linux
@@ -32,6 +30,17 @@ jobs:
         with:
           name: hevm-${{ matrix.os_attr }}
           path: result/bin/hevm
+
+  rpc-tests:
+    strategy:
+      matrix:
+       os: [ ubuntu-latest, macos-latest ]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: run rpc tests
         run: nix-shell --pure --command "cabal run rpc-tests"
 

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -13,11 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v21
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: lookup nix versions
         id: nixpkgs
         run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,11 +8,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - uses: cachix/install-nix-action@v21
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: build docs
         run: nix-shell --pure --command "cd doc && mdbook build"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v22
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: build hevm
         run: |
           nix build .#redistributable --out-link hevmMacos
@@ -29,11 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v22
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: build hevm
         run: |
           nix build .#redistributable --out-link hevmLinux

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
 
         # --- packages ----
 
-        packages.withTests = pkgs.haskell.lib.disableLibraryProfiling hevmUnwrapped;
+        packages.ci = with pkgs.haskell.lib; dontHaddock (disableLibraryProfiling hevmUnwrapped);
         packages.noTests = pkgs.haskell.lib.dontCheck hevmUnwrapped;
         packages.hevm = hevmWrapped;
         packages.redistributable = hevmRedistributable;

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
             inherit secp256k1;
           })
           [
-            (haskell.lib.compose.overrideCabal (old: { testTarget = "test"; }))
+            (haskell.lib.compose.overrideCabal (old: { testTarget = "test ethereum-tests"; }))
             (haskell.lib.compose.addTestToolDepends testDeps)
             (haskell.lib.compose.appendBuildFlags ["-v3"])
             (haskell.lib.compose.appendConfigureFlags (

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
 
         # --- packages ----
 
-        packages.withTests = hevmUnwrapped;
+        packages.withTests = pkgs.haskell.lib.disableLibraryProfiling hevmUnwrapped;
         packages.noTests = pkgs.haskell.lib.dontCheck hevmUnwrapped;
         packages.hevm = hevmWrapped;
         packages.redistributable = hevmRedistributable;

--- a/flake.nix
+++ b/flake.nix
@@ -155,11 +155,12 @@
             ] ++ testDeps;
             withHoogle = true;
 
-            # NOTE: hacks for bugged cabal new-repl
-            LD_LIBRARY_PATH = libraryPath;
             HEVM_SOLIDITY_REPO = solidity;
             DAPP_SOLC = "${pkgs.solc}/bin/solc";
             HEVM_ETHEREUM_TESTS_REPO = ethereum-tests;
+
+            # NOTE: hacks for bugged cabal new-repl
+            LD_LIBRARY_PATH = libraryPath;
             shellHook = lib.optionalString stdenv.isDarwin ''
               export DYLD_LIBRARY_PATH="${libraryPath}";
             '';

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,5 @@
 # hevm
 
-test
 The `hevm` project is an implementation of the Ethereum virtual machine (EVM) made specifically for
 symbolic execution, unit testing and debugging of smart contracts. The `hevm` command line program
 can symbolically execute smart contracts, run unit tests, interactively debug contracts while

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
 # hevm
 
+test
 The `hevm` project is an implementation of the Ethereum virtual machine (EVM) made specifically for
 symbolic execution, unit testing and debugging of smart contracts. The `hevm` command line program
 can symbolically execute smart contracts, run unit tests, interactively debug contracts while


### PR DESCRIPTION
## Description

- switches from cachix to magic-nix-cache (local cache should be a bit faster than cachix cache)
- runs cabal check and rpc-tests in parallel with the main `nix build` (duplicates a bit of work but we finish faster in the end)
- runs rpc-tests on linux only (running on macos was taking 20mins)
- uses the github cache for hackage deps on windows
- runs ethereum-tests as part of `nix build` (avoids shell setup time)
- disbles library profiling in ci (avoids double builds)
- disabled haddock generation in ci (not needed to build & test executables)
- runs ci on push to main and pull request only (avoids duplicated builds on prs)

Taken together this seems to get us down to ~10mins for ci execution. Ideally we would also cache all our nix deps in the github actions cache (instead of pulling from cache.nixos.org) but there doesn't seem to be a really good way to do that atm (magic-nix-cache only caches stuff that gets built during the actions run).

Note that this change also means that we no longer run ci on every push to every branch. If you want CI to run for a branch, you need to open a draft. This is a bit unfortunate, but it seems to be a limitation of the github actions workflow triggers. I decided that cutting ci time was more important than having it run on every commit...

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
