### PR TITLE
Rename "store:" to "storage:"

### DIFF
--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -649,13 +649,13 @@ formatExpr = go
         ]
 
       -- Stores
-      SLoad slot store -> T.unlines
+      SLoad slot storage -> T.unlines
         [ "(SLoad"
         , indent 2 $ T.unlines
           [ "slot:"
           , indent 2 $ formatExpr slot
-          , "store:"
-          , indent 2 $ formatExpr store
+          , "storage:"
+          , indent 2 $ formatExpr storage
           ]
         , ")"
         ]


### PR DESCRIPTION
## Description
Very tiny change, but I think it's best to use a noun "storage" than a verb "store" here, because it's loading from this storage. The verb sounds like it maybe storing something, i.e. changing the storage. I actually had to double-check the code just to be sure it's really an SLoad, because the verb threw me off. Of course a "store" is also a noun (e.g. "I went to the store") but here, without context, it does sound like a verb. "storage" is more clearly a noun.

Just a nitpick, but I thought I'd throw it in here.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
