### PR TITLE
SymExec: default symbolic values when displaying calldata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CopySlice wraparound issue especially during CopyCallBytesToMemory
 - EVM.Solidity.toCode to include contractName in error string
+- Better cex reconstruction in cases where branches do not refer to all input variables in calldata
 
 ## Changed
 

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -19,7 +19,7 @@ import EVM.FeeSchedule qualified as FeeSchedule
 import EVM.Fetch qualified as Fetch
 import EVM.Format
 import EVM.Solidity
-import EVM.SymExec (defaultVeriOpts, symCalldata, verify, isQed, extractCex, runExpr, subModel, VeriOpts(..))
+import EVM.SymExec (defaultVeriOpts, symCalldata, verify, isQed, extractCex, runExpr, subModel, defaultSymbolicValues, VeriOpts(..))
 import EVM.Types
 import EVM.Transaction (initTx)
 import EVM.RLP
@@ -777,7 +777,7 @@ prettyCalldata cex buf sig types = head (Text.splitOn "(" sig) <> showCalldata c
 showCalldata :: (?context :: DappContext) => SMTCex -> [AbiType] -> Expr Buf -> Text
 showCalldata cex tps buf = "(" <> intercalate "," (fmap showVal vals) <> ")"
   where
-    argdata = Expr.drop 4 $ simplify $ subModel cex buf
+    argdata = Expr.drop 4 . simplify . defaultSymbolicValues $ subModel cex buf
     vals = case decodeBuf tps argdata of
              CAbi v -> v
              _ -> internalError $ "unable to abi decode function arguments:\n" <> (Text.unpack $ formatExpr argdata)

--- a/test/test.hs
+++ b/test/test.hs
@@ -57,7 +57,7 @@ import EVM.SMT hiding (one)
 import EVM.Solidity
 import EVM.Solvers
 import EVM.Stepper qualified as Stepper
-import EVM.SymExec
+import EVM.SymExec hiding (subStore)
 import EVM.Test.Tracing qualified as Tracing
 import EVM.Test.Utils
 import EVM.Traversals


### PR DESCRIPTION
## Description

Sometimes we get back a model that does not mention all variables that are present in the input calldata buffer. This can happen if those variables are not relevant to the branch that we are producing a model for.

In this case we can simply set the values that remain symbolic afters subsituting in our cex to some default value. We will still have issues here if we have lost some constraints over those variables during simplification, but it's better than what we're doing now (i.e. just printing "Any" if we can't get a fully concrete model for calldata out).

A fully general (and hopefully correct) approach could look like: https://github.com/ethereum/hevm/issues/334

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
