### PR TITLE
flake.nix: install cabal-install from head

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "cabal-head": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689711523,
+        "narHash": "sha256-lmECGcDNg+rgGAYTaK6v3xMiblrA+W0LOBDrWvaOr4Y=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "baa767a90dd8c0d3bafd82b48ff8e83b779f238a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "ethereum-tests": {
       "flake": false,
       "locked": {
@@ -118,6 +134,7 @@
     },
     "root": {
       "inputs": {
+        "cabal-head": "cabal-head",
         "ethereum-tests": "ethereum-tests",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -24,22 +24,7 @@ build-type:
   Simple
 extra-source-files:
   CHANGELOG.md
-  bench/contracts/erc20.sol
-  test/contracts/lib/test.sol
-  test/contracts/lib/erc20.sol
-  test/contracts/pass/trivial.sol
-  test/contracts/pass/abstract.sol
-  test/contracts/pass/cheatCodes.sol
-  test/contracts/pass/constantinople.sol
-  test/contracts/pass/dsProvePass.sol
-  test/contracts/pass/invariants.sol
-  test/contracts/pass/libraries.sol
-  test/contracts/pass/loops.sol
-  test/contracts/pass/rpc.sol
-  test/contracts/fail/trivial.sol
-  test/contracts/fail/cheatCodes.sol
-  test/contracts/fail/dsProveFail.sol
-  test/contracts/fail/invariantFail.sol
+  bench/contracts/*.sol
   test/scripts/convert_trace_to_json.sh
 
 flag ci


### PR DESCRIPTION
## Description

This is pretty ugly (and will probably make updating to a newer nixpkgs annoying), but it does give us access to the multiple components features that were added to cabal in https://github.com/haskell/cabal/pull/8726. Which is imo a large enough workflow upgrade that it's worth this temporary hack until we get an official release. 

See https://well-typed.com/blog/2023/03/cabal-multi-unit/ for docs.

To spawn a repl session for the tests where `:r` will reload changes made in `lib:hevm`, and run a single test:

```
cabal repl --enable-multi-repl test lib:hevm lib:test-utils
ghci> import Main
ghci> runSubSet "<TESTNAME>"
```

One unfortunate downside is that `Paths.getDataFileName` seems to be broken in a multi-component repl, so the tests that trace vs geth and the `Dapp-Tests` test group are broken. They still work in the normal single component repl.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
