### PR TITLE
SymExec: evalProp handles equality of concrete stores and buffers

### DIFF
--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -520,6 +520,8 @@ evalProp prop =
     go (PImpl (PBool False) _) = PBool True
 
     go (PEq (Lit l) (Lit r)) = PBool (l == r)
+    go (PEq (ConcreteBuf l) (ConcreteBuf r)) = PBool (l == r)
+    go (PEq (ConcreteStore l) (ConcreteStore r)) = PBool (l == r)
     go o@(PEq l r)
       | l == r = PBool True
       | otherwise = o


### PR DESCRIPTION
## Description

Missed this case when I rewrote `evalProp` before...

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
