### PR TITLE
Move Windows build to GHC 9.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: UCRT64
+          msystem: CLANG64
           path-type: inherit
           update: true
           install: >-
@@ -75,7 +75,8 @@ jobs:
           pacboy: >-
             cmake:p
             ninja:p
-            gcc:p
+            clang:p
+            lld:p
             autotools:p
             gmp:p
             openssl:p
@@ -122,7 +123,8 @@ jobs:
 
       - name: build hevm library
         run: |
-          cabal build --extra-include-dirs="$HOME/.local/include" --extra-lib-dirs="$HOME/.local/lib"
+          cabal build --extra-include-dirs="$HOME/.local/include" --extra-lib-dirs="$HOME/.local/lib" \
+                      --extra-include-dirs="D:/a/_temp/msys64/clang64/include" --extra-lib-dirs="D:/a/_temp/msys64/clang64/lib"
 
   cabal-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,10 +79,10 @@ jobs:
             autotools:p
             gmp:p
             openssl:p
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup
         with:
-          ghc-version: '9.2.8'
+          ghc-version: '9.4.7'
 
       - name: build and install c dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: CLANG64
-          path-type: inherit
+          path-type: minimal
           update: true
           install: >-
             base-devel
@@ -85,6 +85,14 @@ jobs:
         with:
           ghc-version: '9.4.7'
 
+      - name: Extract GHC & Cabal paths
+        run: |
+          HASKELL_PATHS="$(cygpath -u "$GHC_PATH"):$(cygpath -u "$CABAL_PATH")"
+          echo "HASKELL_PATHS=$HASKELL_PATHS" >> "$GITHUB_ENV"
+        env:
+          GHC_PATH: ${{ steps.setup.outputs.ghc-path }}
+          CABAL_PATH: ${{ steps.setup.outputs.cabal-path }}
+
       - name: build and install c dependencies
         run: |
           echo "::group::Installing libsecp256k1"
@@ -95,6 +103,7 @@ jobs:
           echo "::endgroup::"
       - name: Configure the build
         run: |
+          export PATH="$HASKELL_PATHS:$PATH"
           cabal configure --disable-tests --disable-benchmarks --disable-documentation
           cabal build --dry-run
           # The last step generates dist-newstyle/cache/plan.json for the cache key.
@@ -110,7 +119,9 @@ jobs:
           restore-keys: ${{ env.key }}-
 
       - name: Install haskell dependencies
-        run: cabal build all --only-dependencies
+        run: |
+          export PATH="$HASKELL_PATHS:$PATH"
+          cabal build all --only-dependencies
 
       # Cache dependencies already, so that we do not have to rebuild them should the subsequent steps fail.
       - name: Save cached dependencies
@@ -123,6 +134,7 @@ jobs:
 
       - name: build hevm library
         run: |
+          export PATH="$HASKELL_PATHS:$PATH"
           cabal build --extra-include-dirs="$HOME/.local/include" --extra-lib-dirs="$HOME/.local/lib" \
                       --extra-include-dirs="D:/a/_temp/msys64/clang64/include" --extra-lib-dirs="D:/a/_temp/msys64/clang64/lib"
 

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,8 @@
           grep = "${pkgs.gnugrep}/bin/grep";
           otool = "${pkgs.darwin.binutils.bintools}/bin/otool";
           install_name_tool = "${pkgs.darwin.binutils.bintools}/bin/install_name_tool";
+          codesign_allocate = "${pkgs.darwin.binutils.bintools}/bin/codesign_allocate";
+          codesign = "${pkgs.darwin.sigtool}/bin/codesign";
         in if pkgs.stdenv.isLinux
         then pkgs.haskell.lib.dontCheck hevmUnwrapped
         else pkgs.runCommand "stripNixRefs" {} ''
@@ -151,6 +153,7 @@
           chmod 777 $out/bin/hevm
           ${install_name_tool} -change "$cxx" /usr/lib/libc++.1.dylib $out/bin/hevm
           ${install_name_tool} -change "$iconv" /usr/lib/libiconv.dylib $out/bin/hevm
+          CODESIGN_ALLOCATE=${codesign_allocate} ${codesign} -f -s - $out/bin/hevm
           chmod 555 $out/bin/hevm
         '';
 

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -58,6 +58,7 @@ common shared
     -Wno-unticked-promoted-constructors
     -Wno-orphans
     -Wno-ambiguous-fields
+    -optc-Wno-ignored-attributes
   default-language: GHC2021
   default-extensions:
     DuplicateRecordFields

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -110,7 +110,7 @@ library
   elif !os(darwin)
     extra-libraries: stdc++
   else
-    extra-libraries: c++
+    -- extra-libraries: c++
     -- https://gitlab.haskell.org/ghc/ghc/-/issues/11829
     ld-options: -Wl,-keep_dwarf_unwind
     ghc-options: -fcompact-unwind
@@ -228,6 +228,8 @@ executable hevm
     optics-core,
     githash                       >= 0.1.6 && < 0.2,
     witch
+  if os(darwin)
+    extra-libraries: c++
   if os(windows)
     buildable: False
 
@@ -237,8 +239,6 @@ common test-base
   import: shared
   hs-source-dirs:
     test
-  extra-libraries:
-    secp256k1
   other-modules:
     Paths_hevm
   autogen-modules:
@@ -303,6 +303,8 @@ common test-common
     EVM.Test.Utils
     EVM.Test.Tracing
     EVM.Test.BlockchainTests
+  if os(darwin)
+    extra-libraries: c++
   if os(windows)
     buildable: False
 
@@ -363,3 +365,5 @@ benchmark bench
     filepath,
     containers,
     mtl
+  if os(darwin)
+    extra-libraries: c++

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -195,6 +195,8 @@ executable hevm
   ghc-options: -threaded -with-rtsopts=-N
   other-modules:
     Paths_hevm
+  if os(darwin)
+    extra-libraries: c++
   build-depends:
     QuickCheck,
     aeson,
@@ -229,8 +231,6 @@ executable hevm
     optics-core,
     githash                       >= 0.1.6 && < 0.2,
     witch
-  if os(darwin)
-    extra-libraries: c++
   if os(windows)
     buildable: False
 
@@ -304,10 +304,10 @@ common test-common
     EVM.Test.Utils
     EVM.Test.Tracing
     EVM.Test.BlockchainTests
-  if os(darwin)
-    extra-libraries: c++
   if os(windows)
     buildable: False
+  if os(darwin)
+    extra-libraries: c++
 
 --- Test Suites ---
 
@@ -349,6 +349,8 @@ benchmark bench
     bench
   ghc-options:
     -O2
+  if os(darwin)
+    extra-libraries: c++
   other-modules:
     Paths_hevm
   autogen-modules:
@@ -366,5 +368,3 @@ benchmark bench
     filepath,
     containers,
     mtl
-  if os(darwin)
-    extra-libraries: c++

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -103,8 +103,17 @@ library
     Paths_hevm
   autogen-modules:
     Paths_hevm
-  if os(linux) || os(windows)
+  if impl(ghc >= 9.4) && !os(darwin)
+    -- darwin is skipped because it produces this error when building
+    -- > ghc: loadArchive: Neither an archive, nor a fat archive: `/nix/store/l3lkdfm7sg1wwc850451cikqds766h15-clang-wrapper-11.1.0/bin/clang++'
+    build-depends: system-cxx-std-lib
+  elif !os(darwin)
     extra-libraries: stdc++
+  else
+    extra-libraries: c++
+    -- https://gitlab.haskell.org/ghc/ghc/-/issues/11829
+    ld-options: -Wl,-keep_dwarf_unwind
+    ghc-options: -fcompact-unwind
   extra-libraries:
     secp256k1, ff, gmp
   c-sources:
@@ -185,12 +194,6 @@ executable hevm
   ghc-options: -threaded -with-rtsopts=-N
   other-modules:
     Paths_hevm
-  if os(darwin)
-    extra-libraries: c++
-    ld-options: -Wl,-keep_dwarf_unwind
-    ghc-options: -fcompact-unwind
-  else
-    extra-libraries: stdc++
   build-depends:
     QuickCheck,
     aeson,
@@ -302,13 +305,6 @@ common test-common
     EVM.Test.BlockchainTests
   if os(windows)
     buildable: False
-  if os(darwin)
-    extra-libraries: c++
-    -- https://gitlab.haskell.org/ghc/ghc/-/issues/11829
-    ld-options: -Wl,-keep_dwarf_unwind
-    ghc-options: -fcompact-unwind
-  else
-    extra-libraries: stdc++
 
 --- Test Suites ---
 
@@ -350,10 +346,6 @@ benchmark bench
     bench
   ghc-options:
     -O2
-  if os(darwin)
-     extra-libraries: c++
-  else
-     extra-libraries: stdc++
   other-modules:
     Paths_hevm
   autogen-modules:


### PR DESCRIPTION
## Description

This PR introduces several changes to the Windows CI in order to build with GHC 9.4

GHC 9.4 currently breaks on Windows because it now uses a Clang-based toolchain and the C++ standard library name does no longer match:

  * https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4#windows-uses-a-clang-based-toolchain
  * https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4#link-against-system-cxx-std-lib-instead-of-stdc

Additionally, GHC 9.4 now requires the CLANG64 environment in MSYS2 for native code linking:

  * https://gitlab.haskell.org/ghc/ghc/-/issues/22561

GHC 9.4 introduces a generic way of linking against the system C++ standard library, `build-depends: system-cxx-std-lib`:

  * https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4#link-against-system-cxx-std-lib-instead-of-stdc

This can be used to reliably link against the system's C++ standard library implementation without having to use platform-dependent conditionals. Unfortunately it does not properly work on Nix, so we link manually on Darwin to work around the issue:

  * https://gitlab.haskell.org/ghc/ghc/-/issues/23138

The GitHub runner also has many things preinstalled that tend to cause conflicts during building. This PR switches it to use the minimal MSYS2 path option and adds-in the Haskell tools we need instead.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
