### PR TITLE
Keccak: update min value assumption to match `readStorage`

### DIFF
--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -51,7 +51,7 @@ combine lst = combine' lst []
       combine' xs (xcomb:acc)
 
 minProp :: Expr EWord -> Prop
-minProp k@(Keccak _) = PGT k (Lit 50)
+minProp k@(Keccak _) = PGT k (Lit 256)
 minProp _ = internalError "expected keccak expression"
 
 injProp :: (Expr EWord, Expr EWord) -> Prop


### PR DESCRIPTION
## Description

Since https://github.com/ethereum/hevm/pull/367 we will strip writes to a concrete slot where the index is < 256. This PR updates the min value assumptions in Keccak.hs to match.

Fixes https://github.com/ethereum/hevm/issues/394\

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
