### PR TITLE
Fix and enfore compilation of benchmarks

### DIFF
--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -89,7 +89,7 @@ runBCTest x =
 
 debugContract :: ByteString -> IO ()
 debugContract c = withSolvers CVC5 4 Nothing $ \solvers -> do
-  let prestate = abstractVM (mkCalldata Nothing []) c Nothing AbstractStore
+  let prestate = abstractVM (mkCalldata Nothing []) c Nothing AbstractStore False
   void $ TTY.runFromVM solvers Nothing Nothing emptyDapp prestate
 
 findPanics :: Solver -> Natural -> Integer -> ByteString -> IO ()

--- a/flake.nix
+++ b/flake.nix
@@ -168,7 +168,7 @@
 
         # --- packages ----
 
-        packages.ci = with pkgs.haskell.lib; dontHaddock (disableLibraryProfiling hevmUnwrapped);
+        packages.ci = with pkgs.haskell.lib; doBenchmark (dontHaddock (disableLibraryProfiling hevmUnwrapped));
         packages.noTests = pkgs.haskell.lib.dontCheck hevmUnwrapped;
         packages.hevm = hevmWrapped;
         packages.redistributable = hevmRedistributable;


### PR DESCRIPTION
## Description

Extends https://github.com/ethereum/hevm/pull/301.

- Fixes compilation of bench.hs
- Fixes the invocation of the bc test runner there
- builds the benchmarking harness in ci

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog