### PR TITLE
Simplify Props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contract balances can now be fully symbolic
 - Contract code can now be fully abstract. Calls into contracts with unknown code will fail with `UnexpectedSymbolicArg`.
 - Run expression simplification on branch conditions
+- Improved Prop simplification
 
 ## API Changes
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -27,6 +27,10 @@ import Optics.Core
 import EVM.Traversals
 import EVM.Types
 
+-- ** Constants **
+
+maxLit :: W256
+maxLit = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 
 -- ** Stack Ops ** ---------------------------------------------------------------------------------
 
@@ -666,8 +670,8 @@ simplifyProp p = mapProp' go p
     -- trivial LT/LEq comparisions
     go (PLT  (Var _) (Lit 0)) = PBool False
     go (PLEq (Lit 0) (Var _)) = PBool True
-    go (PLT  (Lit 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) (Var _)) = PBool False
-    go (PLEq (Var _) (Lit 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)) = PBool True
+    go (PLT  (Lit val) (Var _)) | val == maxLit = PBool False
+    go (PLEq (Var _) (Lit val)) | val == maxLit = PBool True
 
     -- negations
     go (PNeg (PBool True)) = PBool False
@@ -816,7 +820,7 @@ simplify e = if (mapExpr go e == e)
       | otherwise = o
     go o@(And v (Lit x))
       | x == 0 = Lit 0
-      | x == 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff = v
+      | x == maxLit = v
       | otherwise = o
     go o@(Or (Lit x) b)
       | x == 0 = b

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -652,7 +652,6 @@ flattenProps (a:ax) = case a of
 flattenProps [] = []
 
 simplifyProp :: Expr a -> Expr a
--- simplifyProp p = simplifyPropExp (flattenProps) p
 simplifyProp p = simplifyPropExp (removeTrueProps . map (mapProp' go) . flattenProps) p
   where
     go :: Prop -> Prop

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -650,8 +650,8 @@ remRedundantProps p = collapseFalse . filter (\x -> x /= PBool True) . nubOrd $ 
     collapseFalse :: [Prop] -> [Prop]
     collapseFalse ps = if isJust $ find (== PBool False) ps then [PBool False] else ps
 
-simplifyPropExpr :: Expr a -> Expr a
-simplifyPropExpr e = applyToProps (remRedundantProps . map evalProp . flattenProps) e
+simplifyProp :: Expr End -> Expr End
+simplifyProp e = applyToProps (remRedundantProps . map evalProp . flattenProps) e
   where
     -- Makes [PAnd a b] into [a,b]
     flattenProps :: [Prop] -> [Prop]

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1084,7 +1084,7 @@ evalProp prop =
     go (POr (PBool l) (PBool r)) = PBool (l || r)
 
     -- Imply
-    go (PImpl (PBool l) (PBool r)) = PBool ((Prelude.not l) || r)
+    go (PImpl _ (PBool True)) = PBool True
     go (PImpl (PBool True) b) = b
     go (PImpl (PBool False) _) = PBool True
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -655,9 +655,8 @@ simplifyProp e = applyToProps (remRedundantProps . map evalProp . flattenProps) 
     -- removes redundant (constant True/False) props
     remRedundantProps :: [Prop] -> [Prop]
     remRedundantProps p = collapseFalse . filter (\x -> x /= PBool True) . nubOrd $ p
-      where
-        collapseFalse :: [Prop] -> [Prop]
-        collapseFalse ps = if isJust $ find (== PBool False) ps then [PBool False] else ps
+    collapseFalse :: [Prop] -> [Prop]
+    collapseFalse ps = if isJust $ find (== PBool False) ps then [PBool False] else ps
 
 -- | Simple recursive match based AST simplification
 -- Note: may not terminate!

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1059,9 +1059,6 @@ evalProp prop =
   in if (new == prop) then prop else evalProp new
   where
     go :: Prop -> Prop
-    go (POr (PBool True) _) = PBool True
-    go (POr _ (PBool True)) = PBool True
-
     -- rewrite everything as LEq or LT
     go (PGEq a b) = PLEq b a
     go (PGT a b) = PLT b a
@@ -1082,6 +1079,8 @@ evalProp prop =
     go (PAnd (PBool l) (PBool r)) = PBool (l && r)
     go (PAnd (PBool False) _) = PBool False
     go (PAnd _ (PBool False)) = PBool False
+    go (POr (PBool True) _) = PBool True
+    go (POr _ (PBool True)) = PBool True
     go (POr (PBool l) (PBool r)) = PBool (l || r)
 
     -- Imply

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -532,8 +532,7 @@ verify solvers opts preState maybepost = do
   when opts.debug $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
 
   putStrLn "Simplifying expression"
-  let exprPartialSimp = if opts.simp then (Expr.simplify exprInter) else exprInter
-  let expr = if opts.simp then (Expr.simplifyProp exprPartialSimp) else exprPartialSimp
+  let expr = if opts.simp then (Expr.simplify exprInter) else exprInter
   when opts.debug $ T.writeFile "simplified.expr" (formatExpr expr)
 
   putStrLn $ "Explored contract (" <> show (Expr.numBranches expr) <> " branches)"

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -533,7 +533,7 @@ verify solvers opts preState maybepost = do
 
   putStrLn "Simplifying expression"
   let exprPartialSimp = if opts.simp then (Expr.simplify exprInter) else exprInter
-  let expr = if opts.simp then (Expr.simplifyPropExpr exprPartialSimp) else exprPartialSimp
+  let expr = if opts.simp then (Expr.simplifyProp exprPartialSimp) else exprPartialSimp
   when opts.debug $ T.writeFile "simplified.expr" (formatExpr expr)
 
   putStrLn $ "Explored contract (" <> show (Expr.numBranches expr) <> " branches)"

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -532,11 +532,11 @@ verify solvers opts preState maybepost = do
   when opts.debug $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
 
   putStrLn "Simplifying expression"
-  let f = Expr.simplifyProp exprInter
+  let f = Expr.simplifyPropExpr exprInter
   when opts.debug $ T.writeFile "mate.expr" (formatExpr f)
 
   let exprPartialSimp = if opts.simp then (Expr.simplify exprInter) else exprInter
-  let expr = if opts.simp then (Expr.simplifyProp exprPartialSimp) else exprPartialSimp
+  let expr = if opts.simp then (Expr.simplifyPropExpr exprPartialSimp) else exprPartialSimp
   when opts.debug $ T.writeFile "simplified.expr" (formatExpr expr)
 
   putStrLn $ "Explored contract (" <> show (Expr.numBranches expr) <> " branches)"

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -532,7 +532,11 @@ verify solvers opts preState maybepost = do
   when opts.debug $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
 
   putStrLn "Simplifying expression"
-  expr <- if opts.simp then (pure $ Expr.simplify exprInter) else pure exprInter
+  let f = Expr.simplifyProp exprInter
+  when opts.debug $ T.writeFile "mate.expr" (formatExpr f)
+
+  let exprPartialSimp = if opts.simp then (Expr.simplify exprInter) else exprInter
+  let expr = if opts.simp then (Expr.simplifyProp exprPartialSimp) else exprPartialSimp
   when opts.debug $ T.writeFile "simplified.expr" (formatExpr expr)
 
   putStrLn $ "Explored contract (" <> show (Expr.numBranches expr) <> " branches)"

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -532,9 +532,6 @@ verify solvers opts preState maybepost = do
   when opts.debug $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
 
   putStrLn "Simplifying expression"
-  let f = Expr.simplifyPropExpr exprInter
-  when opts.debug $ T.writeFile "mate.expr" (formatExpr f)
-
   let exprPartialSimp = if opts.simp then (Expr.simplify exprInter) else exprInter
   let expr = if opts.simp then (Expr.simplifyPropExpr exprPartialSimp) else exprPartialSimp
   when opts.debug $ T.writeFile "simplified.expr" (formatExpr expr)

--- a/test/test.hs
+++ b/test/test.hs
@@ -232,11 +232,11 @@ tests = testGroup "hevm"
     , testProperty "evalProp-equivalence-sym" $ \(p) -> ioProperty $ do
         let simplified = Expr.evalProp p
         checkEquivProp simplified p
-    , testProperty "simpProp-equivalence-sym" $ \(p :: Prop) -> ioProperty $ do
-        let simplified = Expr.simplifyProp p
-        checkEquivProp simplified p
+    , testProperty "simpProp-equivalence-sym" $ \(ps :: [Prop]) -> ioProperty $ do
+        let simplified = pand (Expr.simplifyProps ps)
+        checkEquivProp simplified (pand ps)
     , testProperty "simpProp-equivalence-sym" $ \(LitProp p) -> ioProperty $ do
-        let simplified = Expr.simplifyProp p
+        let simplified = pand (Expr.simplifyProps [p])
         checkEquivProp simplified p
     ]
   , testGroup "MemoryTests"

--- a/test/test.hs
+++ b/test/test.hs
@@ -2235,6 +2235,39 @@ tests = testGroup "hevm"
           assertBool "Did not find expected storage cex" testCex
           putStrLn "Expected counterexample found"
   ]
+  , testGroup "simplification-working"
+  [
+    testCase "prop-simp-bool1" $ do
+      let
+        a = Success [PAnd (PBool True) (PBool False)] mempty (ConcreteBuf "") mempty
+        b = Expr.simplify a
+      assertEqual "Must simplify down" (Success [PBool False] mempty (ConcreteBuf "") mempty) b
+    , testCase "prop-simp-bool2" $ do
+      let
+        a = Success [POr (PBool True) (PBool False)] mempty (ConcreteBuf "") mempty
+        b = Expr.simplify a
+      assertEqual "Must simplify down" (Success [] mempty (ConcreteBuf "") mempty) b
+    , testCase "prop-simp-LT" $ do
+      let
+        a = Success [PLT (Lit 1) (Lit 2)] mempty (ConcreteBuf "") mempty
+        b = Expr.simplify a
+      assertEqual "Must simplify down" (Success [] mempty (ConcreteBuf "") mempty) b
+    , testCase "prop-simp-GEq" $ do
+      let
+        a = Success [PGEq (Lit 1) (Lit 2)] mempty (ConcreteBuf "") mempty
+        b = Expr.simplify a
+      assertEqual "Must simplify down" (Success [PBool False] mempty (ConcreteBuf "") mempty) b
+    , testCase "prop-simp-multiple" $ do
+      let
+        a = Success [PBool False, PBool True] mempty (ConcreteBuf "") mempty
+        b = Expr.simplify a
+      assertEqual "Must simplify down" (Success [PBool False] mempty (ConcreteBuf "") mempty) b
+    , testCase "prop-simp-expr" $ do
+      let
+        a = Success [PEq (Add (Lit 1) (Lit 2)) (Sub (Lit 4) (Lit 1))] mempty (ConcreteBuf "") mempty
+        b = Expr.simplify a
+      assertEqual "Must simplify down" (Success [] mempty (ConcreteBuf "") mempty) b
+  ]
   , testGroup "equivalence-checking"
     [
       testCase "eq-yul-simple-cex" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -3037,6 +3037,7 @@ genProp onlyLits sz = oneof
   where
     subWord = if onlyLits then frequency [(2, Lit <$> arbitrary)
                                          ,(1, pure $ Lit 0)
+                                         ,(1, pure $ Lit Expr.maxLit)
                                          ]
                           else genWord 1 (sz `div` 2)
     subProp = genProp onlyLits (sz `div` 2)
@@ -3087,6 +3088,7 @@ genWord litFreq 0 = frequency
       val <- frequency
        [ (10, fmap (`mod` 100) arbitrary)
        , (1, pure 0)
+       , (1, pure Expr.maxLit)
        , (1, arbitrary)
        ]
       pure $ Lit val

--- a/test/test.hs
+++ b/test/test.hs
@@ -2239,34 +2239,39 @@ tests = testGroup "hevm"
   [
     testCase "prop-simp-bool1" $ do
       let
-        a = Success [PAnd (PBool True) (PBool False)] mempty (ConcreteBuf "") mempty
+        a = successGen [PAnd (PBool True) (PBool False)]
         b = Expr.simplify a
-      assertEqual "Must simplify down" (Success [PBool False] mempty (ConcreteBuf "") mempty) b
+      assertEqual "Must simplify down" (successGen [PBool False]) b
     , testCase "prop-simp-bool2" $ do
       let
-        a = Success [POr (PBool True) (PBool False)] mempty (ConcreteBuf "") mempty
+        a = successGen [POr (PBool True) (PBool False)]
         b = Expr.simplify a
-      assertEqual "Must simplify down" (Success [] mempty (ConcreteBuf "") mempty) b
+      assertEqual "Must simplify down" (successGen []) b
     , testCase "prop-simp-LT" $ do
       let
-        a = Success [PLT (Lit 1) (Lit 2)] mempty (ConcreteBuf "") mempty
+        a = successGen [PLT (Lit 1) (Lit 2)]
         b = Expr.simplify a
-      assertEqual "Must simplify down" (Success [] mempty (ConcreteBuf "") mempty) b
+      assertEqual "Must simplify down" (successGen []) b
     , testCase "prop-simp-GEq" $ do
       let
-        a = Success [PGEq (Lit 1) (Lit 2)] mempty (ConcreteBuf "") mempty
+        a = successGen [PGEq (Lit 1) (Lit 2)]
         b = Expr.simplify a
-      assertEqual "Must simplify down" (Success [PBool False] mempty (ConcreteBuf "") mempty) b
+      assertEqual "Must simplify down" (successGen [PBool False]) b
     , testCase "prop-simp-multiple" $ do
       let
-        a = Success [PBool False, PBool True] mempty (ConcreteBuf "") mempty
+        a = successGen [PBool False, PBool True]
         b = Expr.simplify a
-      assertEqual "Must simplify down" (Success [PBool False] mempty (ConcreteBuf "") mempty) b
+      assertEqual "Must simplify down" (successGen [PBool False]) b
     , testCase "prop-simp-expr" $ do
       let
-        a = Success [PEq (Add (Lit 1) (Lit 2)) (Sub (Lit 4) (Lit 1))] mempty (ConcreteBuf "") mempty
+        a = successGen [PEq (Add (Lit 1) (Lit 2)) (Sub (Lit 4) (Lit 1))]
         b = Expr.simplify a
-      assertEqual "Must simplify down" (Success [] mempty (ConcreteBuf "") mempty) b
+      assertEqual "Must simplify down" (successGen []) b
+    , testCase "prop-simp-impl" $ do
+      let
+        a = successGen [PImpl (PBool False) (PEq (Var "abc") (Var "bcd"))]
+        b = Expr.simplify a
+      assertEqual "Must simplify down" (successGen []) b
   ]
   , testGroup "equivalence-checking"
     [
@@ -3365,3 +3370,6 @@ checkPost post c sig = do
   case cexs of
     [] -> pure $ Right e
     cs -> pure $ Left cs
+
+successGen :: [Prop] -> Expr End
+successGen props = Success props mempty (ConcreteBuf "") mempty


### PR DESCRIPTION
## Description
We don't simplify `Prop`-s -- we simplify the expressions they utilize, but not the `Prop`-s themselves. So we quite often end up with stuff like:

```
      (PAnd
        (PGEq
          (Var "arg1")
          0x0
        )
        (PLEq
          (Var "arg1")
          0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
        )
      )
```

in the `Expr 'End`. Notice that the above is always TRUE. 

With this PR, we  get rid of these, and more. The basic idea is:

* Take out the `Prop` list from `Success`/`Failure`/`Partial`
* Flatten it by making `[PAnd x y]` ->` [x,y]`
* Do trivial simplifications on the `PLT`,`PLEq`, and transform all `GT` to `LT` and `GEq` to `LEq`
* Remove all `PBool True`-s

This gets rid of some of the redundant `(assert true)` in our SMT2, and makes it smaller in general.  We get something like this even for a trivial SMT2:

```
 ; logic
@@ -233,13 +233,9 @@
 (assert (and (bvuge (max (_ bv36 256) txdata_length) (_ bv36 256)) (bvult (max (_ bv36 256) txdata_length) (_ bv18446744073709551616 256))))
 (assert (and (bvuge arg1 (_ bv0 256)) (bvule arg1 (_ bv115792089237316195423570985008687907853269984665640564039457584007913129639935 256))))
 (assert (= arg1 (_ bv10 256)))
-(assert true)
-(assert true)
-(assert true)
-(assert true)
 (assert (not (= (ite (= txvalue (_ bv0 256)) (_ bv1 256) (_ bv0 256)) (_ bv0 256))))
-(assert (and (bvuge (max (_ bv36 256) txdata_length) (_ bv36 256)) (bvult (max (_ bv36 256) txdata_length) (_ bv18446744073709551616 256))))
-(assert (and (bvuge arg1 (_ bv0 256)) (bvule arg1 (_ bv115792089237316195423570985008687907853269984665640564039457584007913129639935 256))))
+(assert (bvule (_ bv36 256) (max (_ bv36 256) txdata_length)))
+(assert (bvult (max (_ bv36 256) txdata_length) (_ bv18446744073709551616 256)))
 (assert (= (bvsub arg1 (_ bv10 256)) (_ bv0 256)))
 (assert (not (= (ite (= txvalue (_ bv0 256)) (_ bv1 256) (_ bv0 256)) (_ bv0 256))))
```

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
