### PR TITLE
Constant folding during path checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved Prop simplification
 - CopySlice+WriteWord+ConcreteBuf now truncates ConcreteBuf in special cases
 - Better simplification of Eq IR elements
+- Run a toplevel constant folding reasoning system on branch conditions
 
 ## API Changes
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -844,7 +844,15 @@ simplify e = if (mapExpr go e == e)
 
 
 simplifyProps :: [Prop] -> [Prop]
+<<<<<<< Updated upstream
 simplifyProps = remRedundantProps . map evalProp . flattenProps
+=======
+simplifyProps ps = if canBeSat then simplified else [PBool False]
+  where
+    simplified = remRedundantProps . map evalProp . flattenProps $ ps
+    canBeSat = constFoldProp simplified
+
+>>>>>>> Stashed changes
 
 -- | Evaluate the provided proposition down to its most concrete result
 evalProp :: Prop -> Prop

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -846,6 +846,8 @@ simplify e = if (mapExpr go e == e)
 simplifyProps :: [Prop] -> [Prop]
 simplifyProps = remRedundantProps . map evalProp . flattenProps
 
+
+
 -- | Evaluate the provided proposition down to its most concrete result
 evalProp :: Prop -> Prop
 evalProp prop =
@@ -1120,43 +1122,6 @@ containsNode p = getAny . foldExpr go (Any False)
 
 inRange :: Int -> Expr EWord -> Prop
 inRange sz e = PAnd (PGEq e (Lit 0)) (PLEq e (Lit $ 2 ^ sz - 1))
-
--- | Evaluate the provided proposition down to its most concrete result
-evalProp :: Prop -> Prop
-evalProp prop =
-  let new = mapProp' go prop
-  in if (new == prop) then prop else evalProp new
-  where
-    go :: Prop -> Prop
-    go (PLT (Lit l) (Lit r)) = PBool (l < r)
-    go (PGT (Lit l) (Lit r)) = PBool (l > r)
-    go (PGEq (Lit l) (Lit r)) = PBool (l >= r)
-    go (PLEq (Lit l) (Lit r)) = PBool (l <= r)
-    go (PNeg (PBool b)) = PBool (Prelude.not b)
-
-    go (PAnd (PBool l) (PBool r)) = PBool (l && r)
-    go (PAnd (PBool False) _) = PBool False
-    go (PAnd _ (PBool False)) = PBool False
-
-    go (POr (PBool l) (PBool r)) = PBool (l || r)
-    go (POr (PBool True) _) = PBool True
-    go (POr _ (PBool True)) = PBool True
-
-    go (PImpl (PBool l) (PBool r)) = PBool ((Prelude.not l) || r)
-    go (PImpl (PBool False) _) = PBool True
-
-    go (PEq (Eq a b) (Lit 0)) = PNeg (PEq a b)
-    go (PEq (Eq a b) (Lit 1)) = PEq a b
-
-    go (PEq (Sub a b) (Lit 0)) = PEq a b
-
-    go (PNeg (PNeg a)) = a
-
-    go (PEq (Lit l) (Lit r)) = PBool (l == r)
-    go o@(PEq l r)
-      | l == r = PBool True
-      | otherwise = o
-    go p = p
 
 
 data ConstState = ConstState

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1153,10 +1153,8 @@ constFoldProp ps = (execState (mapM (go . evalProp) ps) (ConstState mempty True)
           let
             v1 = constFoldProp [a]
             v2 = constFoldProp [b]
-          _ <- if (Prelude.not v1) then go a
-                                   else pure ()
-          _ <- if (Prelude.not v2) then go b
-                                   else pure ()
+          unless v1 $ go a
+          unless v2 $ go b
           s <- get
           put $ s{canBeSat=(s.canBeSat && (v1 || v2))}
         PBool False -> put $ ConstState {canBeSat=False, values=mempty}

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -854,7 +854,7 @@ simplifyProps ps = if canBeSat then simplified else [PBool False]
     -- simplifies the inner expression
     simpInnerExpr (PEq a b) = PEq (simplify a) (simplify b)
     simpInnerExpr (PLT a b) = PLT (simplify a) (simplify b)
-    simpInnerExpr (PLEq a b) = PEq (simplify a) (simplify b)
+    simpInnerExpr (PLEq a b) = PLEq (simplify a) (simplify b)
     simpInnerExpr (PNeg a) = PNeg (simpInnerExpr a)
     simpInnerExpr (PAnd a b) = PAnd (simpInnerExpr a) (simpInnerExpr b)
     simpInnerExpr (POr a b) = POr (simpInnerExpr a) (simpInnerExpr b)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1141,7 +1141,7 @@ constFoldProp ps = (execState (mapM (go . evalProp) ps) (ConstState mempty True)
           case Map.lookup a s.values of
             Just l2 -> case l==l2 of
                 True -> pure ()
-                False -> put $ s{canBeSat=False}
+                False -> put ConstState {canBeSat=False, values=mempty}
             Nothing -> do
               let vs' = Map.insert a l s.values
               put $ s{values=vs'}
@@ -1159,5 +1159,5 @@ constFoldProp ps = (execState (mapM (go . evalProp) ps) (ConstState mempty True)
                                    else pure ()
           s <- get
           put $ s{canBeSat=(s.canBeSat && (v1 || v2))}
-        PBool False -> put $ s{canBeSat=False}
+        PBool False -> put $ ConstState {canBeSat=False, values=mempty}
         _ -> pure ()

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -846,8 +846,6 @@ simplify e = if (mapExpr go e == e)
 simplifyProps :: [Prop] -> [Prop]
 simplifyProps = remRedundantProps . map evalProp . flattenProps
 
-
-
 -- | Evaluate the provided proposition down to its most concrete result
 evalProp :: Prop -> Prop
 evalProp prop =

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -842,6 +842,7 @@ simplify e = if (mapExpr go e == e)
 
 -- ** Prop Simplification ** -----------------------------------------------------------------------
 
+
 simplifyProps :: [Prop] -> [Prop]
 simplifyProps ps = if canBeSat then simplified else [PBool False]
   where

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1169,8 +1169,6 @@ data ConstState = ConstState
 constFoldProp :: [Prop] -> ConstState
 constFoldProp ps = execState (mapM (go . evalProp) ps) (ConstState mempty True)
   where
-    constProp :: Prop -> State ConstState Prop
-    constProp prop = go (evalProp prop)
     go :: Prop -> State ConstState Prop
     go x = case x of
         PEq a (Lit l) -> do

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1141,8 +1141,7 @@ constFoldProp ps = (execState (mapM (go . evalProp) ps) (ConstState mempty True)
           case Map.lookup a s.values of
             Just l2 -> case l==l2 of
                 True -> pure ()
-                False -> do
-                  put $ s{canBeSat=False}
+                False -> put $ s{canBeSat=False}
             Nothing -> do
               let vs' = Map.insert a l s.values
               put $ s{values=vs'}
@@ -1160,7 +1159,5 @@ constFoldProp ps = (execState (mapM (go . evalProp) ps) (ConstState mempty True)
                                    else pure ()
           s <- get
           put $ s{canBeSat=(s.canBeSat && (v1 || v2))}
-        PBool False -> do
-          s <- get
-          put $ s{canBeSat=False}
+        PBool False -> put $ s{canBeSat=False}
         _ -> pure ()

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1166,8 +1166,8 @@ data ConstState = ConstState
   deriving (Show)
 
 -- | Folds constants
-constFoldProp :: [Prop] -> ConstState
-constFoldProp ps = execState (mapM (go . evalProp) ps) (ConstState mempty True)
+constFoldProp :: [Prop] -> Bool
+constFoldProp ps = (execState (mapM (go . evalProp) ps) (ConstState mempty True)).canBeSat
   where
     go :: Prop -> State ConstState Prop
     go x = case x of
@@ -1190,8 +1190,8 @@ constFoldProp ps = execState (mapM (go . evalProp) ps) (ConstState mempty True)
           pure $ PBool True
         POr a b -> do
           let
-            ConstState _ v1 = constFoldProp [a]
-            ConstState _ v2 = constFoldProp [b]
+            v1 = constFoldProp [a]
+            v2 = constFoldProp [b]
           _ <- if (Prelude.not v1) then go a
                                    else pure $ PBool True
           _ <- if (Prelude.not v2) then go b

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1167,7 +1167,7 @@ data ConstState = ConstState
 
 -- | Folds constants
 constFoldProp :: [Prop] -> ConstState
-constFoldProp ps = execState (mapM constProp ps) (ConstState mempty True)
+constFoldProp ps = execState (mapM (go . evalProp) ps) (ConstState mempty True)
   where
     constProp :: Prop -> State ConstState Prop
     constProp prop = go (evalProp prop)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -844,15 +844,10 @@ simplify e = if (mapExpr go e == e)
 
 
 simplifyProps :: [Prop] -> [Prop]
-<<<<<<< Updated upstream
-simplifyProps = remRedundantProps . map evalProp . flattenProps
-=======
 simplifyProps ps = if canBeSat then simplified else [PBool False]
   where
     simplified = remRedundantProps . map evalProp . flattenProps $ ps
     canBeSat = constFoldProp simplified
-
->>>>>>> Stashed changes
 
 -- | Evaluate the provided proposition down to its most concrete result
 evalProp :: Prop -> Prop

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -192,8 +192,16 @@ abstractAwayProps abstRefineConfig ps = runState (mapM abstrAway ps) (AbstState 
 smt2Line :: Builder -> SMT2
 smt2Line txt = SMT2 [txt] mempty mempty
 
+
 assertProps :: AbstRefineConfig -> [Prop] -> SMT2
-assertProps abstRefineConfig (Expr.simplifyProps -> ps) =
+assertProps conf ps = assertPropsNoSimp conf (Expr.simplifyProps ps)
+
+-- Note: assertProps must NEVER call simplify or simplifyProps, because we use
+-- assertProps to verify the correctness of our simplification passes through
+-- property-based testing. Hence, our verification could be rendered ineffective
+-- if we used simplify/simplifyProps here
+assertPropsNoSimp :: AbstRefineConfig -> [Prop] -> SMT2
+assertPropsNoSimp abstRefineConfig ps =
   let encs = map propToSMT psElimAbst
       abstSMT = map propToSMT abstProps
       intermediates = declareIntermediates bufs stores in

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -148,8 +148,9 @@ declareIntermediates bufs stores =
     encodeStore n expr =
        "(define-const store" <> (fromString . show $ n) <> " Storage " <> exprToSMT expr <> ")"
 
+-- TODO: we would ideally call simplifyProps on input props and generated props all together
 assertProps :: [Prop] -> SMT2
-assertProps ps =
+assertProps (Expr.simplifyProps -> ps) =
   let encs = map propToSMT ps_elim
       intermediates = declareIntermediates bufs stores in
   prelude
@@ -192,7 +193,6 @@ assertProps ps =
       <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakAssumptions ps_elim bufVals storeVals)) mempty
       <> SMT2 ["; keccak computations"] mempty
       <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakCompute ps_elim bufVals storeVals)) mempty
-
 
     readAssumes
       = SMT2 ["; read assumptions"] mempty

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -196,10 +196,9 @@ smt2Line txt = SMT2 [txt] mempty mempty
 assertProps :: AbstRefineConfig -> [Prop] -> SMT2
 assertProps conf ps = assertPropsNoSimp conf (Expr.simplifyProps ps)
 
--- Note: assertProps must NEVER call simplify or simplifyProps, because we use
--- assertProps to verify the correctness of our simplification passes through
--- property-based testing. Hence, our verification could be rendered ineffective
--- if we used simplify/simplifyProps here
+-- Note: we need a version that does NOT call simplify or simplifyProps,
+-- because we make use of it to verify the correctness of our simplification
+-- passes through property-based testing.
 assertPropsNoSimp :: AbstRefineConfig -> [Prop] -> SMT2
 assertPropsNoSimp abstRefineConfig ps =
   let encs = map propToSMT psElimAbst

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -192,7 +192,6 @@ abstractAwayProps abstRefineConfig ps = runState (mapM abstrAway ps) (AbstState 
 smt2Line :: Builder -> SMT2
 smt2Line txt = SMT2 [txt] mempty mempty
 
-
 assertProps :: AbstRefineConfig -> [Prop] -> SMT2
 assertProps conf ps = assertPropsNoSimp conf (Expr.simplifyProps ps)
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -309,11 +309,13 @@ interpret fetcher maxIter askSmtIters heuristic vm =
                   (Just True, True, _) ->
                     -- ask the smt solver about the loop condition
                     performQuery
-                  -- otherwise just try both branches and don't ask the solver
                   _ -> do
                     (r, vm') <- case canBeSat of
+                      -- If constant folding over Props statically determined
+                      -- that it cannot be SAT
                       False ->
                         stToIO $ runStateT (continue (Case False)) vm
+                      -- otherwise just try both branches and don't ask the solver
                       True ->
                         stToIO $ runStateT (continue EVM.Types.Unknown) vm
                     interpret fetcher maxIter askSmtIters heuristic vm' (k r)

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -319,7 +319,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
                       -- if we can statically determine unsatisfiability then we skip exploring the jump
                       [PBool False] -> stToIO $ runStateT (continue (Case False)) vm
                       -- otherwise we explore both branches
-                      ps -> stToIO $ runStateT (continue EVM.Types.Unknown) vm
+                      _ -> stToIO $ runStateT (continue EVM.Types.Unknown) vm
                     interpret fetcher maxIter askSmtIters heuristic vm' (k r)
           _ -> performQuery
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -280,7 +280,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
           PleaseAskSMT cond preconds continue -> do
             let
               simpCond = Expr.simplify cond
-              (Expr.ConstState _ canBeSat) = Expr.constFoldProp ((simpCond ./= Lit 0):preconds)
+              canBeSat = Expr.constFoldProp ((simpCond ./= Lit 0):preconds)
             case simpCond of
               -- is the condition concrete?
               Lit c ->


### PR DESCRIPTION
## Description
This is a PR I have been sitting on, and had some partial experience regarding its performance, but I finally got some better proof :) While running PR #352 , I noticed:

```
Checking file: /nix/store/sayhv9lb1nl58rrwsgx928bcng20hqd1-source/test/libyul/yulOptimizerTests/unusedAssignEliminator/for_multi_break.yul

WARNING: hevm was only able to partially explore the given contract due to the following issues:

  - Max Iterations Reached in contract: SymAddr "entrypoint" pc: 19

Found 720801 total pairs of endstates
Reuse of previous queries was Useful in 364751 cases
"OK. Took 154.138271977s seconds"
```

Which is sad. On `main`, it behaves exactly the same. Sad. I thought... maybe my PR can fix it! And indeed it can:

```
Checking file: /nix/store/sayhv9lb1nl58rrwsgx928bcng20hqd1-source/test/libyul/yulOptimizerTests/unusedAssignEliminator/for_multi_break.yul

WARNING: hevm was only able to partially explore the given contract due to the following issues:

  - Max Iterations Reached in contract: symbolic(entrypoint) pc: 19

Found 37249 total pairs of endstates
Asking the SMT solver for 16900 pairs
Reuse of previous queries was Useful in 15286 cases
"OK. Took 7.409072883s seconds"
OK (7.42s)
```

That's some nice improvement right there! So now I'm more confident in the performance of this PR :) This PR basically adds a certain level of constant folding to branch exploration. It's a slightly enhanced version of #329 .


## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
