### PR TITLE
Expr: fix downcast exception in simplify

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -788,8 +788,11 @@ simplify e = if (mapExpr go e == e)
         -- n+sz of ConcreteBuf will be used by CopySlice
         (WriteWord wOff value (ConcreteBuf buf)) dst)
           -- Let's not deal with overflow
-          | n+sz >= n && n+sz >= sz = (CopySlice srcOff dstOff size
-              (WriteWord wOff value (ConcreteBuf simplifiedBuf)) dst)
+          | n+sz >= n
+          , n+sz >= sz
+          , n+sz <= maxBytes
+            = (CopySlice srcOff dstOff size
+                (WriteWord wOff value (ConcreteBuf simplifiedBuf)) dst)
           | otherwise = orig
             where simplifiedBuf = BS.take (unsafeInto (n+sz)) buf
     go (CopySlice a b c d f) = copySlice a b c d f


### PR DESCRIPTION
## Description

We were sometimes hitting a TryFrom exception during fuzzing when simplifying `CopySlice` expressions with large values.

Fixes https://github.com/ethereum/hevm/issues/395

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
