### PR TITLE
Simplifying BufLength via bufLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run a toplevel constant folding reasoning system on branch conditions
 - `evalProp` is renamed to `simplifyProp` for consistency
 - Mem explosion in `writeWord` function was possible in case `offset` was close to 2^256. Fixed.
+- BufLength was not simplified via bufLength function. Fixed.
 
 ## API Changes
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -788,6 +788,7 @@ simplify e = if (mapExpr go e == e)
     go (ReadWord idx buf) = readWord idx buf
     go o@(ReadByte (Lit _) _) = simplifyReads o
     go (ReadByte idx buf) = readByte idx buf
+    go (BufLength buf) = bufLength buf
 
     -- We can zero out any bytes in a base ConcreteBuf that we know will be overwritten by a later write
     -- TODO: make this fully general for entire write chains, not just a single write.

--- a/test/test.hs
+++ b/test/test.hs
@@ -282,7 +282,12 @@ tests = testGroup "hevm"
     ]
   , testGroup "SimplifierUnitTests"
     -- common overflow cases that the simplifier was getting wrong
-    [ testCase "writeWord-overflow" $ do
+    [ testCase "bufLength-simp" $ do
+      let
+        a = BufLength (ConcreteBuf "ab")
+        simp = Expr.simplify a
+      assertEqual "Must be simplified down to a Lit" simp (Lit 2)
+    , testCase "writeWord-overflow" $ do
         let e = ReadByte (Lit 0x0) (WriteWord (Lit 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd) (Lit 0x0) (ConcreteBuf "\255\255\255\255"))
         b <- checkEquiv e (Expr.simplify e)
         assertBool "Simplifier failed" b


### PR DESCRIPTION
## Description
We accidentally removed(?) or never added(?) the `bufLength` call to simplify `BufLength`. Discovered this while writing a concrete fuzzer of Expr. This is a pretty funny one I think! :D Added a unit test to make sure we catch this next time!

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
