### PR TITLE
Using the internalError function

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -566,7 +566,7 @@ stripWrites off size = \case
   WriteByte i v prev -> WriteByte i v (stripWrites off size prev)
   WriteWord i v prev -> WriteWord i v (stripWrites off size prev)
   CopySlice srcOff dstOff size' src dst -> CopySlice srcOff dstOff size' src dst
-  GVar _ ->  internalError "unexpected GVar in stripWrites"
+  GVar _ ->  internalError "Unexpected GVar in stripWrites"
 
 
 -- ** Storage ** -----------------------------------------------------------------------------------

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -251,7 +251,7 @@ checkBranch solvers branchcondition pathconditions = do
         Sat _ -> pure EVM.Types.Unknown
         -- Explore both branches in case of timeout
         EVM.Solvers.Unknown -> pure EVM.Types.Unknown
-        Error e -> error $ "Internal Error: SMT Solver pureed with an error: " <> T.unpack e
+        Error e -> internalError $ "SMT Solver pureed with an error: " <> T.unpack e
     -- If the query times out, we simply explore both paths
     EVM.Solvers.Unknown -> pure EVM.Types.Unknown
     Error e -> internalError $ "SMT Solver pureed with an error: " <> T.unpack e

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -196,7 +196,7 @@ showTraceTree dapp vm =
   in pack $ concatMap showTree traces
 
 showTraceTree' :: DappInfo -> Expr End -> Text
-showTraceTree' _ (ITE {}) = error "Internal Error: ITE does not contain a trace"
+showTraceTree' _ (ITE {}) = internalError "ITE does not contain a trace"
 showTraceTree' dapp leaf =
   let forest = traceForest' leaf
       traces = fmap (fmap (unpack . showTrace dapp (traceContext leaf))) forest

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -911,7 +911,7 @@ formatEAddr :: Expr EAddr -> Builder
 formatEAddr = \case
   LitAddr a -> fromString ("litaddr_" <> show a)
   SymAddr a -> fromText ("symaddr_" <> a)
-  GVar _ -> internalError "unexpected GVar"
+  GVar _ -> internalError "Unexpected GVar"
 
 
 -- ** Cex parsing ** --------------------------------------------------------------------------------

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -278,7 +278,7 @@ checkCommand inst cmd = do
   res <- sendCommand inst cmd
   case res of
     "success" -> pure ()
-    _ -> error $ "Internal Error: Unexpected solver output: " <> (T.unpack res)
+    _ -> internalError $ "Unexpected solver output: " <> T.unpack res
 
 -- | Sends a single command to the solver, returns the first available line from the output buffer
 sendCommand :: SolverInstance -> Text -> IO Text


### PR DESCRIPTION
## Description
This gets rid of a lot of `error "internal error: blah"` and replaces it with `internalError "blah"`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
