### PR TITLE
A fairly regular `CopySlice` simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contract balances can now be fully symbolic
 - Contract code can now be fully abstract. Calls into contracts with unknown code will fail with `UnexpectedSymbolicArg`.
 - Run expression simplification on branch conditions
+- CopySlice+WriteWord+ConcreteBuf now truncates ConcreteBuf in special cases
 
 ## API Changes
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -663,6 +663,8 @@ simplify e = if (mapExpr go e == e)
     go (WriteWord a b c) = writeWord a b c
 
     go (WriteByte a b c) = writeByte a b c
+
+    -- truncate some concrete source buffers to the portion relevant for the CopySlice if we're copying a fully concrete region
     go orig@(CopySlice srcOff@(Lit n) dstOff size@(Lit sz)
         -- It doesn't matter what wOffs we write to, because only the first
         -- n+sz of ConcreteBuf will be used by CopySlice

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -663,6 +663,8 @@ simplify e = if (mapExpr go e == e)
     go (WriteWord a b c) = writeWord a b c
 
     go (WriteByte a b c) = writeByte a b c
+    go (CopySlice srcOff@(Lit 0) dstOff size@(Lit sz) (WriteWord (Lit 0) value (ConcreteBuf buf)) dst) = (CopySlice srcOff dstOff size (WriteWord (Lit 0) value (ConcreteBuf simplifiedBuf)) dst)
+        where simplifiedBuf = BS.take (unsafeInto sz) buf
     go (CopySlice a b c d f) = copySlice a b c d f
 
     go (IndexWord a b) = indexWord a b


### PR DESCRIPTION
## Description
This simplifies away some of the `ConcreteBuf` when we `CopySlice` from a `WriteWord`+`ConcreteBuf` combo. If the `ConcreteBuf` is larger than what we will copy, the last parts of the `ConcreteBuf` is useless.

Without:
```
            (CopySlice
              srcOffset: 0x0
              dstOffset: 0x0
              size:      0x40
              src:
                (WriteWord
                  idx:
                    0x0
                  val:
                    (WAddr
                      (SymAddr "arg1")
                    )
                )
                (ConcreteBuf
                  Length: 96 (0x60) bytes
                  0000:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                  0010:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                  0020:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                  0030:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                  0040:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                  0050:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 80   ................
                )
            )
            (ConcreteBuf "")
```

With:

```
            (CopySlice
              srcOffset: 0x0
              dstOffset: 0x0
              size:      0x40
              src:
                (WriteWord
                  idx:
                    0x0
                  val:
                    (WAddr
                      (SymAddr "arg1")
                    )
                )
                (ConcreteBuf
                  Length: 64 (0x40) bytes
                  0000:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                  0010:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                  0020:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                  0030:   00 00 00 00  00 00 00 00  00 00 00 00  00 00 00 00   ................
                )
            )
```

Notice that there was no need for all that 96B `ConcreteBuf` -- the `CopySlice` will cut it out anyway. So we only keep 64B, which is what `CopySlice` will copy.


## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
