### PR TITLE
[Review needed] Adding LitAddr, but maybe this is the wrong fix?

### DIFF
--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -210,6 +210,7 @@ referencedWAddrs term = foldTerm go mempty term
   where
     go = \case
       WAddr(a@(SymAddr _)) -> Set.singleton (formatEAddr a)
+      a@(LitAddr _) -> Set.singleton (formatEAddr a)
       _ -> mempty
 
 referencedBufs :: TraversableTerm a => a -> [Builder]
@@ -696,6 +697,7 @@ exprToSMT = \case
   BaseFee -> "basefee"
 
   a@(SymAddr _) -> formatEAddr a
+  a@(LitAddr _) -> formatEAddr a
   WAddr(a@(SymAddr _)) -> "(concat (_ bv0 96)" `sp` exprToSMT a `sp` ")"
 
   LitByte b -> fromLazyText $ "(_ bv" <> T.pack (show (into b :: Integer)) <> " 8)"


### PR DESCRIPTION
## Description
This adds SMT for `LitAddr`, which is missing currently. Not sure this is the right "fix", though... @d-xo  when you are back, perhaps you could take a peek? Alternatively, maybe @arcz if you could take a look? I also added an test, currently with `ignoreTest` that triggers some of this behaviour -- however, it still doesn't correctly assert-fail, potentially due to

```
WARNING: hevm was only able to partially explore the given contract due to the following issues:

  - Unexpected Symbolic Arguments to Opcode
    msg: "call target has unknown code"
    program counter: 129
    arguments: 
      0x0000000000000000000000000000000000000000
```

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
