### PR TITLE
Ux tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EVM.Solidity.toCode to include contractName in error string
 - Better cex reconstruction in cases where branches do not refer to all input variables in calldata
 - Correctly handle empty bytestring compiled contracts' JSON
+- `test` now falls back to displaying an unecoded bytestring for calldata when the model returned by the solver has a different length the length of the arguments in the test signature.
+- we now generate correct counterexamples for branches where only a subset of input variables are referenced by the path conditions
 
 ## Changed
 
 ### UI
 
-- 'check' prefix now recognized as a function signature to symbolically execute for Dapps
-- symbolic solidity tests no longer consider reverts to be a failure, and check only for the ds-test failed bit or unser defined assertion failures (i.e. `Panic(0x01)`)
+- `check` prefix now recognized for symbolic tests
+- solidity tests no longer consider reverts to be a failure, and check only for the ds-test failed bit or unser defined assertion failures (i.e. `Panic(0x01)`). A positive (i.e. non `proveFail`) test with no rechable assertion violations that does not have any succesful branches will still be considered a failure.
 - `vm.prank` now works correctly when passed a symbolic address
+- `test` now takes a `--number` argument to specify which block should be used when making rpc queries
 - The `--initial-storage` flag no longer accepts a concrete prestore (valid values are now `Empty` or `Abstract`)
 - The visual debugger has been removed
 - All concrete ds-test executors have been removed (i.e. plain, fuzzer, invariant)

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -134,6 +134,7 @@ data Command w
       { root        :: w ::: Maybe String               <?> "Path to  project root directory (default: . )"
       , projectType   :: w ::: Maybe ProjectType        <?> "Is this a Foundry or DappTools project (default: Foundry)"
       , rpc           :: w ::: Maybe URL                <?> "Fetch state from a remote node"
+      , number        :: w ::: Maybe W256               <?> "Block: number"
       , verbose       :: w ::: Maybe Int                <?> "Append call trace: {1} failures {2} all"
       , coverage      :: w ::: Bool                     <?> "Coverage analysis"
       , match         :: w ::: Maybe String             <?> "Test case filter - only run methods matching regex"

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -847,6 +847,21 @@ isLitWord (Lit _) = True
 isLitWord (WAddr (LitAddr _)) = True
 isLitWord _ = False
 
+isSuccess :: Expr End -> Bool
+isSuccess = \case
+  Success {} -> True
+  _ -> False
+
+isFailure :: Expr End -> Bool
+isFailure = \case
+  Failure {} -> True
+  _ -> False
+
+isPartial :: Expr End -> Bool
+isPartial = \case
+  Partial {} -> True
+  _ -> False
+
 -- | Returns the byte at idx from the given word.
 indexWord :: Expr EWord -> Expr EWord -> Expr Byte
 -- Simplify masked reads:

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -878,8 +878,13 @@ formatCex cd m@(SMTCex _ _ _ store blockContext txContext) = T.unlines $
 -- but it's probably good enough for now
 defaultSymbolicValues :: Expr a -> Expr a
 defaultSymbolicValues e = subBufs (foldTerm symbufs mempty e)
-                        . subVars (foldTerm symwords mempty e) $ e
+                        . subVars (foldTerm symwords mempty e)
+                        . subAddrs (foldTerm symaddrs mempty e) $ e
   where
+    symaddrs :: Expr a -> Map (Expr EAddr) Addr
+    symaddrs = \case
+      a@(SymAddr _) -> Map.singleton a (Addr 0x1312)
+      _ -> mempty
     symbufs :: Expr a -> Map (Expr Buf) ByteString
     symbufs = \case
       a@(AbstractBuf _) -> Map.singleton a ""

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -233,8 +233,8 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
 
     -- display results
     if all isQed results
-    then if allReverts
-         then pure ("\x1b[31m[FAIL]\x1b[0m " <> testName, Right $ allBranchRev testName)
+    then if allReverts && (not shouldFail)
+         then pure ("\x1b[31m[FAIL]\x1b[0m " <> testName, Left $ allBranchRev testName)
          else pure ("\x1b[32m[PASS]\x1b[0m " <> testName, Right "")
     else do
       let x = mapMaybe extractCex results

--- a/test/contracts/fail/dsProveFail.sol
+++ b/test/contracts/fail/dsProveFail.sol
@@ -12,6 +12,10 @@ contract SolidityTest is DSTest {
         assert(false);
     }
 
+    function prove_all_branches_fail() public {
+        require(false);
+    }
+
     function prove_trivial_dstest() public {
         assertEq(uint(1), uint(2));
     }

--- a/test/contracts/pass/dsProvePass.sol
+++ b/test/contracts/pass/dsProvePass.sol
@@ -49,16 +49,21 @@ contract SolidityTest is DSTest {
     }
 
     // requires do not trigger a failure in `prove_` tests
-    function prove_no_fail_require() public {
-        require(false);
+    function prove_no_fail_require(uint x) public {
+        if (x == 2) {
+            require(false);
+        } else {
+            assert(x != 2);
+        }
     }
 
     // all branches in a proveFail test must end in one of:
     //  - a require
     //  - a failed user defined assert
     //  - a failed ds-test assertion violation
-    function proveFail_require() public {
-        require(false);
+    function proveFail_require(uint x) public {
+        require(x == 100);
+        assert(false);
     }
 
     function proveFail_userAssertSmoke() public {

--- a/test/test.hs
+++ b/test/test.hs
@@ -31,7 +31,7 @@ import GHC.Conc (getNumProcessors)
 import System.Directory
 import System.Environment
 import Test.Tasty
-import Test.Tasty.QuickCheck hiding (Failure, Success, isSuccess)
+import Test.Tasty.QuickCheck hiding (Failure, Success)
 import Test.QuickCheck.Instances.Text()
 import Test.QuickCheck.Instances.Natural()
 import Test.QuickCheck.Instances.ByteString()


### PR DESCRIPTION
## Description

A bunch of small fixes and ux tweaks. This should hopefully be ok to review commit by commit.

- add `number` arg to test `cli` endpoint (was previously always failing cos it was expecting this)
- add default values for symbolic addresses
- prove tests now fail if there are no reachable assertion violations but all branches revert
- prove tests fall back to displaying calldata cexs as raw bytes if the model provided by the solver has a different length than the length of the arguments in the signature

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
