### PR TITLE
Handle nonexistent source map during JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contracts deployed during symbolic execution are created with an empty storage (instead of abstract in previous versions)
 - EVM.Solidity.toCode to include contractName in error string
 - Better cex reconstruction in cases where branches do not refer to all input variables in calldata
+- Correctly handle empty bytestring compiled contracts' JSON
 
 ## Changed
 

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -406,11 +406,15 @@ readFoundryJSON :: Text -> Text -> Maybe (Contracts, Asts, Sources)
 readFoundryJSON contractName json = do
   runtime <- json ^? key "deployedBytecode"
   runtimeCode <- (toCode contractName) . strip0x'' <$> runtime ^? key "object" % _String
-  runtimeSrcMap <- makeSrcMaps =<< runtime ^? key "sourceMap" % _String
+  runtimeSrcMap <- case runtimeCode of
+    "" -> makeSrcMaps ""
+    _ -> makeSrcMaps =<< runtime ^? key "sourceMap" % _String
 
   creation <- json ^? key "bytecode"
   creationCode <- (toCode contractName) . strip0x'' <$> creation ^? key "object" % _String
-  creationSrcMap <- makeSrcMaps =<< creation ^? key "sourceMap" % _String
+  creationSrcMap <- case creationCode of
+    "" -> makeSrcMaps ""
+    _ -> makeSrcMaps =<< creation ^? key "sourceMap" % _String
 
   ast <- json ^? key "ast"
   path <- ast ^? key "absolutePath" % _String

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -406,15 +406,15 @@ readFoundryJSON :: Text -> Text -> Maybe (Contracts, Asts, Sources)
 readFoundryJSON contractName json = do
   runtime <- json ^? key "deployedBytecode"
   runtimeCode <- (toCode contractName) . strip0x'' <$> runtime ^? key "object" % _String
-  runtimeSrcMap <- case runtimeCode of
-    "" -> makeSrcMaps ""
-    _ -> makeSrcMaps =<< runtime ^? key "sourceMap" % _String
+  runtimeSrcMap <- case runtime ^? key "sourceMap" % _String of
+    Nothing -> makeSrcMaps ""
+    smap -> makeSrcMaps =<< smap
 
   creation <- json ^? key "bytecode"
   creationCode <- (toCode contractName) . strip0x'' <$> creation ^? key "object" % _String
-  creationSrcMap <- case creationCode of
-    "" -> makeSrcMaps ""
-    _ -> makeSrcMaps =<< creation ^? key "sourceMap" % _String
+  creationSrcMap <- case creation ^? key "sourceMap" % _String of
+    Nothing -> makeSrcMaps ""
+    smap -> makeSrcMaps =<< smap
 
   ast <- json ^? key "ast"
   path <- ast ^? key "absolutePath" % _String


### PR DESCRIPTION
## Description
When the bytestring is empty, solidity doesn't create a "sourceMap"  JSON attribute. This leads us to a failure to parse the JSON, manifested in #333 . This fixes that. I opted for checking if the `sourceMap` is present. We can also check if `runtimeCode` is empty. What do you think is best? If the empty check is best, we can just revert the last commit. I think the checking for sourceMap is cleaner, but may hide some intent.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
