### PR TITLE
The "test" option was broken somehow. This fixes it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - EVM.Solidity.toCode to include contractName in error string
 - Better cex reconstruction in cases where branches do not refer to all input variables in calldata
 - Correctly handle empty bytestring compiled contracts' JSON
+- "test" option was broken due to missing `--number` option, this is now fixed
 
 ## Changed
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -135,6 +135,7 @@ data Command w
       , projectType   :: w ::: Maybe ProjectType        <?> "Is this a Foundry or DappTools project (default: Foundry)"
       , rpc           :: w ::: Maybe URL                <?> "Fetch state from a remote node"
       , verbose       :: w ::: Maybe Int                <?> "Append call trace: {1} failures {2} all"
+      , number        :: w ::: Maybe W256               <?> "Block: number"
       , coverage      :: w ::: Bool                     <?> "Coverage analysis"
       , match         :: w ::: Maybe String             <?> "Test case filter - only run methods matching regex"
       , solver        :: w ::: Maybe Text               <?> "Used SMT solver: z3 (default) or cvc5"


### PR DESCRIPTION
## Description
The "test" option in `hevm` executable has been broken somehow in `main`:

```
$ cabal run exe:hevm --  test --root /home/matesoos/development/benchmarks --match ".*"
hevm: No match in record selector number
```

Where `No match in record selector number` is actually a runtime error of Haskell's type system(!?). The code here:

```
 unitTestOptions :: Command Options.Unwrapped -> SolverGroup -> Maybe BuildOutput -> IO (UnitTestOptions RealWorld)
 unitTestOptions cmd solvers buildOutput = do
   root <- getRoot cmd
   let srcInfo = maybe emptyDapp (dappInfo root) buildOutput
   let rpcinfo = case (cmd.number, cmd.rpc) of
```
Should not type-check, I think? The `cmd` doesn't actually have a `number` field. The `No match in record selector` is the runtime type error (didn't even know that existed) that we are getting here. This PR adds the `number` (i.e. block number, I think it should be called blknumber everywhere instead) field, so this does not fail. Note that `number` is available when e.g. running `hevm symbolic`:

```
cabal run exe:hevm --  symbolic -h
[...]
Available options:
[...]
  --number W256            Block: number
```

But not when running `hevm test`. So this code wasn't correct, since it tried accessing `number` in a record that didn't have `number`. Strange that it type-checked, must be some weird type magic.

Currently, without this PR, it is not possible to run any `hevm test ...` commands, they all fail with above error.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
