### PR TITLE
Add contractname to to code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ## Fixed
+
 - CopySlice wraparound issue especially during CopyCallBytesToMemory
+- EVM.Solidity.toCode to include contractName in error string
 
 ## Changed
 


### PR DESCRIPTION
## Description

I am fed up with:

```
echidna: invalid character at offset: 28328
CallStack (from HasCallStack):
  error, called at src/EVM/Solidity.hs:654:18 in hevm-0.51.3-J1ldUo8hL8f8OHSfPt43cf:EVM.Solidity
```

And I decided to fix:

```haskell
toCode :: Text -> ByteString
toCode t = case BS16.decodeBase16 (encodeUtf8 t) of
  Right d -> d
  Left e -> if containsLinkerHole t
            then error "Error: unlinked libraries detected in bytecode"
            else error $ T.unpack e
```

Here is the change. I tested locally with a nixpkgs build of echidna:

```
echidna: Error :invalid character at offset: 21198 in /home/hellwolf/Projects/superfluid/protocol-monorepo_dev/packages/hot-fuzz/contracts/superfluid-tests/SuperHotFuzz.sol:SuperHotFuzz
CallStack (from HasCallStack):
  error, called at src/EVM/Solidity.hs:654:18 in hevm-0.51.3-J1ldUo8hL8f8OHSfPt43cf:EVM.Solidity
```


## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
