### PR TITLE
Abstract gas v2

### DIFF
--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -382,7 +382,7 @@ launchExec cmd = do
         internalError "no EVM result"
 
 -- | Creates a (concrete) VM from command line options
-vmFromCommand :: Command Options.Unwrapped -> IO (VM RealWorld)
+vmFromCommand :: Gas gas => Command Options.Unwrapped -> IO (VM gas RealWorld)
 vmFromCommand cmd = do
   (miner,ts,baseFee,blockNum,prevRan) <- case cmd.rpc of
     Nothing -> pure (LitAddr 0,Lit 0,0,0,0)
@@ -472,7 +472,7 @@ vmFromCommand cmd = do
         addr f def = maybe def LitAddr (f cmd)
         bytes f def = maybe def decipher (f cmd)
 
-symvmFromCommand :: Command Options.Unwrapped -> (Expr Buf, [Prop]) -> IO (VM RealWorld)
+symvmFromCommand :: Command Options.Unwrapped -> (Expr Buf, [Prop]) -> IO (VM gas RealWorld)
 symvmFromCommand cmd calldata = do
   (miner,blockNum,baseFee,prevRan) <- case cmd.rpc of
     Nothing -> pure (SymAddr "miner",0,0,0)

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -33,7 +33,6 @@ import EVM.Dapp (dappInfo, DappInfo, emptyDapp)
 import EVM.Expr qualified as Expr
 import EVM.Concrete qualified as Concrete
 import GitHash
-import EVM.FeeSchedule (feeSchedule)
 import EVM.Fetch qualified as Fetch
 import EVM.Format (hexByteString, strip0x, showTraceTree, formatExpr)
 import EVM.Solidity
@@ -469,7 +468,6 @@ vmFromCommand cmd = do
           , gasprice       = word (.gasprice) 0
           , maxCodeSize    = word (.maxcodesize) 0xffffffff
           , prevRandao     = word (.prevRandao) prevRan
-          , schedule       = feeSchedule
           , chainId        = word (.chainid) 1
           , create         = (.create) cmd
           , baseState      = EmptyBase
@@ -550,7 +548,6 @@ symvmFromCommand cmd calldata = do
       , gasprice       = word (.gasprice) 0
       , maxCodeSize    = word (.maxcodesize) 0xffffffff
       , prevRandao     = word (.prevRandao) prevRan
-      , schedule       = feeSchedule
       , chainId        = word (.chainid) 1
       , create         = (.create) cmd
       , baseState      = maybe AbstractBase parseInitialStorage (cmd.initialStorage)

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -69,7 +69,7 @@ class Gas gas where
 data SymGas = SymGas
 
 instance Gas SymGas where
-  burn _ _ = pure ()
+  burn _ cont = cont
   returnGas _ = pure ()
   forceGas _ _ = 0
   gasToWord64 _ = 0
@@ -98,7 +98,7 @@ instance Gas Word64 where
   forceGas _ w =
     case maybeLitWord w of
       Just ww -> ww
-      Nothing -> error "expected concrete word"
+      Nothing -> internalError "expected concrete word"
 
   {-# INLINE gasFromWord64 #-}
   gasFromWord64 = id

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -2,7 +2,6 @@ module EVM.Exec where
 
 import EVM hiding (createAddress)
 import EVM.Concrete (createAddress)
-import EVM.FeeSchedule (feeSchedule)
 import EVM.Types
 
 import Control.Monad.Trans.State.Strict (get, State)
@@ -37,7 +36,6 @@ vmForEthrunCreation creationCode =
     , baseFee = 0
     , priorityFee = 0
     , maxCodeSize = 0xffffffff
-    , schedule = feeSchedule
     , chainId = 1
     , create = False
     , txAccessList = mempty

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -15,7 +15,7 @@ import Data.Word (Word64)
 ethrunAddress :: Addr
 ethrunAddress = Addr 0x00a329c0648769a73afac7f9381e08fb43dbea72
 
-vmForEthrunCreation :: Gas gas => ByteString -> ST s (VM gas s)
+vmForEthrunCreation :: ByteString -> ST s (VM Word64 s)
 vmForEthrunCreation creationCode =
   (makeVm $ VMOpts
     { contract = initialContract (InitCode creationCode mempty)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -374,13 +374,13 @@ writeByte offset byte src = WriteByte offset byte src
 
 writeWord :: Expr EWord -> Expr EWord -> Expr Buf -> Expr Buf
 writeWord o@(Lit offset) (WAddr (LitAddr val)) b@(ConcreteBuf _)
-  | offset + 32 < maxBytes
+  | offset < maxBytes
   = writeWord o (Lit $ into val) b
 writeWord (Lit offset) (Lit val) (ConcreteBuf "")
-  | offset + 32 < maxBytes
+  | offset < maxBytes
   = ConcreteBuf $ BS.replicate (unsafeInto offset) 0 <> word256Bytes val
 writeWord o@(Lit offset) v@(Lit val) buf@(ConcreteBuf src)
-  | offset + 32 < maxBytes
+  | offset < maxBytes
     = ConcreteBuf $ (padRight (unsafeInto offset) $ BS.take (unsafeInto offset) src)
                  <> word256Bytes val
                  <> BS.drop ((unsafeInto offset) + 32) src

--- a/src/EVM/FeeSchedule.hs
+++ b/src/EVM/FeeSchedule.hs
@@ -1,108 +1,107 @@
 module EVM.FeeSchedule where
 
-data FeeSchedule n = FeeSchedule
-  { g_zero :: n
-  , g_base :: n
-  , g_verylow :: n
-  , g_low :: n
-  , g_mid :: n
-  , g_high :: n
-  , g_extcode :: n
-  , g_balance :: n
-  , g_sload :: n
-  , g_jumpdest :: n
-  , g_sset :: n
-  , g_sreset :: n
-  , r_sclear :: n
-  , g_selfdestruct :: n
-  , g_selfdestruct_newaccount :: n
-  , r_selfdestruct :: n
-  , g_create :: n
-  , g_codedeposit :: n
-  , g_call :: n
-  , g_callvalue :: n
-  , g_callstipend :: n
-  , g_newaccount :: n
-  , g_exp :: n
-  , g_expbyte :: n
-  , g_memory :: n
-  , g_txcreate :: n
-  , g_txdatazero :: n
-  , g_txdatanonzero :: n
-  , g_transaction :: n
-  , g_log :: n
-  , g_logdata :: n
-  , g_logtopic :: n
-  , g_sha3 :: n
-  , g_sha3word :: n
-  , g_initcodeword :: n
-  , g_copy :: n
-  , g_blockhash :: n
-  , g_extcodehash :: n
-  , g_quaddivisor :: n
-  , g_ecadd :: n
-  , g_ecmul :: n
-  , g_pairing_point :: n
-  , g_pairing_base :: n
-  , g_fround :: n
-  , r_block :: n
-  , g_cold_sload :: n
-  , g_cold_account_access :: n
-  , g_warm_storage_read :: n
-  , g_access_list_address :: n
-  , g_access_list_storage_key :: n
-  } deriving Show
+import Data.Word (Word64)
 
-feeSchedule :: Num n => FeeSchedule n
-feeSchedule = FeeSchedule
-  { g_zero = 0
-  , g_base = 2
-  , g_verylow = 3
-  , g_low = 5
-  , g_mid = 8
-  , g_high = 10
-  , g_extcode = 2600
-  , g_balance = 2600
-  , g_sload = 100
-  , g_jumpdest = 1
-  , g_sset = 20000
-  , g_sreset = 2900
-  , r_sclear = 15000
-  , g_selfdestruct = 5000
-  , g_selfdestruct_newaccount = 25000
-  , r_selfdestruct = 24000
-  , g_create = 32000
-  , g_codedeposit = 200
-  , g_call = 2600
-  , g_callvalue = 9000
-  , g_callstipend = 2300
-  , g_newaccount = 25000
-  , g_exp = 10
-  , g_expbyte = 50
-  , g_memory = 3
-  , g_txcreate = 32000
-  , g_txdatazero = 4
-  , g_txdatanonzero = 16
-  , g_transaction = 21000
-  , g_log = 375
-  , g_logdata = 8
-  , g_logtopic = 375
-  , g_sha3 = 30
-  , g_sha3word = 6
-  , g_initcodeword = 2
-  , g_copy = 3
-  , g_blockhash = 20
-  , g_extcodehash = 2600
-  , g_quaddivisor = 20
-  , g_ecadd = 150
-  , g_ecmul = 6000
-  , g_pairing_point = 34000
-  , g_pairing_base = 45000
-  , g_fround = 1
-  , r_block = 2000000000000000000
-  , g_cold_sload = 2100
-  , g_cold_account_access = 2600
-  , g_warm_storage_read = 100
-  , g_access_list_address = 2400
-  , g_access_list_storage_key = 1900
-  }
+class FeeSchedule n where
+  g_zero :: n
+  g_base :: n
+  g_verylow :: n
+  g_low :: n
+  g_mid :: n
+  g_high :: n
+  g_extcode :: n
+  g_balance :: n
+  g_sload :: n
+  g_jumpdest :: n
+  g_sset :: n
+  g_sreset :: n
+  r_sclear :: n
+  g_selfdestruct :: n
+  g_selfdestruct_newaccount :: n
+  r_selfdestruct :: n
+  g_create :: n
+  g_codedeposit :: n
+  g_call :: n
+  g_callvalue :: n
+  g_callstipend :: n
+  g_newaccount :: n
+  g_exp :: n
+  g_expbyte :: n
+  g_memory :: n
+  g_txcreate :: n
+  g_txdatazero :: n
+  g_txdatanonzero :: n
+  g_transaction :: n
+  g_log :: n
+  g_logdata :: n
+  g_logtopic :: n
+  g_sha3 :: n
+  g_sha3word :: n
+  g_initcodeword :: n
+  g_copy :: n
+  g_blockhash :: n
+  g_extcodehash :: n
+  g_quaddivisor :: n
+  g_ecadd :: n
+  g_ecmul :: n
+  g_pairing_point :: n
+  g_pairing_base :: n
+  g_fround :: n
+  r_block :: n
+  g_cold_sload :: n
+  g_cold_account_access :: n
+  g_warm_storage_read :: n
+  g_access_list_address :: n
+  g_access_list_storage_key :: n
+
+instance FeeSchedule Word64 where
+  g_zero = 0
+  g_base = 2
+  g_verylow = 3
+  g_low = 5
+  g_mid = 8
+  g_high = 10
+  g_extcode = 2600
+  g_balance = 2600
+  g_sload = 100
+  g_jumpdest = 1
+  g_sset = 20000
+  g_sreset = 2900
+  r_sclear = 15000
+  g_selfdestruct = 5000
+  g_selfdestruct_newaccount = 25000
+  r_selfdestruct = 24000
+  g_create = 32000
+  g_codedeposit = 200
+  g_call = 2600
+  g_callvalue = 9000
+  g_callstipend = 2300
+  g_newaccount = 25000
+  g_exp = 10
+  g_expbyte = 50
+  g_memory = 3
+  g_txcreate = 32000
+  g_txdatazero = 4
+  g_txdatanonzero = 16
+  g_transaction = 21000
+  g_log = 375
+  g_logdata = 8
+  g_logtopic = 375
+  g_sha3 = 30
+  g_sha3word = 6
+  g_initcodeword = 2
+  g_copy = 3
+  g_blockhash = 20
+  g_extcodehash = 2600
+  g_quaddivisor = 20
+  g_ecadd = 150
+  g_ecmul = 6000
+  g_pairing_point = 34000
+  g_pairing_base = 45000
+  g_fround = 1
+  r_block = 2000000000000000000
+  g_cold_sload = 2100
+  g_cold_account_access = 2600
+  g_warm_storage_read = 100
+  g_access_list_address = 2400
+  g_access_list_storage_key = 1900

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -182,18 +182,18 @@ fetchChainIdFrom url = do
   sess <- Session.newAPISession
   fetchQuery Latest (fetchWithSession url sess) QueryChainId
 
-http :: Natural -> Maybe Natural -> BlockNumber -> Text -> Fetcher s
+http :: Natural -> Maybe Natural -> BlockNumber -> Text -> Fetcher gas s
 http smtjobs smttimeout n url q =
   withSolvers Z3 smtjobs smttimeout $ \s ->
     oracle s (Just (n, url)) q
 
-zero :: Natural -> Maybe Natural -> Fetcher s
+zero :: Natural -> Maybe Natural -> Fetcher gas s
 zero smtjobs smttimeout q =
   withSolvers Z3 smtjobs smttimeout $ \s ->
     oracle s Nothing q
 
 -- smtsolving + (http or zero)
-oracle :: SolverGroup -> RpcInfo -> Fetcher s
+oracle :: SolverGroup -> RpcInfo -> Fetcher gas s
 oracle solvers info q = do
   case q of
     PleaseDoFFI vals continue -> case vals of
@@ -229,7 +229,7 @@ oracle solvers info q = do
            Nothing ->
              internalError $ "oracle error: " ++ show q
 
-type Fetcher s = Query s -> IO (EVM s ())
+type Fetcher gas s = Query gas s -> IO (EVM gas s ())
 
 -- | Checks which branches are satisfiable, checking the pathconditions for consistency
 -- if the third argument is true.

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -437,6 +437,7 @@ formatPartial = \case
     ]
   MaxIterationsReached pc addr -> "Max Iterations Reached in contract: " <> formatAddr addr <> " pc: " <> pack (show pc)
   JumpIntoSymbolicCode pc idx -> "Encountered a jump into a potentially symbolic code region while executing initcode. pc: " <> pack (show pc) <> " jump dst: " <> pack (show idx)
+  SymbolicGasIntrospection pc -> "Encountered an attempt to introspect on the value of symbolic gas at pc " <> pack (show pc)
 
 formatSomeExpr :: SomeExpr -> Text
 formatSomeExpr (SomeExpr e) = formatExpr e

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -187,7 +187,7 @@ formatSBinary (ConcreteBuf bs) = formatBinary bs
 formatSBinary (AbstractBuf t) = "<" <> t <> " abstract buf>"
 formatSBinary _ = internalError "formatSBinary: implement me"
 
-showTraceTree :: DappInfo -> VM s -> Text
+showTraceTree :: DappInfo -> VM gas s -> Text
 showTraceTree dapp vm =
   let forest = traceForest vm
       traces = fmap (fmap (unpack . showTrace dapp (vm.env.contracts))) forest

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -296,7 +296,7 @@ referencedFrameContext expr = nubOrd $ foldTerm go [] expr
     go = \case
       TxValue -> [(fromString "txvalue", [])]
       v@(Balance a) -> [(fromString "balance_" <> formatEAddr a, [PLT v (Lit $ 2 ^ (96 :: Int))])]
-      Gas {} -> internalError "TODO: GAS"
+      v@(Gas n) -> [(fromString "gas_" <> fromString (show n), [PLT v (Lit $ 2 ^ (64 :: Int))])]
       _ -> []
 
 referencedBlockContext :: TraversableTerm a => a -> [(Builder, [Prop])]
@@ -738,6 +738,7 @@ exprToSMT = \case
     let enc = exprToSMT a in
     "(sha256 " <> enc <> ")"
 
+  Gas n -> fromString $ "gas_" <> show n
   TxValue -> fromString "txvalue"
   Balance a -> fromString "balance_" <> formatEAddr a
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -546,10 +546,11 @@ getPartials = mapMaybe go
 -- | Symbolically execute the VM and check all endstates against the
 -- postcondition, if available.
 verify
-  :: SolverGroup
+  :: EVM.Gas gas
+  => SolverGroup
   -> VeriOpts
-  -> VM SymGas RealWorld
-  -> Maybe (Postcondition SymGas RealWorld)
+  -> VM gas RealWorld
+  -> Maybe (Postcondition gas RealWorld)
   -> IO (Expr End, [VerifyResult])
 verify solvers opts preState maybepost = do
   putStrLn "Exploring contract"

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -42,7 +42,6 @@ import EVM.Stepper (Stepper)
 import EVM.Stepper qualified as Stepper
 import EVM.Traversals
 import EVM.Types
-import EVM.FeeSchedule (feeSchedule)
 import EVM.Format (indent, formatBinary)
 import GHC.Conc (getNumProcessors)
 import GHC.Generics (Generic)
@@ -232,7 +231,6 @@ loadSymVM x callvalue cd create =
     , baseFee = 0
     , priorityFee = 0
     , maxCodeSize = 0xffffffff
-    , schedule = feeSchedule
     , chainId = 1
     , create = create
     , txAccessList = mempty

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -29,6 +29,7 @@ import Data.Text.Lazy.IO qualified as TL
 import Data.Tree.Zipper qualified as Zipper
 import Data.Tuple (swap)
 import EVM (makeVm, abstractContract, initialContract, getCodeLocation, isValidJumpDest, SymGas)
+import EVM qualified
 import EVM.Exec
 import EVM.Fetch qualified as Fetch
 import EVM.ABI
@@ -241,18 +242,20 @@ loadSymVM x callvalue cd create =
 -- | Interpreter which explores all paths at branching points. Returns an
 -- 'Expr End' representing the possible executions.
 interpret
-  :: Fetch.Fetcher SymGas RealWorld
+  :: forall gas
+   . EVM.Gas gas
+  => Fetch.Fetcher gas RealWorld
   -> Maybe Integer -- max iterations
   -> Integer -- ask smt iterations
   -> LoopHeuristic
-  -> VM SymGas RealWorld
-  -> Stepper SymGas RealWorld (Expr End)
+  -> VM gas RealWorld
+  -> Stepper gas RealWorld (Expr End)
   -> IO (Expr End)
 interpret fetcher maxIter askSmtIters heuristic vm =
   eval . Operational.view
   where
   eval
-    :: Operational.ProgramView (Stepper.Action SymGas RealWorld) (Expr End)
+    :: Operational.ProgramView (Stepper.Action gas RealWorld) (Expr End)
     -> IO (Expr End)
 
   eval (Operational.Return x) = pure x

--- a/src/EVM/Transaction.hs
+++ b/src/EVM/Transaction.hs
@@ -246,7 +246,7 @@ setupTx origin coinbase gasPrice gasLimit prestate =
 -- | Given a valid tx loaded into the vm state,
 -- subtract gas payment from the origin, increment the nonce
 -- and pay receiving address
-initTx :: VM s -> VM s
+initTx :: VM gas s -> VM gas s
 initTx vm = let
     toAddr   = vm.state.contract
     origin   = vm.tx.origin

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -164,7 +164,7 @@ foldExpr f acc expr = acc <> (go expr)
 
       -- frame context
 
-      e@(Gas _ _) -> f e
+      e@(Gas _) -> f e
       e@(Balance {}) -> f e
 
       -- code
@@ -487,7 +487,7 @@ mapExprM f expr = case expr of
 
   -- frame context
 
-  Gas a b -> f (Gas a b)
+  Gas a -> f (Gas a)
   Balance a -> do
     a' <- mapExprM f a
     f (Balance a')

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -282,9 +282,7 @@ data Expr (a :: EType) where
 
   Balance        :: Expr EAddr -> Expr EWord
 
-  Gas            :: Int                -- frame idx
-                 -> Int                -- PC
-                 -> Expr EWord
+  Gas            :: Int -> Expr EWord
 
   -- code
 
@@ -718,6 +716,7 @@ data Env = Env
   { contracts      :: Map (Expr EAddr) Contract
   , chainId        :: W256
   , freshAddresses :: Int
+  , freshGasVals   :: Int
   }
   deriving (Show, Generic)
 

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -11,7 +11,6 @@ import EVM.Dapp
 import EVM.Exec
 import EVM.Expr (readStorage', simplify)
 import EVM.Expr qualified as Expr
-import EVM.FeeSchedule (feeSchedule)
 import EVM.Fetch qualified as Fetch
 import EVM.Format
 import EVM.Solidity
@@ -462,7 +461,6 @@ initialUnitTestVm (UnitTestOptions {..}) theContract = do
            , priorityFee = testParams.priorityFee
            , maxCodeSize = testParams.maxCodeSize
            , prevRandao = testParams.prevrandao
-           , schedule = feeSchedule
            , chainId = testParams.chainId
            , create = True
            , baseState = EmptyBase

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -221,7 +221,7 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
                                    Partial _ _ _ -> PBool True
                                    _ -> internalError "Invalid leaf node"
 
-    vm' <- undefined <$> Stepper.interpret (Fetch.oracle solvers rpcInfo) vm $
+    vm' <- Stepper.interpret (Fetch.oracle solvers rpcInfo) vm $
       Stepper.evm $ do
         pushTrace (EntryTrace testName)
         makeTxCall testParams cd

--- a/test/EVM/Test/BlockchainTests.hs
+++ b/test/EVM/Test/BlockchainTests.hs
@@ -168,7 +168,7 @@ fromConcrete :: Expr Storage -> Map W256 W256
 fromConcrete (ConcreteStore s) = s
 fromConcrete s = internalError $ "unexpected abstract store: " <> show s
 
-checkStateFail :: Bool -> Case -> VM RealWorld -> (Bool, Bool, Bool, Bool) -> IO String
+checkStateFail :: Bool -> Case -> VM Word64 RealWorld -> (Bool, Bool, Bool, Bool) -> IO String
 checkStateFail diff x vm (okMoney, okNonce, okData, okCode) = do
   let
     printContracts :: Map Addr Contract -> IO ()
@@ -200,7 +200,7 @@ checkStateFail diff x vm (okMoney, okNonce, okData, okCode) = do
     printContracts actual
   pure (unwords reason)
 
-checkExpectation :: Bool -> Case -> VM RealWorld -> IO (Maybe String)
+checkExpectation :: Bool -> Case -> VM Word64 RealWorld -> IO (Maybe String)
 checkExpectation diff x vm = do
   let expectation = x.testExpectation
       (okState, b2, b3, b4, b5) = checkExpectedContracts vm expectation
@@ -227,7 +227,7 @@ c1 === c2 =
       (RuntimeCode a', RuntimeCode b') -> a' == b'
       _ -> internalError "unexpected code"
 
-checkExpectedContracts :: VM RealWorld -> Map Addr Contract -> (Bool, Bool, Bool, Bool, Bool)
+checkExpectedContracts :: VM Word64 RealWorld -> Map Addr Contract -> (Bool, Bool, Bool, Bool, Bool)
 checkExpectedContracts vm expected =
   let cs = fmap (clearZeroStorage . clearOrigStorage) $ forceConcreteAddrs vm.env.contracts
   in ( (expected ~= cs)
@@ -453,7 +453,7 @@ checkTx tx block prestate = do
   else
     pure prestate
 
-vmForCase :: Case -> IO (VM RealWorld)
+vmForCase :: Case -> IO (VM Word64 RealWorld)
 vmForCase x = do
   vm <- stToIO $ makeVm x.vmOpts
     <&> set (#env % #contracts) (Map.mapKeys LitAddr x.checkContracts)

--- a/test/EVM/Test/BlockchainTests.hs
+++ b/test/EVM/Test/BlockchainTests.hs
@@ -2,7 +2,6 @@ module EVM.Test.BlockchainTests where
 
 import EVM (initialContract, makeVm)
 import EVM.Concrete qualified as EVM
-import EVM.FeeSchedule (feeSchedule)
 import EVM.Fetch qualified
 import EVM.Format (hexText)
 import EVM.Stepper qualified
@@ -370,7 +369,7 @@ fromBlockchainCase' block tx preState postState =
          , caller         = LitAddr origin
          , baseState      = EmptyBase
          , origin         = LitAddr origin
-         , gas            = tx.gasLimit - txGasCost feeSchedule tx
+         , gas            = tx.gasLimit - txGasCost tx
          , baseFee        = block.baseFee
          , priorityFee    = priorityFee tx block.baseFee
          , gaslimit       = tx.gasLimit
@@ -381,7 +380,6 @@ fromBlockchainCase' block tx preState postState =
          , maxCodeSize    = maxCodeSize
          , blockGaslimit  = block.gasLimit
          , gasprice       = effectiveGasPrice
-         , schedule       = feeSchedule
          , chainId        = 1
          , create         = isCreate
          , txAccessList   = Map.mapKeys LitAddr (txAccessMap tx)


### PR DESCRIPTION
## Description

This is a second attempt at implementing a partially abstract gas model, based on top of some experiments from @arcz. Instead of modelling gas as a `Maybe Word64` (as in https://github.com/ethereum/hevm/pull/352), here we add a `gas` parameter to the `VM` type and constrain it to be an instance of the `Gas` typeclass.

Two instances of this class are provided:

1. `Word64`: this exactly matches the previous concrete gas semantics
2. `SymGas`: this is a single constructor type and simply acts as a marker that we should ignore all gas accounting

This (combined with a bunch of specilialise and inline pragmas) should keep the overhead for concrete execution relatively low. There are still four failing ethereum tests that need to be fixed before I can confirm this hypothesis for sure, but initial tests by @arcz on an earlier commit seemed promising.

Compared to https://github.com/ethereum/hevm/pull/352 this is maybe not quite as clean (our type parameters continue to proliferate), and it does allow more invalid vm states (e.g. as implemented here the combination of concrete gas with symbolic VM state will output garbage numbers for gas), but it's probably worth it if it minimizes the impact to concrete perf.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
