### PR TITLE
UnitTest: reverts do not fail symbolic tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run expression simplification on branch conditions
 - 'check' prefix now recognized as a function signature to symbolically execute for Dapps
 
+- symbolic solidity tests no longer consider reverts to be a failure, and check only for the ds-test failed bit or unser defined assertion failures (i.e. `Panic(0x01)`)
+
 ## [0.51.3] - 2023-07-14
 
 ## Fixed

--- a/test/contracts/fail/dsProveFail.sol
+++ b/test/contracts/fail/dsProveFail.sol
@@ -12,15 +12,15 @@ contract SolidityTest is DSTest {
         assert(false);
     }
 
+    function prove_trivial_dstest() public {
+        assertEq(uint(1), uint(2));
+    }
+
     function prove_add(uint x, uint y) public {
         unchecked {
             assertTrue(x + y >= x);
         }
     }
-
-    //function proveFail_shouldFail(address usr) public {
-        //usr.call("");
-    //}
 
     function prove_smtTimeout(uint x, uint y, uint z) public {
         if ((x * y / z) * (x / y) / (x * y) == (x * x * x * y * z / x * z * y)) {
@@ -42,25 +42,8 @@ contract SolidityTest is DSTest {
         }
     }
 
-    function prove_mul(uint136 x, uint128 y) public {
-        x * y;
-    }
-
     function prove_distributivity(uint120 x, uint120 y, uint120 z) public {
         assertEq(x + (y * z), (x + y) * (x + z));
-    }
-
-    function prove_transfer(uint supply, address usr, uint amt) public {
-        token.mint(address(this), supply);
-
-        uint prebal = token.balanceOf(usr);
-        token.transfer(usr, amt);
-        uint postbal = token.balanceOf(usr);
-
-        uint expected = usr == address(this)
-                        ? 0    // self transfer is a noop
-                        : amt; // otherwise `amt` has been transfered to `usr`
-        assertEq(expected, postbal - prebal);
     }
 }
 

--- a/test/contracts/pass/dsProvePass.sol
+++ b/test/contracts/pass/dsProvePass.sol
@@ -48,29 +48,22 @@ contract SolidityTest is DSTest {
         assertEq(b, c.a());
     }
 
-    function proveFail_revertSmoke() public {
+    function prove_no_fail_require() public {
         require(false);
+    }
+
+    function proveFail_userAssertSmoke() public {
+        assert(false);
     }
 
     function proveFail_assertSmoke() public {
         assertTrue(false);
     }
 
-    // Takes too long, disabling here, moving to benchmarks
-    // function prove_transfer(uint supply, address usr, uint amt) public {
-    //     if (amt > supply) return; // no underflow
-    //
-    //     token.mint(address(this), supply);
-    //
-    //     uint prebal = token.balanceOf(usr);
-    //     token.transfer(usr, amt);
-    //     uint postbal = token.balanceOf(usr);
-    //
-    //     uint expected = usr == address(this)
-    //                     ? 0    // self transfer is a noop
-    //                     : amt; // otherwise `amt` has been transfered to `usr`
-    //     assertEq(expected, postbal - prebal);
-    // }
+    // requires don't fail passing tests, but are not treated as successes in proveFail tests.
+    function proveFail_require() public {
+        require(false);
+    }
 
     function prove_burn(uint supply, uint amt) public {
         if (amt > supply) return; // no undeflow

--- a/test/contracts/pass/dsProvePass.sol
+++ b/test/contracts/pass/dsProvePass.sol
@@ -48,7 +48,16 @@ contract SolidityTest is DSTest {
         assertEq(b, c.a());
     }
 
+    // requires do not trigger a failure in `prove_` tests
     function prove_no_fail_require() public {
+        require(false);
+    }
+
+    // all branches in a proveFail test must end in one of:
+    //  - a require
+    //  - a failed user defined assert
+    //  - a failed ds-test assertion violation
+    function proveFail_require() public {
         require(false);
     }
 
@@ -58,11 +67,6 @@ contract SolidityTest is DSTest {
 
     function proveFail_assertSmoke() public {
         assertTrue(false);
-    }
-
-    // requires don't fail passing tests, but are not treated as successes in proveFail tests.
-    function proveFail_require() public {
-        require(false);
     }
 
     function prove_burn(uint supply, uint amt) public {

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -60,7 +60,7 @@ tests = testGroup "rpc"
     -- execute against remote state from a ds-test harness
     [ testCase "dapp-test" $ do
         let testFile = "test/contracts/pass/rpc.sol"
-        runSolidityTestCustom testFile ".*" Nothing False testRpcInfo Foundry >>= assertEqual "test result" True
+        runSolidityTestCustom testFile ".*" Nothing Nothing False testRpcInfo Foundry >>= assertEqual "test result" True
 
     -- concretely exec "transfer" on WETH9 using remote rpc
     -- https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2#code

--- a/test/test.hs
+++ b/test/test.hs
@@ -663,7 +663,6 @@ tests = testGroup "hevm"
         let testFile = "test/contracts/fail/dsProveFail.sol"
         runSolidityTest testFile "prove_trivial" >>= assertEqual "test result" False
         runSolidityTest testFile "prove_trivial_dstest" >>= assertEqual "test result" False
-        runSolidityTest testFile "proveFail_require" >>= assertEqual "test result" False
         runSolidityTest testFile "prove_add" >>= assertEqual "test result" False
         runSolidityTestCustom testFile "prove_smtTimeout" (Just 1) Nothing False Nothing Foundry >>= assertEqual "test result" False
         runSolidityTest testFile "prove_multi" >>= assertEqual "test result" False

--- a/test/test.hs
+++ b/test/test.hs
@@ -641,7 +641,7 @@ tests = testGroup "hevm"
               , ("test/contracts/fail/dsProveFail.sol", "prove_add", False)
               ]
         results <- forM cases $ \(testFile, match, expected) -> do
-          actual <- runSolidityTestCustom testFile match Nothing False Nothing DappTools
+          actual <- runSolidityTestCustom testFile match Nothing Nothing False Nothing DappTools
           pure (actual == expected)
         assertBool "test result" (and results)
     , testCase "Trivial-Fail" $ do
@@ -662,15 +662,17 @@ tests = testGroup "hevm"
     , testCase "Prove-Tests-Fail" $ do
         let testFile = "test/contracts/fail/dsProveFail.sol"
         runSolidityTest testFile "prove_trivial" >>= assertEqual "test result" False
+        runSolidityTest testFile "prove_trivial_dstest" >>= assertEqual "test result" False
+        runSolidityTest testFile "proveFail_require" >>= assertEqual "test result" False
         runSolidityTest testFile "prove_add" >>= assertEqual "test result" False
-        --runSolidityTest testFile "prove_smtTimeout" >>= assertEqual "test result" False
+        runSolidityTestCustom testFile "prove_smtTimeout" (Just 1) Nothing False Nothing Foundry >>= assertEqual "test result" False
         runSolidityTest testFile "prove_multi" >>= assertEqual "test result" False
         -- TODO: implement overflow checking optimizations and enable, currently this runs forever
         --runSolidityTest testFile "prove_distributivity" >>= assertEqual "test result" False
     , testCase "Loop-Tests" $ do
         let testFile = "test/contracts/pass/loops.sol"
-        runSolidityTestCustom testFile "prove_loop" (Just 10) False Nothing Foundry >>= assertEqual "test result" True
-        runSolidityTestCustom testFile "prove_loop" (Just 100) False Nothing Foundry >>= assertEqual "test result" False
+        runSolidityTestCustom testFile "prove_loop" Nothing (Just 10) False Nothing Foundry >>= assertEqual "test result" True
+        runSolidityTestCustom testFile "prove_loop" Nothing (Just 100) False Nothing Foundry >>= assertEqual "test result" False
     , testCase "Invariant-Tests-Pass" $ do
         let testFile = "test/contracts/pass/invariants.sol"
         runSolidityTest testFile ".*" >>= assertEqual "test result" True
@@ -683,8 +685,8 @@ tests = testGroup "hevm"
         runSolidityTest testFile ".*" >>= assertEqual "test result" True
     , testCase "Cheat-Codes-Fail" $ do
         let testFile = "test/contracts/fail/cheatCodes.sol"
-        runSolidityTestCustom testFile "testBadFFI" Nothing False Nothing Foundry >>= assertEqual "test result" False
-        runSolidityTestCustom testFile "test_prank_underflow" Nothing False Nothing Foundry >>= assertEqual "test result" False
+        runSolidityTestCustom testFile "testBadFFI" Nothing Nothing False Nothing Foundry >>= assertEqual "test result" False
+        runSolidityTestCustom testFile "test_prank_underflow" Nothing Nothing False Nothing Foundry >>= assertEqual "test result" False
     , testCase "Unwind" $ do
         let testFile = "test/contracts/pass/unwind.sol"
         runSolidityTest testFile ".*" >>= assertEqual "test result" True


### PR DESCRIPTION
## Description

This change makes it so that symbolic tests will no longer report any reachable revert as a failure, and instead treat only the following as failures:

1. A failed user defined assert (e.g `assert(0 == 1)`)
2. A failed ds-test assertion violation (e.g. `assertEq`)

This makes tests execute faster, jmakes them easier to write, and aligns with the way halmos and kevm work.

I also tidied a little bit the solidity test files and the code that executes them.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
