### PR TITLE
EVM: fix concrete prefix detection during contract creation

### DIFF
--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -445,7 +445,7 @@ formatExpr = go
   where
     go :: Expr a -> Text
     go x = T.stripEnd $ case x of
-      Lit w -> T.pack $ show w
+      Lit w -> T.pack $ show (into w :: Integer)
       (Var v) -> "(Var " <> T.pack (show v) <> ")"
       (GVar v) -> "(GVar " <> T.pack (show v) <> ")"
       LitByte w -> T.pack $ show w


### PR DESCRIPTION
## Description

This replaces `Expr.concPrefix` with a much simpler routine that:

1. converts the input buffer into a vector of bytes
2. scans through this vector until it finds the first non Lit byte
3. uses this to split the input buf into a concrete and symbolic part

While 1. has non trivial complexity, we were already doing it later anyway (over the concrete part only), so this hopefully doesn't impact perf too much.

There are still a few issues to work out:

- [ ] the routine as described does not support constructor args that have a fully abstract size (i.e. bytes[], string)
- [ ] it breaks some of the existing tests

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
