### PR TITLE
SymExec: run whole expression simplifier on branch conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EVM.Solidity.toCode to include contractName in error string
 
 ## Changed
+- Run expression simplification on branch conditions
 
 ## [0.51.3] - 2023-07-14
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1121,11 +1121,12 @@ choose = assign #result . Just . HandleEffect . Choose
 branch :: CodeLocation -> Expr EWord -> (Bool -> EVM ()) -> EVM ()
 branch loc cond continue = do
   pathconds <- use #constraints
-  query $ PleaseAskSMT cond pathconds choosePath
+  query $ PleaseAskSMT condSimp pathconds choosePath
   where
+    condSimp = Expr.simplify cond
     choosePath (Case v) = do
       assign #result Nothing
-      pushTo #constraints $ if v then (cond ./= Lit 0) else (cond .== Lit 0)
+      pushTo #constraints $ if v then (condSimp ./= Lit 0) else (condSimp .== Lit 0)
       (iteration, _) <- use (#iterations % at loc % non (0,[]))
       stack <- use (#state % #stack)
       assign (#cache % #path % at (loc, iteration)) (Just v)
@@ -1133,7 +1134,7 @@ branch loc cond continue = do
       continue v
     -- Both paths are possible; we ask for more input
     choosePath Unknown =
-      choose . PleaseChoosePath cond $ choosePath . Case
+      choose . PleaseChoosePath condSimp $ choosePath . Case
 
 -- | Construct RPC Query and halt execution until resolved
 fetchAccount :: Addr -> (Contract -> EVM ()) -> EVM ()

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -280,7 +280,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
 
         case q of
           PleaseAskSMT cond _ continue -> do
-            case cond of
+            case Expr.simplify cond of
               -- is the condition concrete?
               Lit c ->
                 -- have we reached max iterations, are we inside a loop?

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -280,7 +280,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
 
         case q of
           PleaseAskSMT cond _ continue -> do
-            case Expr.simplify cond of
+            case cond of
               -- is the condition concrete?
               Lit c ->
                 -- have we reached max iterations, are we inside a loop?


### PR DESCRIPTION
## Description

Runs the whole expression simplifier on branch conditions. Haven't really benchmarks, but should hopefully help us simplify down some stuff that the inline rules match (e.g. `Eq a a == Lit 1`).

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
