### PR TITLE
Test: don't generate same name for different types

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -3194,7 +3194,7 @@ instance Arbitrary Addr where
 instance Arbitrary (Expr EAddr) where
   arbitrary = oneof
     [ fmap LitAddr arbitrary
-    , fmap SymAddr genName
+    , fmap SymAddr (genName "addr")
     ]
 
 instance Arbitrary (Expr Storage) where
@@ -3442,9 +3442,9 @@ genLit bound = do
 genNat :: Gen Int
 genNat = fmap unsafeInto (arbitrary :: Gen Natural)
 
-genName :: Gen Text
+genName :: String -> Gen Text
 -- In order not to generate SMT reserved words, we prepend with "esc_"
-genName = fmap (T.pack . ("esc_" <> )) $ listOf1 (oneof . (fmap pure) $ ['a'..'z'] <> ['A'..'Z'])
+genName ty = fmap (T.pack . (("esc_" <> ty <> "_") <> )) $ listOf1 (oneof . (fmap pure) $ ['a'..'z'] <> ['A'..'Z'])
 
 genEnd :: Int -> Gen (Expr End)
 genEnd 0 = oneof
@@ -3487,7 +3487,7 @@ genWord litFreq 0 = frequency
       --, liftM2 SelfBalance arbitrary arbitrary
       --, liftM2 Gas arbitrary arbitrary
       , fmap Lit arbitrary
-      , fmap Var genName
+      , fmap Var (genName "word")
       ]
     )
   ]
@@ -3657,7 +3657,7 @@ maybeBoundedLit bound = do
 
 genBuf :: W256 -> Int -> Gen (Expr Buf)
 genBuf _ 0 = oneof
-  [ fmap AbstractBuf genName
+  [ fmap AbstractBuf (genName "buf")
   , fmap ConcreteBuf arbitrary
   ]
 genBuf bound sz = oneof


### PR DESCRIPTION
## Description

We were hitting failures in the prop simplifier fuzz tests due to error messages like the following from the smt solver:

```
Error "error while writing SMT to solver: Solver returned an error:\n(error \"line 86 column 74: ambiguous constant reference, more than one constant with the same sort, use a qualified expression (as <symbol> <sort>) to disambiguate esc_Q\")\nwhile sending the following line: (assert (=> (bvuge (_ bv0 256) (max (_ bv0 256) esc_Q_length)) (= (select esc_Q (_ bv0 256)) (_ bv0 8))))"
```

This was because we could generate the same name for different types (e.g. buffer and word). This changes ensures that we never generate the same name for expressions with different types. We could fix this at the smt layer (as directed by the error message), but I feel like generating this kind of smt during normal execution would be indicative of some deeper problem, so prefer to surface the error if it occurs.

Fixes https://github.com/ethereum/hevm/issues/396

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
