### PR TITLE
EVM: respect prank address in callChecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `test` now falls back to displaying an unecoded bytestring for calldata when the model returned by the solver has a different length the length of the arguments in the test signature.
 - we now generate correct counterexamples for branches where only a subset of input variables are referenced by the path conditions
 - `vm.prank` now works correctly when passed a symbolic address
+- `vm.prank` now works correctly when the next call transfers value
 
 ## Changed
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1013,14 +1013,9 @@ callChecks this xGas xContext xTo xValue xInOffset xInSize xOutOffset xOutSize x
       availableGas <- use (#state % #gas)
       let recipientExists = accountExists xContext vm
       (cost, gas') <- costOfCall fees recipientExists xValue availableGas xGas xTo
-      burn (cost - gas') $
-        branch (Expr.gt xValue this.balance) $ \case
-          True -> do
-            assign (#state % #stack) (Lit 0 : xs)
-            assign (#state % #returndata) mempty
-            pushTrace $ ErrorTrace (BalanceTooLow xValue this.balance)
-            next
-          False ->
+      let from = fromMaybe vm.state.contract vm.config.overrideCaller
+      fromBal <- preuse $ #env % #contracts % ix from % #balance
+      let checkCallDepth =
             if length vm.frames >= 1024
             then do
               assign (#state % #stack) (Lit 0 : xs)
@@ -1028,6 +1023,40 @@ callChecks this xGas xContext xTo xValue xInOffset xInSize xOutOffset xOutSize x
               pushTrace $ ErrorTrace CallDepthLimitReached
               next
             else continue gas'
+      case (fromBal, xValue) of
+        -- we're not transfering any value, and can skip the balance check
+        (_, Lit 0) -> burn (cost - gas') checkCallDepth
+
+        -- from is in the state, we check if they have enough balance
+        (Just fb, _) -> do
+          burn (cost - gas') $
+            branch (Expr.gt xValue fb) $ \case
+              True -> do
+                assign (#state % #stack) (Lit 0 : xs)
+                assign (#state % #returndata) mempty
+                pushTrace $ ErrorTrace (BalanceTooLow xValue this.balance)
+                next
+              False -> checkCallDepth
+
+        -- from is not in the state, we insert if if safe to do so and run the checks again
+        (Nothing, _) -> case from of
+          LitAddr _ -> do
+            -- insert an entry in the state
+            let contract = case vm.config.baseState of
+                  AbstractBase -> unknownContract from
+                  EmptyBase -> emptyContract
+            (#env % #contracts) %= (Map.insert from contract)
+            -- run callChecks again
+            callChecks this xGas xContext xTo xValue xInOffset xInSize xOutOffset xOutSize xs continue
+
+          -- adding a symbolic address into the state here would be unsound (due to potential aliasing)
+          SymAddr _ -> do
+            pc <- use (#state % #pc)
+            partial $ UnexpectedSymbolicArg pc "Attempting to transfer eth from a symbolic address that is not present in the state" (wrap [from])
+          GVar _ -> internalError "Unexpected GVar"
+
+
+
 
 precompiledContract
   :: (?op :: Word8)

--- a/test/contracts/pass/cheatCodes.sol
+++ b/test/contracts/pass/cheatCodes.sol
@@ -27,6 +27,7 @@ contract Prankster {
 
 contract Payable {
     function hi() public payable {}
+    receive() external payable {}
 }
 
 contract Empty {}
@@ -192,4 +193,22 @@ contract CheatCodes is DSTest {
 
         assertEq(preBal - postBal, amt);
     }
+
+    function prove_prank_val_2() public {
+        address payable a = payable(address(new Payable()));
+        address payable b = payable(address(new Payable()));
+
+        // send this.balance to a
+        a.call{value: address(this).balance}("");
+        uint aBal = a.balance;
+
+        // send 1 wei from a to b
+        hevm.prank(a);
+        address(b).call{value: 1}("");
+
+        // check balances
+        assertEq(a.balance, aBal - 1);
+        assertEq(b.balance, 1);
+    }
+
 }


### PR DESCRIPTION
## Description

Previously we would incorrectly fail here if sending value after calling `vm.prank` since `callChecks` did not take the value of `overrideCaller` into account when checking if the caller had sufficient balance.

There is some duplication of the logic in `transfer` here, but I'm not sure how to handle it better, since I do not want `transfer` to be incomplete, and we can't rely on `transfer` for callcode and delegatecall (which don't actually move any eth).

This fixes #343.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
