### PR TITLE
Abstraction refinement of ReadWord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Support for fully symbolic contract addresses required some very extensive chang
 ## Changed
 
 - Removed sha3Crack which has been deprecated for keccakEqs
+- Abstraction-refinement for more complicated expressions such as MULMOD
 
 ## Added
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -144,7 +144,7 @@ data Command w
       , smttimeout    :: w ::: Maybe Natural            <?> "Timeout given to SMT solver in seconds (default: 300)"
       , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point"
       , loopDetectionHeuristic :: w ::: LoopHeuristic   <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
-      , abstractArithmetic    :: w ::: Bool                      <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
+      , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       }
@@ -216,7 +216,7 @@ equivalence cmd = do
                           , maxIter = cmd.maxIterations
                           , askSmtIters = cmd.askSmtIterations
                           , loopHeuristic = cmd.loopDetectionHeuristic
-                          , abstRefineArith = cmd.abstractArith
+                          , abstRefineArith = cmd.abstractArithmetic
                           , abstRefineMem = cmd.abstractMemory
                           , rpcInfo = Nothing
                           }
@@ -303,7 +303,7 @@ assert cmd = do
       maxIter = cmd.maxIterations,
       askSmtIters = cmd.askSmtIterations,
       loopHeuristic = cmd.loopDetectionHeuristic,
-      abstRefineArith = cmd.abstractArith,
+      abstRefineArith = cmd.abstractArithmetic,
       abstRefineMem = cmd.abstractMemory,
       rpcInfo = rpcinfo
     }

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -144,6 +144,7 @@ data Command w
       , smttimeout    :: w ::: Maybe Natural            <?> "Timeout given to SMT solver in seconds (default: 300)"
       , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point"
       , loopDetectionHeuristic :: w ::: LoopHeuristic   <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
+      , abstRefine    :: w ::: Bool                      <?> "Use abstraction refinement"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       }
   | Version
@@ -214,6 +215,7 @@ equivalence cmd = do
                           , maxIter = cmd.maxIterations
                           , askSmtIters = cmd.askSmtIterations
                           , loopHeuristic = cmd.loopDetectionHeuristic
+                          , abstRefine = cmd.abstRefine
                           , rpcInfo = Nothing
                           }
   calldata <- buildCalldata cmd
@@ -299,6 +301,7 @@ assert cmd = do
       maxIter = cmd.maxIterations,
       askSmtIters = cmd.askSmtIterations,
       loopHeuristic = cmd.loopDetectionHeuristic,
+      abstRefine = cmd.abstRefine,
       rpcInfo = rpcinfo
     }
     (expr, res) <- verify solvers opts preState (Just $ checkAssertions errCodes)

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -89,6 +89,8 @@ data Command w
       , askSmtIterations :: w ::: Integer         <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       , numSolvers    :: w ::: Maybe Natural      <?> "Number of solver instances to use (default: number of cpu cores)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
+      , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
+      , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       }
   | Equivalence -- prove equivalence between two programs
       { codeA         :: w ::: ByteString       <?> "Bytecode of the first program"
@@ -103,6 +105,8 @@ data Command w
       , smtdebug      :: w ::: Bool             <?> "Print smt queries sent to the solver"
       , askSmtIterations :: w ::: Integer       <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
+      , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
+      , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       }
   | Exec -- Execute a given program with specified env & calldata
       { code        :: w ::: Maybe ByteString  <?> "Program bytecode"

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -144,7 +144,8 @@ data Command w
       , smttimeout    :: w ::: Maybe Natural            <?> "Timeout given to SMT solver in seconds (default: 300)"
       , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point"
       , loopDetectionHeuristic :: w ::: LoopHeuristic   <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
-      , abstRefine    :: w ::: Bool                      <?> "Use abstraction refinement"
+      , abstractArith    :: w ::: Bool                      <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
+      , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       }
   | Version
@@ -301,7 +302,8 @@ assert cmd = do
       maxIter = cmd.maxIterations,
       askSmtIters = cmd.askSmtIterations,
       loopHeuristic = cmd.loopDetectionHeuristic,
-      abstRefine = cmd.abstRefine,
+      abstRefineArith = cmd.abstArith,
+      abstRefineMem = cmd.abstMemory,
       rpcInfo = rpcinfo
     }
     (expr, res) <- verify solvers opts preState (Just $ checkAssertions errCodes)

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -216,8 +216,7 @@ equivalence cmd = do
                           , maxIter = cmd.maxIterations
                           , askSmtIters = cmd.askSmtIterations
                           , loopHeuristic = cmd.loopDetectionHeuristic
-                          , abstRefineArith = cmd.abstractArithmetic
-                          , abstRefineMem = cmd.abstractMemory
+                          , abstRefineConfig = AbstRefineConfig cmd.abstractArithmetic cmd.abstractMemory
                           , rpcInfo = Nothing
                           }
   calldata <- buildCalldata cmd
@@ -297,15 +296,13 @@ assert cmd = do
   let solverCount = fromMaybe cores cmd.numSolvers
   solver <- getSolver cmd
   withSolvers solver solverCount cmd.smttimeout $ \solvers -> do
-    let opts = VeriOpts {
-      simp = True,
-      debug = cmd.smtdebug,
-      maxIter = cmd.maxIterations,
-      askSmtIters = cmd.askSmtIterations,
-      loopHeuristic = cmd.loopDetectionHeuristic,
-      abstRefineArith = cmd.abstractArithmetic,
-      abstRefineMem = cmd.abstractMemory,
-      rpcInfo = rpcinfo
+    let opts = VeriOpts { simp = True
+                        , debug = cmd.smtdebug
+                        , maxIter = cmd.maxIterations
+                        , askSmtIters = cmd.askSmtIterations
+                        , loopHeuristic = cmd.loopDetectionHeuristic
+                        , abstRefineConfig = AbstRefineConfig cmd.abstractArithmetic cmd.abstractMemory
+                        , rpcInfo = rpcinfo
     }
     (expr, res) <- verify solvers opts preState (Just $ checkAssertions errCodes)
     case res of

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -144,7 +144,7 @@ data Command w
       , smttimeout    :: w ::: Maybe Natural            <?> "Timeout given to SMT solver in seconds (default: 300)"
       , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point"
       , loopDetectionHeuristic :: w ::: LoopHeuristic   <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
-      , abstractArith    :: w ::: Bool                      <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
+      , abstractArithmetic    :: w ::: Bool                      <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       }

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -216,7 +216,8 @@ equivalence cmd = do
                           , maxIter = cmd.maxIterations
                           , askSmtIters = cmd.askSmtIterations
                           , loopHeuristic = cmd.loopDetectionHeuristic
-                          , abstRefine = cmd.abstRefine
+                          , abstRefineArith = cmd.abstractArith
+                          , abstRefineMem = cmd.abstractMemory
                           , rpcInfo = Nothing
                           }
   calldata <- buildCalldata cmd
@@ -302,8 +303,8 @@ assert cmd = do
       maxIter = cmd.maxIterations,
       askSmtIters = cmd.askSmtIterations,
       loopHeuristic = cmd.loopDetectionHeuristic,
-      abstRefineArith = cmd.abstArith,
-      abstRefineMem = cmd.abstMemory,
+      abstRefineArith = cmd.abstractArith,
+      abstRefineMem = cmd.abstractMemory,
       rpcInfo = rpcinfo
     }
     (expr, res) <- verify solvers opts preState (Just $ checkAssertions errCodes)

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -238,13 +238,13 @@ type Fetcher s = Query s -> IO (EVM s ())
 -- will be pruned anyway.
 checkBranch :: SolverGroup -> Prop -> Prop -> IO BranchCondition
 checkBranch solvers branchcondition pathconditions = do
-  checkSat solvers (assertProps [(branchcondition .&& pathconditions)] False) >>= \case
+  checkSat solvers (assertProps False False [(branchcondition .&& pathconditions)]) >>= \case
     -- the condition is unsatisfiable
     Unsat -> -- if pathconditions are consistent then the condition must be false
       pure $ Case False
     -- Sat means its possible for condition to hold
     Sat _ -> -- is its negation also possible?
-      checkSat solvers (assertProps [(pathconditions .&& (PNeg branchcondition))] False) >>= \case
+      checkSat solvers (assertProps False False [(pathconditions .&& (PNeg branchcondition))]) >>= \case
         -- No. The condition must hold
         Unsat -> pure $ Case True
         -- Yes. Both branches possible

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -238,13 +238,13 @@ type Fetcher s = Query s -> IO (EVM s ())
 -- will be pruned anyway.
 checkBranch :: SolverGroup -> Prop -> Prop -> IO BranchCondition
 checkBranch solvers branchcondition pathconditions = do
-  checkSat solvers (assertProps [(branchcondition .&& pathconditions)]) >>= \case
+  checkSat solvers (assertProps [(branchcondition .&& pathconditions)] False) >>= \case
     -- the condition is unsatisfiable
     Unsat -> -- if pathconditions are consistent then the condition must be false
       pure $ Case False
     -- Sat means its possible for condition to hold
     Sat _ -> -- is its negation also possible?
-      checkSat solvers (assertProps [(pathconditions .&& (PNeg branchcondition))]) >>= \case
+      checkSat solvers (assertProps [(pathconditions .&& (PNeg branchcondition))] False) >>= \case
         -- No. The condition must hold
         Unsat -> pure $ Case True
         -- Yes. Both branches possible

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -238,13 +238,13 @@ type Fetcher s = Query s -> IO (EVM s ())
 -- will be pruned anyway.
 checkBranch :: SolverGroup -> Prop -> Prop -> IO BranchCondition
 checkBranch solvers branchcondition pathconditions = do
-  checkSat solvers (assertProps False False [(branchcondition .&& pathconditions)]) >>= \case
+  checkSat solvers (assertProps abstRefineDefault [(branchcondition .&& pathconditions)]) >>= \case
     -- the condition is unsatisfiable
     Unsat -> -- if pathconditions are consistent then the condition must be false
       pure $ Case False
     -- Sat means its possible for condition to hold
     Sat _ -> -- is its negation also possible?
-      checkSat solvers (assertProps False False [(pathconditions .&& (PNeg branchcondition))]) >>= \case
+      checkSat solvers (assertProps abstRefineDefault [(pathconditions .&& (PNeg branchcondition))]) >>= \case
         -- No. The condition must hold
         Unsat -> pure $ Case True
         -- Yes. Both branches possible

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -245,13 +245,13 @@ assertProps ps abstRefine =
 
     keccakAssumes
       = smt2Line "; keccak assumptions"
-      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakAssumptions psElimAbst bufVals storeVals)) mempty mempty
+      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakAssumptions psElim bufVals storeVals)) mempty mempty
       <> smt2Line "; keccak computations"
-      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakCompute psElimAbst bufVals storeVals)) mempty mempty
+      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakCompute psElim bufVals storeVals)) mempty mempty
 
     readAssumes
       = smt2Line "; read assumptions"
-        <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (assertReads psElimAbst bufs stores)) mempty mempty
+        <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (assertReads psElim bufs stores)) mempty mempty
 
 referencedAbstractStores :: TraversableTerm a => a -> Set Builder
 referencedAbstractStores term = foldTerm go mempty term

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -31,6 +31,7 @@ import Language.SMT2.Parser (getValueRes, parseCommentFreeFileMsg)
 import Language.SMT2.Syntax (Symbol, SpecConstant(..), GeneralRes(..), Term(..), QualIdentifier(..), Identifier(..), Sort(..), Index(..), VarBinding(..))
 import Numeric (readHex, readBin)
 import Witch (into, unsafeInto)
+import Control.Monad.State
 
 import EVM.CSE
 import EVM.Expr (writeByte, bufLengthEnv, containsNode, bufLength, minLength, inRange)
@@ -100,6 +101,11 @@ data SMTCex = SMTCex
   }
   deriving (Eq, Show)
 
+
+-- | Used for abstraction-refinement of the SMT formula
+newtype RefinementEqs = RefinementEqs [Builder]
+  deriving (Eq, Show, Monoid, Semigroup)
+
 flattenBufs :: SMTCex -> Maybe SMTCex
 flattenBufs cex = do
   bs <- mapM collapse cex.buffers
@@ -119,17 +125,17 @@ collapse model = case toBuf model of
 getVar :: SMTCex -> TS.Text -> W256
 getVar cex name = fromJust $ Map.lookup (Var name) cex.vars
 
-data SMT2 = SMT2 [Builder] CexVars
+data SMT2 = SMT2 [Builder] RefinementEqs CexVars
   deriving (Eq, Show)
 
 instance Semigroup SMT2 where
-  (SMT2 a b) <> (SMT2 a2 b2) = SMT2 (a <> a2) (b <> b2)
+  (SMT2 a (RefinementEqs b) c) <> (SMT2 a2 (RefinementEqs b2) c2) = SMT2 (a <> a2) (RefinementEqs (b <> b2)) (c <> c2)
 
 instance Monoid SMT2 where
-  mempty = SMT2 mempty mempty
+  mempty = SMT2 mempty mempty mempty
 
 formatSMT2 :: SMT2 -> Text
-formatSMT2 (SMT2 ls _) = T.unlines (fmap toLazyText ls)
+formatSMT2 (SMT2 ls _ _) = T.unlines (fmap toLazyText ls)
 
 -- | Reads all intermediate variables from the builder state and produces SMT declaring them as constants
 declareIntermediates :: BufEnv -> StoreEnv -> SMT2
@@ -138,65 +144,112 @@ declareIntermediates bufs stores =
       encBs = Map.mapWithKey encodeBuf bufs
       sorted = List.sortBy compareFst $ Map.toList $ encSs <> encBs
       decls = fmap snd sorted
-  in SMT2 ([fromText "; intermediate buffers & stores"] <> decls) mempty
+      smt2 = (SMT2 [fromText "; intermediate buffers & stores"] mempty mempty):decls
+  in  foldr (<>) (SMT2[""] mempty mempty) smt2
   where
     compareFst (l, _) (r, _) = compare l r
     encodeBuf n expr =
-      "(define-const buf" <> (fromString . show $ n) <> " Buf " <> exprToSMT expr <> ")\n" <> encodeBufLen n expr
+      SMT2 ["(define-const buf" <> (fromString . show $ n) <> " Buf " <> exprToSMT expr <> ")\n"]  mempty mempty <> encodeBufLen n expr
     encodeBufLen n expr =
-      "(define-const buf" <> (fromString . show $ n) <>"_length" <> " (_ BitVec 256) " <> exprToSMT (bufLengthEnv bufs True expr) <> ")"
+      SMT2 ["(define-const buf" <> (fromString . show $ n) <>"_length" <> " (_ BitVec 256) " <> exprToSMT (bufLengthEnv bufs True expr) <> ")"] mempty mempty
     encodeStore n expr =
-       "(define-const store" <> (fromString . show $ n) <> " Storage " <> exprToSMT expr <> ")"
+      SMT2 ["(define-const store" <> (fromString . show $ n) <> " Storage " <> exprToSMT expr <> ")"] mempty mempty
+
+
+data AbstState = AbstState
+  { words :: Map (Expr EWord) Int
+  , count :: Int
+  }
+  deriving (Show)
+
+abstractAwayProps :: [Prop] -> ([Prop], AbstState)
+abstractAwayProps ps = runState (mapM abstrAway ps) (AbstState mempty 0)
+  where
+    abstrAway :: Prop -> State AbstState Prop
+    abstrAway prop = mapPropM go prop
+    go :: Expr a -> State AbstState (Expr a)
+    go x = case x of
+        e@(Mod{})    -> abstrExpr e
+        e@(SMod{})   -> abstrExpr e
+        e@(MulMod{}) -> abstrExpr e
+        e@(AddMod{}) -> abstrExpr e
+        e@(Mul{})    -> abstrExpr e
+        e@(Div{})    -> abstrExpr e
+        e@(SDiv {})  -> abstrExpr e
+        e -> pure e
+        where
+            abstrExpr e = do
+              s <- get
+              case Map.lookup e s.words of
+                Just v -> pure (Var (TS.pack ("abst_" ++ show v)))
+                Nothing -> do
+                  let
+                    next = s.count
+                    bs' = Map.insert e next s.words
+                  put $ s{words=bs', count=next+1}
+                  pure $ Var (TS.pack ("abst_" ++ show next))
+
+smt2Line :: Builder -> SMT2
+smt2Line txt = SMT2 [txt] mempty mempty
 
 assertProps :: [Prop] -> SMT2
 assertProps ps =
-  let encs = map propToSMT ps_elim
+  let encs = map propToSMT psAbstElim
+      abstSMT = map propToSMT abstProps
       intermediates = declareIntermediates bufs stores in
   prelude
   <> (declareAbstractStores abstractStores)
-  <> SMT2 [""] mempty
+  <> smt2Line ""
   <> (declareAddrs addresses)
-  <> SMT2 [""] mempty
-  <> (declareBufs ps_elim bufs stores)
-  <> SMT2 [""] mempty
+  <> smt2Line ""
+  <> (declareBufs psAbstElim bufs stores)
+  <> smt2Line ""
   <> (declareVars . nubOrd $ foldl (<>) [] allVars)
-  <> SMT2 [""] mempty
+  <> smt2Line ""
   <> (declareFrameContext . nubOrd $ foldl (<>) [] frameCtx)
-  <> SMT2 [""] mempty
+  <> smt2Line ""
   <> (declareBlockContext . nubOrd $ foldl (<>) [] blockCtx)
-  <> SMT2 [""] mempty
+  <> smt2Line ""
   <> intermediates
-  <> SMT2 [""] mempty
+  <> smt2Line ""
   <> keccakAssumes
   <> readAssumes
-  <> SMT2 [""] mempty
-  <> SMT2 (fmap (\p -> "(assert " <> p <> ")") encs) mempty
-  <> SMT2 [] mempty{ storeReads = storageReads }
+  <> smt2Line ""
+  <> SMT2 (fmap (\p -> "(assert " <> p <> ")") encs) mempty mempty
+  <> SMT2 mempty (RefinementEqs $ fmap (\p -> "(assert " <> p <> ")") abstSMT) mempty
+  <> SMT2 mempty mempty mempty { storeReads = storageReads }
 
   where
-    (ps_elim, bufs, stores) = eliminateProps ps
+    (psAbst, bufs, stores) = eliminateProps ps
+    (psAbstElim, abst@(AbstState abstExprToInt _)) = abstractAwayProps psAbst
 
-    allVars = fmap referencedVars ps_elim <> fmap referencedVars bufVals <> fmap referencedVars storeVals
-    frameCtx = fmap referencedFrameContext ps_elim <> fmap referencedFrameContext bufVals <> fmap referencedFrameContext storeVals
-    blockCtx = fmap referencedBlockContext ps_elim <> fmap referencedBlockContext bufVals <> fmap referencedBlockContext storeVals
+    abstProps = map toProp (Map.toList abstExprToInt)
+      where
+      toProp :: (Expr EWord, Int) -> Prop
+      toProp (e, num) = PEq e (Var (TS.pack ("abst_" ++ (show num))))
+
+    allVars = fmap referencedVars psAbst <> fmap referencedVars bufVals <> fmap referencedVars storeVals <> [abstrVars abst]
+    frameCtx = fmap referencedFrameContext psAbst <> fmap referencedFrameContext bufVals <> fmap referencedFrameContext storeVals
+    blockCtx = fmap referencedBlockContext psAbst <> fmap referencedBlockContext bufVals <> fmap referencedBlockContext storeVals
+
+    abstrVars :: AbstState -> [Builder]
+    abstrVars (AbstState b _) = map ((\v->fromString ("abst_" ++ show v)) . snd) (Map.toList b)
 
     bufVals = Map.elems bufs
     storeVals = Map.elems stores
-
     storageReads = Map.unionsWith (<>) $ fmap findStorageReads ps
     abstractStores = Set.toList $ Set.unions (fmap referencedAbstractStores ps)
     addresses = Set.toList $ Set.unions (fmap referencedWAddrs ps)
 
     keccakAssumes
-      = SMT2 ["; keccak assumptions"] mempty
-      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakAssumptions ps_elim bufVals storeVals)) mempty
-      <> SMT2 ["; keccak computations"] mempty
-      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakCompute ps_elim bufVals storeVals)) mempty
-
+      = smt2Line "; keccak assumptions"
+      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakAssumptions psAbstElim bufVals storeVals)) mempty mempty
+      <> smt2Line "; keccak computations"
+      <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (keccakCompute psAbstElim bufVals storeVals)) mempty mempty
 
     readAssumes
-      = SMT2 ["; read assumptions"] mempty
-        <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (assertReads ps_elim bufs stores)) mempty
+      = smt2Line "; read assumptions"
+        <> SMT2 (fmap (\p -> "(assert " <> propToSMT p <> ")") (assertReads psAbstElim bufs stores)) mempty mempty
 
 referencedAbstractStores :: TraversableTerm a => a -> Set Builder
 referencedAbstractStores term = foldTerm go mempty term
@@ -334,7 +387,7 @@ discoverMaxReads props benv senv = bufMap
 
 -- | Returns an SMT2 object with all buffers referenced from the input props declared, and with the appropriate cex extraction metadata attached
 declareBufs :: [Prop] -> BufEnv -> StoreEnv -> SMT2
-declareBufs props bufEnv storeEnv = SMT2 ("; buffers" : fmap declareBuf allBufs <> ("; buffer lengths" : fmap declareLength allBufs)) cexvars
+declareBufs props bufEnv storeEnv = SMT2 ("; buffers" : fmap declareBuf allBufs <> ("; buffer lengths" : fmap declareLength allBufs)) mempty cexvars
   where
     cexvars = (mempty :: CexVars){ buffers = discoverMaxReads props bufEnv storeEnv }
     allBufs = fmap fromLazyText $ Map.keys cexvars.buffers
@@ -343,40 +396,41 @@ declareBufs props bufEnv storeEnv = SMT2 ("; buffers" : fmap declareBuf allBufs 
 
 -- Given a list of variable names, create an SMT2 object with the variables declared
 declareVars :: [Builder] -> SMT2
-declareVars names = SMT2 (["; variables"] <> fmap declare names) cexvars
+declareVars names = SMT2 (["; variables"] <> fmap declare names) mempty cexvars
   where
     declare n = "(declare-const " <> n <> " (_ BitVec 256))"
     cexvars = (mempty :: CexVars){ calldata = fmap toLazyText names }
 
 -- Given a list of variable names, create an SMT2 object with the variables declared
 declareAddrs :: [Builder] -> SMT2
-declareAddrs names = SMT2 (["; symbolic addresseses"] <> fmap declare names) cexvars
+declareAddrs names = SMT2 (["; symbolic addresseses"] <> fmap declare names) mempty cexvars
   where
     declare n = "(declare-const " <> n <> " Addr)"
     cexvars = (mempty :: CexVars){ addrs = fmap toLazyText names }
 
 declareFrameContext :: [(Builder, [Prop])] -> SMT2
-declareFrameContext names = SMT2 (["; frame context"] <> concatMap declare names) cexvars
+declareFrameContext names = SMT2 (["; frame context"] <> concatMap declare names) mempty cexvars
   where
     declare (n,props) = [ "(declare-const " <> n <> " (_ BitVec 256))" ]
                         <> fmap (\p -> "(assert " <> propToSMT p <> ")") props
     cexvars = (mempty :: CexVars){ txContext = fmap (toLazyText . fst) names }
 
 declareAbstractStores :: [Builder] -> SMT2
-declareAbstractStores names = SMT2 (["; abstract base stores"] <> fmap declare names) mempty
+declareAbstractStores names = SMT2 (["; abstract base stores"] <> fmap declare names) mempty mempty
   where
     declare n = "(declare-const " <> n <> " Storage)"
 
 declareBlockContext :: [(Builder, [Prop])] -> SMT2
-declareBlockContext names = SMT2 (["; block context"] <> concatMap declare names) cexvars
+declareBlockContext names = SMT2 (["; block context"] <> concatMap declare names) mempty cexvars
   where
     declare (n, props) = [ "(declare-const " <> n <> " (_ BitVec 256))" ]
                          <> fmap (\p -> "(assert " <> propToSMT p <> ")") props
     cexvars = (mempty :: CexVars){ blockContext = fmap (toLazyText . fst) names }
 
-
 prelude :: SMT2
-prelude =  (flip SMT2) mempty $ fmap (fromLazyText . T.drop 2) . T.lines $ [i|
+prelude =  SMT2 src mempty mempty
+  where
+  src = fmap (fromLazyText . T.drop 2) . T.lines $ [i|
   ; logic
   ; TODO: this creates an error when used with z3?
   ;(set-logic QF_AUFBV)
@@ -394,7 +448,6 @@ prelude =  (flip SMT2) mempty $ fmap (fromLazyText . T.drop 2) . T.lines $ [i|
   ; hash functions
   (declare-fun keccak (Buf) Word)
   (declare-fun sha256 (Buf) Word)
-
   (define-fun max ((a (_ BitVec 256)) (b (_ BitVec 256))) (_ BitVec 256) (ite (bvult a b) b a))
 
   ; word indexing

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -102,7 +102,7 @@ data SMTCex = SMTCex
   deriving (Eq, Show)
 
 
--- | Used for abstraction-refinement of the SMT formula
+-- | Used for abstraction-refinement of the SMT formula. Contains assertions that make our query fully precise. These will be added to the assertion stack if we get `sat` with the abstracted query.
 newtype RefinementEqs = RefinementEqs [Builder]
   deriving (Eq, Show, Monoid, Semigroup)
 

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -176,6 +176,7 @@ abstractAwayProps ps = runState (mapM abstrAway ps) (AbstState mempty 0)
         e@(Mul{})    -> abstrExpr e
         e@(Div{})    -> abstrExpr e
         e@(SDiv {})  -> abstrExpr e
+        e@(ReadWord {})-> abstrExpr e
         e -> pure e
         where
             abstrExpr e = do

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -192,8 +192,8 @@ abstractAwayProps ps = runState (mapM abstrAway ps) (AbstState mempty 0)
 smt2Line :: Builder -> SMT2
 smt2Line txt = SMT2 [txt] mempty mempty
 
-assertProps :: [Prop] -> SMT2
-assertProps ps =
+assertProps :: [Prop] -> Bool -> SMT2
+assertProps ps abstRefine =
   let encs = map propToSMT psElimAbst
       abstSMT = map propToSMT abstProps
       intermediates = declareIntermediates bufs stores in
@@ -221,7 +221,9 @@ assertProps ps =
 
   where
     (psElim, bufs, stores) = eliminateProps ps
-    (psElimAbst, abst@(AbstState abstExprToInt _)) = abstractAwayProps psElim
+    (psElimAbst, abst@(AbstState abstExprToInt _)) = if abstRefine
+      then abstractAwayProps psElim
+      else (psElim, AbstState mempty 0)
 
     abstProps = map toProp (Map.toList abstExprToInt)
       where

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -112,21 +112,30 @@ withSolvers solver count timeout cont = do
       _ <- forkIO $ runTask task inst avail
       orchestrate queue avail
 
-    runTask (Task (SMT2 cmds cexvars) r) inst availableInstances = do
+    runTask (Task (SMT2 cmds (RefinementEqs refineEqs) cexvars) r) inst availableInstances = do
       -- reset solver and send all lines of provided script
-      out <- sendScript inst (SMT2 ("(reset)" : cmds) cexvars)
+      out <- sendScript inst (SMT2 ("(reset)" : cmds) mempty mempty)
       case out of
         -- if we got an error then return it
         Left e -> writeChan r (Error ("error while writing SMT to solver: " <> T.toStrict e))
         -- otherwise call (check-sat), parse the result, and send it down the result channel
         Right () -> do
           sat <- sendLine inst "(check-sat)"
-          res <- case sat of
-            "sat" -> Sat <$> getModel inst cexvars
-            "unsat" -> pure Unsat
-            "timeout" -> pure Unknown
-            "unknown" -> pure Unknown
-            _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat
+          res <- do
+              case sat of
+                "unsat" -> pure Unsat
+                "timeout" -> pure Unknown
+                "unknown" -> pure Unknown
+                "sat" -> do
+                  _ <- sendScript inst (SMT2 refineEqs mempty mempty)
+                  sat2 <- sendLine inst "(check-sat)"
+                  case sat2 of
+                    "unsat" -> pure Unsat
+                    "timeout" -> pure Unknown
+                    "unknown" -> pure Unknown
+                    "sat" -> Sat <$> getModel inst cexvars
+                    _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat2
+                _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat
           writeChan r res
 
       -- put the instance back in the list of available instances
@@ -252,7 +261,7 @@ stopSolver (SolverInstance _ stdin stdout stderr process) = cleanupProcess (Just
 
 -- | Sends a list of commands to the solver. Returns the first error, if there was one.
 sendScript :: SolverInstance -> SMT2 -> IO (Either Text ())
-sendScript solver (SMT2 cmds _) = do
+sendScript solver (SMT2 cmds _ _) = do
   let sexprs = splitSExpr $ fmap toLazyText cmds
   go sexprs
   where

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -126,15 +126,16 @@ withSolvers solver count timeout cont = do
                 "unsat" -> pure Unsat
                 "timeout" -> pure Unknown
                 "unknown" -> pure Unknown
-                "sat" -> do
-                  _ <- sendScript inst (SMT2 refineEqs mempty mempty)
-                  sat2 <- sendLine inst "(check-sat)"
-                  case sat2 of
-                    "unsat" -> pure Unsat
-                    "timeout" -> pure Unknown
-                    "unknown" -> pure Unknown
-                    "sat" -> Sat <$> getModel inst cexvars
-                    _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat2
+                "sat" -> if null refineEqs then Sat <$> getModel inst cexvars
+                         else do
+                              _ <- sendScript inst (SMT2 refineEqs mempty mempty)
+                              sat2 <- sendLine inst "(check-sat)"
+                              case sat2 of
+                                "unsat" -> pure Unsat
+                                "timeout" -> pure Unknown
+                                "unknown" -> pure Unknown
+                                "sat" -> Sat <$> getModel inst cexvars
+                                _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat2
                 _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat
           writeChan r res
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -99,6 +99,9 @@ rpcVeriOpts info = defaultVeriOpts { rpcInfo = Just info }
 debugVeriOpts :: VeriOpts
 debugVeriOpts = defaultVeriOpts { debug = True }
 
+debugAbstVeriOpts :: VeriOpts
+debugAbstVeriOpts = defaultVeriOpts { abstRefine = True }
+
 extractCex :: VerifyResult -> Maybe (Expr End, SMTCex)
 extractCex (Cex c) = Just c
 extractCex _ = Nothing

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -77,6 +77,7 @@ data VeriOpts = VeriOpts
   , maxIter :: Maybe Integer
   , askSmtIters :: Integer
   , loopHeuristic :: LoopHeuristic
+  , abstRefine :: Bool
   , rpcInfo :: Fetch.RpcInfo
   }
   deriving (Eq, Show)
@@ -88,6 +89,7 @@ defaultVeriOpts = VeriOpts
   , maxIter = Nothing
   , askSmtIters = 1
   , loopHeuristic = StackBased
+  , abstRefine = False
   , rpcInfo = Nothing
   }
 
@@ -489,7 +491,7 @@ reachable solvers e = do
               (Nothing, Nothing) -> Nothing
         pure (fst tres <> fst fres, subexpr)
       leaf -> do
-        let query = assertProps pcs
+        let query = assertProps pcs False
         res <- checkSat solvers query
         case res of
           Sat _ -> pure ([query], Just leaf)
@@ -555,7 +557,7 @@ verify solvers opts preState maybepost = do
             _ -> True
         assumes = preState.constraints
         withQueries = canViolate <&> \leaf ->
-          (assertProps (PNeg (post preState leaf) : assumes <> extractProps leaf), leaf)
+          (assertProps (PNeg (post preState leaf) : assumes <> extractProps leaf) opts.abstRefine, leaf)
       putStrLn $ "Checking for reachability of "
                    <> show (length withQueries)
                    <> " potential property violation(s)"
@@ -667,7 +669,7 @@ equivalenceCheck' solvers branchesA branchesB opts = do
     -- used or not
     check :: UnsatCache -> (Set Prop) -> Int -> IO (EquivResult, Bool)
     check knownUnsat props idx = do
-      let smt = assertProps $ Set.toList props
+      let smt = assertProps (Set.toList props) opts.abstRefine
       -- if debug is on, write the query to a file
       let filename = "equiv-query-" <> show idx <> ".smt2"
       when opts.debug $ TL.writeFile filename (formatSMT2 smt <> "\n\n(check-sat)")
@@ -766,7 +768,7 @@ both' f (x, y) = (f x, f y)
 produceModels :: SolverGroup -> Expr End -> IO [(Expr End, CheckSatResult)]
 produceModels solvers expr = do
   let flattened = flattenExpr expr
-      withQueries = fmap (\e -> (assertProps . extractProps $ e, e)) flattened
+      withQueries = fmap (\e -> ((flip assertProps False) . extractProps $ e, e)) flattened
   results <- flip mapConcurrently withQueries $ \(query, leaf) -> do
     res <- checkSat solvers query
     pure (res, leaf)

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -620,6 +620,15 @@ data RuntimeConfig = RuntimeConfig
   }
   deriving (Show)
 
+abstRefineDefault :: AbstRefineConfig
+abstRefineDefault = AbstRefineConfig False False
+
+data AbstRefineConfig = AbstRefineConfig
+  { arith :: Bool
+  , mem   :: Bool
+  }
+  deriving (Show, Eq)
+
 -- | An entry in the VM's "call/create stack"
 data Frame s = Frame
   { context :: FrameContext

--- a/test/test.hs
+++ b/test/test.hs
@@ -2727,7 +2727,7 @@ checkEquivBase mkprop l r = withSolvers Z3 1 (Just 1) $ \solvers -> do
        putStrLn "skip"
        pure True
      else do
-       let smt = assertProps [mkprop l r] False
+       let smt = assertProps False False [mkprop l r]
        res <- checkSat solvers smt
        print res
        pure $ case res of

--- a/test/test.hs
+++ b/test/test.hs
@@ -2727,7 +2727,7 @@ checkEquivBase mkprop l r = withSolvers Z3 1 (Just 1) $ \solvers -> do
        putStrLn "skip"
        pure True
      else do
-       let smt = assertProps [mkprop l r]
+       let smt = assertProps [mkprop l r] False
        res <- checkSat solvers smt
        print res
        pure $ case res of

--- a/test/test.hs
+++ b/test/test.hs
@@ -2727,7 +2727,7 @@ checkEquivBase mkprop l r = withSolvers Z3 1 (Just 1) $ \solvers -> do
        putStrLn "skip"
        pure True
      else do
-       let smt = assertProps False False [mkprop l r]
+       let smt = assertProps abstRefineDefault [mkprop l r]
        res <- checkSat solvers smt
        print res
        pure $ case res of

--- a/test/test.hs
+++ b/test/test.hs
@@ -1274,7 +1274,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _])  <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+        (_, [Qed _])  <- withSolvers CVC5 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "sdiv works as expected"
       ,
      testCase "signed-overflow-checks" $ do
@@ -1416,6 +1416,33 @@ tests = testGroup "hevm"
             |]
         (_, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         putStrLn "XOR works as expected"
+      ,
+      testCase "opcode-add-commutative" $ do
+        Just c <- solcRuntime "MyContract"
+            [i|
+            contract MyContract {
+              function fun(uint256 a, uint256 b) external pure {
+                uint256 res1;
+                uint256 res2;
+                assembly {
+                  res1 := add(a,b)
+                  res2 := add(b,a)
+                }
+                assert (res1 == res2);
+              }
+            }
+            |]
+        a <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        case a of
+          (_, [Cex (_, ctr)]) -> do
+            let x = getVar ctr "arg1"
+            let y = getVar ctr "arg2"
+            putStrLn $ "y:" <> show y
+            putStrLn $ "x:" <> show x
+            assertEqual "Addition is not commutative... that's wrong" False True
+          (_, [Qed _]) -> do
+            putStrLn "adding is commutative"
+          _ -> internalError "Unexpected"
       ,
       testCase "opcode-div-res-zero-on-div-by-zero" $ do
         Just c <- solcRuntime "MyContract"
@@ -2111,13 +2138,13 @@ tests = testGroup "hevm"
           (res, [Qed _]) <- withSolvers Z3 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLn $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
-        ignoreTest $ testCase "safemath distributivity (yul)" $ do
+        testCase "safemath-distributivity-yul" $ do
           let yulsafeDistributivity = hex "6355a79a6260003560e01c14156016576015601f565b5b60006000fd60a1565b603d602d604435600435607c565b6039602435600435607c565b605d565b6052604b604435602435605d565b600435607c565b141515605a57fe5b5b565b6000828201821115151560705760006000fd5b82820190505b92915050565b6000818384048302146000841417151560955760006000fd5b82820290505b92915050565b"
           vm <- stToIO $ abstractVM (mkCalldata (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) []) yulsafeDistributivity Nothing False
           (_, [Qed _]) <-  withSolvers Z3 1 Nothing $ \s -> verify s defaultVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
           putStrLn "Proven"
         ,
-        testCase "safemath distributivity (sol)" $ do
+        testCase "safemath-distributivity-sol" $ do
           Just c <- solcRuntime "C"
             [i|
               contract C {
@@ -2139,7 +2166,7 @@ tests = testGroup "hevm"
               }
             |]
 
-          (_, [Qed _]) <- withSolvers Z3 1 (Just 99999999) $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          (_, [Qed _]) <- withSolvers CVC5 1 (Just 99999999) $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLn "Proven"
         ,
         testCase "storage-cex-1" $ do


### PR DESCRIPTION
## Description
This adds an extra abstraction of the memory at the IR level. We have discussed this and I believe @d-xo had a diff that was either exactly this or similar to this. It's a single line difference on top of #330, namely:
```
e@(ReadWord {})-> abstrExpr e
```

This is actually very powerful and improves the speed a lot: ~30% faster runtime on unit tests... except for:

```
testCase "calldata beyond calldatasize is 0 (symbolic calldata)" $ do
testCase "calldata beyond calldatasize is 0 (concrete dalldata prefix)" $ do
testCase "calldata symbolic access" $ do
```

Where it struggles AND eventually it gives the wrong result. Very strange. I will work on this next. I want to understand why it doesn't work. There must be some weird reason and I have a feeling it may be a deeper issue. In general, I think this kind of abstraction-refinement at the IR level is likely very powerful, perhaps much more powerful than at the SMT level.

This is a work-in-progress.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
