### PR TITLE
Add `check` signature prefix to Dapp checking prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - Run expression simplification on branch conditions
+- 'check' prefix now recognized as a function signature to symbolically execute for Dapps
 
 ## [0.51.3] - 2023-07-14
 

--- a/src/EVM/Dapp.hs
+++ b/src/EVM/Dapp.hs
@@ -106,6 +106,7 @@ mkTest :: Text -> Maybe Test
 mkTest sig
   | "test" `isPrefixOf` sig = Just (ConcreteTest sig)
   | "prove" `isPrefixOf` sig = Just (SymbolicTest sig)
+  | "check" `isPrefixOf` sig = Just (SymbolicTest sig)
   | "invariant" `isPrefixOf` sig = Just (InvariantTest sig)
   | otherwise = Nothing
 

--- a/test/contracts/fail/check-prefix.sol
+++ b/test/contracts/fail/check-prefix.sol
@@ -1,0 +1,11 @@
+import "ds-test/test.sol";
+
+contract SolidityTest is DSTest {
+
+    function setUp() public {
+    }
+
+    function check_trivial() public {
+        assertTrue(false);
+    }
+}

--- a/test/test.hs
+++ b/test/test.hs
@@ -656,6 +656,9 @@ tests = testGroup "hevm"
     , testCase "Prove-Tests-Pass" $ do
         let testFile = "test/contracts/pass/dsProvePass.sol"
         runSolidityTest testFile ".*" >>= assertEqual "test result" True
+    , testCase "prefix-check-for-dapp" $ do
+        let testFile = "test/contracts/fail/check-prefix.sol"
+        runSolidityTest testFile "check_trivial" >>= assertEqual "test result" False
     , testCase "Prove-Tests-Fail" $ do
         let testFile = "test/contracts/fail/dsProveFail.sol"
         runSolidityTest testFile "prove_trivial" >>= assertEqual "test result" False


### PR DESCRIPTION
## Description
This is needed for some tests is sc-comp. Added test to see if this `check` is now working. It seems to be.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
