### PR TITLE
Fuzzing Expr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prop is now correctly ordered, better BufLength and Max simplifications of Expr,
   and further solc-specific simplifications of Expr
 - Simplify earlier and don't check reachability for things statically determined to be FALSE
+- New concrete fuzzer that can be controlled via `--num-cex-fuzz`
 
 ## [0.52.0] - 2023-10-26
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -90,6 +90,7 @@ data Command w
       , trace         :: w ::: Bool               <?> "Dump trace"
       , assertions    :: w ::: Maybe [Word256]    <?> "Comma separated list of solc panic codes to check for (default: user defined assertion violations only)"
       , askSmtIterations :: w ::: Integer         <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
+      , numCexFuzz    :: w ::: Integer            <!> "3" <?> "Number of fuzzing tries to do to generate a counterexample (default: 3)"
       , numSolvers    :: w ::: Maybe Natural      <?> "Number of solver instances to use (default: number of cpu cores)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
@@ -109,6 +110,7 @@ data Command w
       , debug         :: w ::: Bool             <?> "Debug printing of internal behaviour"
       , trace         :: w ::: Bool             <?> "Dump trace"
       , askSmtIterations :: w ::: Integer       <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
+      , numCexFuzz    :: w ::: Integer          <!> "3" <?> "Number of fuzzing tries to do to generate a counterexample (default: 3)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
@@ -158,6 +160,7 @@ data Command w
       , loopDetectionHeuristic :: w ::: LoopHeuristic   <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
+      , numCexFuzz    :: w ::: Integer                  <!> "3" <?> "Number of fuzzing tries to do to generate a counterexample (default: 3)"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       }
   | Version
@@ -197,6 +200,7 @@ main = do
   let env = Env { config = defaultConfig
     { dumpQueries = cmd.smtdebug
     , debug = cmd.debug
+    , numCexFuzz = cmd.numCexFuzz
     , abstRefineMem = cmd.abstractMemory
     , abstRefineArith = cmd.abstractArithmetic
     , dumpTrace = cmd.trace

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -83,6 +83,7 @@ library
     EVM.Expr,
     EVM.SMT,
     EVM.Solvers,
+    EVM.Fuzz,
     EVM.Exec,
     EVM.Format,
     EVM.Fetch,
@@ -180,7 +181,8 @@ library
     spawn                             >= 0.3 && < 0.4,
     filepattern                       >= 0.1.2 && < 0.2,
     witch                             >= 1.1 && < 1.3,
-    unliftio-core                     >= 0.2.1.0
+    unliftio-core                     >= 0.2.1.0,
+    MonadRandom                       >= 0.5.1,
   if !os(windows)
     build-depends:
       brick                           >= 1.4 && < 2.0,

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -181,8 +181,7 @@ library
     spawn                             >= 0.3 && < 0.4,
     filepattern                       >= 0.1.2 && < 0.2,
     witch                             >= 1.1 && < 1.3,
-    unliftio-core                     >= 0.2.1.0,
-    MonadRandom                       >= 0.5.1,
+    unliftio-core                     >= 0.2.1.0
   if !os(windows)
     build-depends:
       brick                           >= 1.4 && < 2.0,

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -55,6 +55,10 @@ data Config = Config
   , abstRefineMem   :: Bool
   , dumpTrace       :: Bool
   , numCexFuzz      :: Integer
+   -- Used to debug fuzzer in test.hs. It disables the SMT solver
+   -- and uses the fuzzer ONLY to try to find a counterexample.
+   -- Returns Unknown if the Cex cannot be found via fuzzing
+  , onlyCexFuzz     :: Bool
   }
   deriving (Show, Eq)
 
@@ -67,7 +71,8 @@ defaultConfig = Config
   , abstRefineArith = False
   , abstRefineMem   = False
   , dumpTrace = False
-  , numCexFuzz = 100
+  , numCexFuzz = 10
+  , onlyCexFuzz  = False
   }
 
 -- Write to the console

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -54,6 +54,7 @@ data Config = Config
   , abstRefineArith :: Bool
   , abstRefineMem   :: Bool
   , dumpTrace       :: Bool
+  , numCexFuzz      :: Integer
   }
   deriving (Show, Eq)
 
@@ -66,6 +67,7 @@ defaultConfig = Config
   , abstRefineArith = False
   , abstRefineMem   = False
   , dumpTrace = False
+  , numCexFuzz = 30
   }
 
 -- Write to the console

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -67,7 +67,7 @@ defaultConfig = Config
   , abstRefineArith = False
   , abstRefineMem   = False
   , dumpTrace = False
-  , numCexFuzz = 30
+  , numCexFuzz = 100
   }
 
 -- Write to the console

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -836,6 +836,8 @@ simplify e = if (mapExpr go e == e)
     go (EVM.Types.GEq a b) = leq b a
     go (EVM.Types.LEq a b) = EVM.Types.IsZero (gt a b)
     go (IsZero a) = iszero a
+    go (SLT a@(Lit _) b@(Lit _)) = slt a b
+    go (SGT a b) = SLT b a
 
     -- syntactic Eq reduction
     go (Eq (Lit a) (Lit b))

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -792,7 +792,7 @@ simplify e = if (mapExpr go e == e)
     go (ReadWord idx buf) = readWord idx buf
     go o@(ReadByte (Lit _) _) = simplifyReads o
     go (ReadByte idx buf) = readByte idx buf
-    go (BufLength a) = bufLength a
+    go (BufLength buf) = bufLength buf
 
     -- We can zero out any bytes in a base ConcreteBuf that we know will be overwritten by a later write
     -- TODO: make this fully general for entire write chains, not just a single write.

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -792,7 +792,7 @@ simplify e = if (mapExpr go e == e)
     go (ReadWord idx buf) = readWord idx buf
     go o@(ReadByte (Lit _) _) = simplifyReads o
     go (ReadByte idx buf) = readByte idx buf
-    go (BufLength buf) = bufLength buf
+    go (BufLength a) = bufLength a
 
     -- We can zero out any bytes in a base ConcreteBuf that we know will be overwritten by a later write
     -- TODO: make this fully general for entire write chains, not just a single write.

--- a/src/EVM/Fuzz.hs
+++ b/src/EVM/Fuzz.hs
@@ -13,24 +13,25 @@ import Data.Maybe (fromMaybe)
 import Data.Map.Strict as Map (fromList, Map, (!), (!?), insert)
 import EVM.Expr qualified as Expr
 import EVM.Expr (bytesToW256)
-import Data.Set as Set (insert, Set, empty, toList)
+import Data.Set as Set (insert, Set, empty, toList, fromList)
 import EVM.Traversals
 import Data.ByteString qualified as BS
 import Data.Word (Word8)
-import Control.Monad.Random.Strict qualified as CMR
+import Test.QuickCheck.Gen
 
 import EVM.Types (Prop(..), W256, Expr(..), EType(..), internalError, keccak')
 import EVM.SMT (BufModel(..), SMTCex(..))
-import Debug.Trace
+import Test.QuickCheck (Arbitrary(arbitrary))
+import Test.QuickCheck.Random (mkQCGen)
 
 -- TODO: Extract Var X = Lit Z, and set it
-tryCexFuzz :: [Prop] -> Integer -> Maybe (SMTCex)
-tryCexFuzz ps tries = CMR.evalRand (testVals tries) (CMR.mkStdGen 1337)
+tryCexFuzz :: [Prop] -> Integer -> (Maybe (SMTCex))
+tryCexFuzz ps tries = unGen (testVals tries) (mkQCGen 0) 1337
   where
     vars = extractVars ps
     bufs = extractBufs ps
     stores = extractStorage ps
-    testVals :: CMR.MonadRandom m => Integer -> m (Maybe SMTCex)
+    testVals :: Integer -> Gen (Maybe SMTCex)
     testVals 0 = pure Nothing
     testVals todo = do
       varVals <- getVals vars
@@ -39,7 +40,6 @@ tryCexFuzz ps tries = CMR.evalRand (testVals tries) (CMR.mkStdGen 1337)
       let
         ret =  filterCorrectKeccak $ map (substituteEWord varVals . substituteBuf bufVals . substituteStores storeVals) ps
         retSimp =  Expr.simplifyProps ret
-      traceM $ "varvals: " <> show varVals -- <> "ret: " <> show ret <> " retsimp: " <> show retSimp
       if null retSimp then pure $ Just (SMTCex {
                                     vars = varVals
                                     , addrs = mempty
@@ -86,7 +86,6 @@ substituteStores valMap p = mapProp go p
     go a = a
 
 -- Var extraction
--- TODO extract all Lit's and stick them into the values once in a while
 data CollectVars = CollectVars {vars :: Set.Set (Expr EWord)
                                ,vals :: Set.Set W256
                                }
@@ -117,7 +116,6 @@ extractVars :: [Prop] -> CollectVars
 extractVars ps = execState (mapM_ findVarProp ps) initVarsState
 
 
-
 --- Buf extraction
 newtype CollectBufs = CollectBufs { bufs :: Set.Set (Expr Buf) }
   deriving (Show)
@@ -142,14 +140,14 @@ findBufProp p = mapPropM go p
       e -> pure e
 
 --- Store extraction
-data CollectStorage = CollectStorage { stores :: Set.Set (Expr EAddr)
-                                     , loads :: Set.Set W256
-                                     -- TODO values
+data CollectStorage = CollectStorage { addrs :: Set.Set (Expr EAddr)
+                                     , keys :: Set.Set W256
+                                     , values :: Set.Set W256
                                      }
   deriving (Show)
 
 initStorageState :: CollectStorage
-initStorageState = CollectStorage { stores = Set.empty, loads = Set.empty }
+initStorageState = CollectStorage { addrs = Set.empty, keys = Set.empty, values = Set.fromList [0x0, 0x1, Expr.maxLit] }
 
 extractStorage :: [Prop] -> CollectStorage
 extractStorage ps = execState (mapM_ findStorageProp ps) initStorageState
@@ -161,76 +159,80 @@ findStorageProp p = mapPropM go p
     go = \case
       e@(AbstractStore a) -> do
         s <- get
-        put $ s{stores=Set.insert a s.stores}
+        put $  CollectStorage {addrs=Set.insert a s.addrs, keys=s.keys, values=s.values}
         pure e
       e@(SLoad (Lit val) _) -> do
         s <- get
-        put $ s{loads=Set.insert val s.loads}
+        put $ s{keys=Set.insert val s.keys}
         pure e
+      e@(SStore _ (Lit val) _) -> do
+          s <- get
+          put $ s{values=Set.insert val s.values}
+          pure e
       e -> pure e
 
--- Var value generation
-getVals :: CMR.MonadRandom m => CollectVars -> m (Map (Expr EWord) W256)
+-- Var value and TX value generation
+getVals :: CollectVars -> Gen (Map (Expr EWord) W256)
 getVals vars = do
     bufs <- go (Set.toList vars.vars) mempty
     addTxStuff bufs
   where
-    addTxStuff :: CMR.MonadRandom m => Map (Expr EWord) W256 -> m (Map (Expr EWord) W256)
-    addTxStuff a = pure $ Map.insert TxValue 0 a -- TODO change from 0 sometimes
-    go :: CMR.MonadRandom m => [Expr EWord] -> Map (Expr EWord) W256 -> m (Map (Expr EWord) W256)
+    addTxStuff :: Map (Expr EWord) W256 -> Gen (Map (Expr EWord) W256)
+    addTxStuff a = do
+      val <- frequency [ (20, pure 0)
+                       , (1, getRndW256)
+                       ]
+      pure $ Map.insert TxValue val a
+    go :: [Expr EWord] -> Map (Expr EWord) W256 -> Gen (Map (Expr EWord) W256)
     go [] valMap = pure valMap
     go (a:ax) valMap = do
-      pickKnown :: Bool <- CMR.getRandom
-      let choices :: [W256] = Set.toList (vars.vals)
+      pickKnown :: Bool <- arbitrary
       val <- if (not pickKnown) || (null vars.vals) then do getRndW256
-                                                    else do pickOne choices
+                                                    else elements $ Set.toList (vars.vals)
       go ax (Map.insert a val valMap)
 
 -- Storage value generation
-getStores :: CMR.MonadRandom m => CollectStorage -> m (Map (Expr EAddr) (Map W256 W256))
-getStores storesLoads = go (Set.toList storesLoads.stores) mempty
+getStores :: CollectStorage -> Gen (Map (Expr EAddr) (Map W256 W256))
+getStores storesLoads = go (Set.toList storesLoads.addrs) mempty
   where
-    go :: CMR.MonadRandom m => [Expr EAddr] -> Map (Expr EAddr) (Map W256 W256) -> m (Map (Expr EAddr) (Map W256 W256))
+    go :: [Expr EAddr] -> Map (Expr EAddr) (Map W256 W256) -> Gen (Map (Expr EAddr) (Map W256 W256))
     go [] addrToValsMap = pure addrToValsMap
-    -- TODO: add more than one write to a single address
     go (addr:ax) addrToValsMap = do
-      emptySize :: Bool <- CMR.getRandom
-      valMap <- if emptySize then pure $ Map.fromList [(0 :: W256,0::W256)]
-                             else do
-                               a <- getRndElem storesLoads.loads
-                               b <- getRndW256
-                               pure $ Map.fromList [(fromMaybe (0::W256) a, b)]
-      go ax (Map.insert addr valMap addrToValsMap)
-    getRndElem :: CMR.MonadRandom m => Set W256 -> m (Maybe W256)
+      -- number of elements inserted into storage
+      numElems :: Int <- frequency [(1, pure 0)
+                                   ,(10, choose (1, 10))
+                                   ,(1, choose (11, 100))
+                                   ]
+      l <- replicateM numElems oneWrite
+      go ax (Map.insert addr (Map.fromList l) addrToValsMap)
+        where
+          oneWrite :: Gen (W256, W256)
+          oneWrite = do
+                    a <- getRndElem storesLoads.keys
+                    b <- frequency [(1, getRndW256)
+                                   ,(3, elements $ Set.toList storesLoads.values)
+                                   ]
+                    pure (fromMaybe (0::W256) a, b)
+    getRndElem :: Set W256 -> Gen (Maybe W256)
     getRndElem choices = if null choices then pure Nothing
-                         else do fmap Just $ pickOne $ Set.toList choices
-
--- Picks one element from list. List must be non-empty
-pickOne :: CMR.MonadRandom m => [k] -> m k
-pickOne s = do
-  k <- CMR.getRandomR (0, (length s)-1)
-  pure $ s !! k
+                         else do fmap Just $ elements $ Set.toList choices
 
 -- Buf value generation
-getBufs :: CMR.MonadRandom m => [Expr Buf] -> m (Map (Expr Buf) BufModel)
+getBufs :: [Expr Buf] -> Gen (Map (Expr Buf) BufModel)
 getBufs bufs = go bufs mempty
   where
-    go :: CMR.MonadRandom m => [Expr Buf] -> Map (Expr Buf) BufModel -> m (Map (Expr Buf) BufModel)
+    go :: [Expr Buf] -> Map (Expr Buf) BufModel -> Gen (Map (Expr Buf) BufModel)
     go [] valMap = pure valMap
     go (a:ax) valMap = do
-      emptySize :: Bool <- CMR.getRandom
-      size <- if emptySize then (pure 0)
-                           else getRndW8
-      bytes <- getRndW8s (fromIntegral size)
+      bytes :: [Word8] <- frequency [
+              (1, do
+                x :: Int <- choose (1, 100)
+                replicateM x arbitrary)
+            , (1, replicateM 0 arbitrary)
+       ]
       go ax (Map.insert a (Flat $ BS.pack bytes) valMap)
 
-getRndW8 :: CMR.MonadRandom m => m Word8
-getRndW8 = do CMR.getRandom
-
-getRndW256 :: CMR.MonadRandom m => m W256
+getRndW256 :: Gen W256
 getRndW256 = do
-      val <- getRndW8s 32
+      val <- replicateM 32 arbitrary
       pure $ bytesToW256 val
-
-getRndW8s :: CMR.MonadRandom m => Int -> m [Word8]
-getRndW8s n = replicateM n getRndW8

--- a/src/EVM/Fuzz.hs
+++ b/src/EVM/Fuzz.hs
@@ -1,0 +1,236 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- |
+    Module: EVM.Fuzz
+    Description: Concrete Fuzzer of Exprs
+-}
+
+module EVM.Fuzz where
+
+import Prelude hiding (LT, GT, lookup)
+import Control.Monad.State
+import Data.Maybe (fromMaybe)
+import Data.Map.Strict as Map (fromList, Map, (!), (!?), insert)
+import EVM.Expr qualified as Expr
+import EVM.Expr (bytesToW256)
+import Data.Set as Set (insert, Set, empty, toList)
+import EVM.Traversals
+import Data.ByteString qualified as BS
+import Data.Word (Word8)
+import Control.Monad.Random.Strict qualified as CMR
+
+import EVM.Types (Prop(..), W256, Expr(..), EType(..), internalError, keccak')
+import EVM.SMT (BufModel(..), SMTCex(..))
+import Debug.Trace
+
+-- TODO: Extract Var X = Lit Z, and set it
+tryCexFuzz :: [Prop] -> Integer -> Maybe (SMTCex)
+tryCexFuzz ps tries = CMR.evalRand (testVals tries) (CMR.mkStdGen 1337)
+  where
+    vars = extractVars ps
+    bufs = extractBufs ps
+    stores = extractStorage ps
+    testVals :: CMR.MonadRandom m => Integer -> m (Maybe SMTCex)
+    testVals 0 = pure Nothing
+    testVals todo = do
+      varVals <- getVals vars
+      bufVals <- getBufs bufs
+      storeVals <- getStores stores
+      let
+        ret =  filterCorrectKeccak $ map (substituteEWord varVals . substituteBuf bufVals . substituteStores storeVals) ps
+        retSimp =  Expr.simplifyProps ret
+      traceM $ "varvals: " <> show varVals -- <> "ret: " <> show ret <> " retsimp: " <> show retSimp
+      if null retSimp then pure $ Just (SMTCex {
+                                    vars = varVals
+                                    , addrs = mempty
+                                    , buffers = bufVals
+                                    , store = storeVals
+                                    , blockContext = mempty
+                                    , txContext = mempty
+                                    })
+                                    else testVals (todo-1)
+
+-- Filter out PEq (Lit X) (keccak (ConcreteBuf Y)) if it's correct
+filterCorrectKeccak :: [Prop] -> [Prop]
+filterCorrectKeccak ps = filter checkKecc ps
+  where
+    checkKecc (PEq (Lit x) (Keccak (ConcreteBuf y))) = keccak' y /= x
+    checkKecc _ = True
+
+substituteEWord :: Map (Expr EWord) W256 -> Prop -> Prop
+substituteEWord valMap p = mapProp go p
+  where
+    go :: Expr a -> Expr a
+    go orig@(Var _) = Lit (valMap ! orig)
+    go orig@(TxValue) = Lit (valMap ! orig)
+    go a = a
+
+
+substituteBuf :: Map (Expr Buf) BufModel -> Prop -> Prop
+substituteBuf valMap p = mapProp go p
+  where
+    go :: Expr a -> Expr a
+    go orig@(AbstractBuf _) = case (valMap !? orig) of
+                                Just (Flat x) -> ConcreteBuf x
+                                Just (Comp _) -> internalError "No compressed allowed in fuzz"
+                                Nothing -> orig
+    go a = a
+
+substituteStores ::  Map (Expr 'EAddr) (Map W256 W256) -> Prop -> Prop
+substituteStores valMap p = mapProp go p
+  where
+    go :: Expr a -> Expr a
+    go (AbstractStore a) = case valMap !? a of
+                                  Just m -> ConcreteStore m
+                                  Nothing -> ConcreteStore mempty
+    go a = a
+
+-- Var extraction
+-- TODO extract all Lit's and stick them into the values once in a while
+data CollectVars = CollectVars {vars :: Set.Set (Expr EWord)
+                               ,vals :: Set.Set W256
+                               }
+  deriving (Show)
+
+initVarsState :: CollectVars
+initVarsState = CollectVars {vars = Set.empty
+                            ,vals =  Set.empty
+                            }
+
+findVarProp :: Prop -> State CollectVars Prop
+findVarProp p = mapPropM go p
+  where
+    go :: forall a. Expr a -> State CollectVars (Expr a)
+    go = \case
+      e@(Var a) -> do
+        s :: CollectVars <- get
+        put CollectVars {vars=Set.insert (Var a) s.vars, vals = s.vals}
+        pure e
+      e@(Lit a) -> do
+        s :: CollectVars <- get
+        put $ s{vals=Set.insert a s.vals}
+        pure e
+      e -> pure e
+
+
+extractVars :: [Prop] -> CollectVars
+extractVars ps = execState (mapM_ findVarProp ps) initVarsState
+
+
+
+--- Buf extraction
+newtype CollectBufs = CollectBufs { bufs :: Set.Set (Expr Buf) }
+  deriving (Show)
+
+initBufsState :: CollectBufs
+initBufsState = CollectBufs { bufs = Set.empty }
+
+extractBufs :: [Prop] -> [Expr Buf]
+extractBufs ps = Set.toList bufs
+ where
+  CollectBufs bufs = execState (mapM_ findBufProp ps) initBufsState
+
+findBufProp :: Prop -> State CollectBufs Prop
+findBufProp p = mapPropM go p
+  where
+    go :: forall a. Expr a -> State CollectBufs (Expr a)
+    go = \case
+      e@(AbstractBuf a) -> do
+        s <- get
+        put $ s{bufs=Set.insert (AbstractBuf a) s.bufs}
+        pure e
+      e -> pure e
+
+--- Store extraction
+data CollectStorage = CollectStorage { stores :: Set.Set (Expr EAddr)
+                                     , loads :: Set.Set W256
+                                     -- TODO values
+                                     }
+  deriving (Show)
+
+initStorageState :: CollectStorage
+initStorageState = CollectStorage { stores = Set.empty, loads = Set.empty }
+
+extractStorage :: [Prop] -> CollectStorage
+extractStorage ps = execState (mapM_ findStorageProp ps) initStorageState
+
+findStorageProp :: Prop -> State CollectStorage Prop
+findStorageProp p = mapPropM go p
+  where
+    go :: forall a. Expr a -> State CollectStorage (Expr a)
+    go = \case
+      e@(AbstractStore a) -> do
+        s <- get
+        put $ s{stores=Set.insert a s.stores}
+        pure e
+      e@(SLoad (Lit val) _) -> do
+        s <- get
+        put $ s{loads=Set.insert val s.loads}
+        pure e
+      e -> pure e
+
+-- Var value generation
+getVals :: CMR.MonadRandom m => CollectVars -> m (Map (Expr EWord) W256)
+getVals vars = do
+    bufs <- go (Set.toList vars.vars) mempty
+    addTxStuff bufs
+  where
+    addTxStuff :: CMR.MonadRandom m => Map (Expr EWord) W256 -> m (Map (Expr EWord) W256)
+    addTxStuff a = pure $ Map.insert TxValue 0 a -- TODO change from 0 sometimes
+    go :: CMR.MonadRandom m => [Expr EWord] -> Map (Expr EWord) W256 -> m (Map (Expr EWord) W256)
+    go [] valMap = pure valMap
+    go (a:ax) valMap = do
+      pickKnown :: Bool <- CMR.getRandom
+      let choices :: [W256] = Set.toList (vars.vals)
+      val <- if (not pickKnown) || (null vars.vals) then do getRndW256
+                                                    else do pickOne choices
+      go ax (Map.insert a val valMap)
+
+-- Storage value generation
+getStores :: CMR.MonadRandom m => CollectStorage -> m (Map (Expr EAddr) (Map W256 W256))
+getStores storesLoads = go (Set.toList storesLoads.stores) mempty
+  where
+    go :: CMR.MonadRandom m => [Expr EAddr] -> Map (Expr EAddr) (Map W256 W256) -> m (Map (Expr EAddr) (Map W256 W256))
+    go [] addrToValsMap = pure addrToValsMap
+    -- TODO: add more than one write to a single address
+    go (addr:ax) addrToValsMap = do
+      emptySize :: Bool <- CMR.getRandom
+      valMap <- if emptySize then pure $ Map.fromList [(0 :: W256,0::W256)]
+                             else do
+                               a <- getRndElem storesLoads.loads
+                               b <- getRndW256
+                               pure $ Map.fromList [(fromMaybe (0::W256) a, b)]
+      go ax (Map.insert addr valMap addrToValsMap)
+    getRndElem :: CMR.MonadRandom m => Set W256 -> m (Maybe W256)
+    getRndElem choices = if null choices then pure Nothing
+                         else do fmap Just $ pickOne $ Set.toList choices
+
+-- Picks one element from list. List must be non-empty
+pickOne :: CMR.MonadRandom m => [k] -> m k
+pickOne s = do
+  k <- CMR.getRandomR (0, (length s)-1)
+  pure $ s !! k
+
+-- Buf value generation
+getBufs :: CMR.MonadRandom m => [Expr Buf] -> m (Map (Expr Buf) BufModel)
+getBufs bufs = go bufs mempty
+  where
+    go :: CMR.MonadRandom m => [Expr Buf] -> Map (Expr Buf) BufModel -> m (Map (Expr Buf) BufModel)
+    go [] valMap = pure valMap
+    go (a:ax) valMap = do
+      emptySize :: Bool <- CMR.getRandom
+      size <- if emptySize then (pure 0)
+                           else getRndW8
+      bytes <- getRndW8s (fromIntegral size)
+      go ax (Map.insert a (Flat $ BS.pack bytes) valMap)
+
+getRndW8 :: CMR.MonadRandom m => m Word8
+getRndW8 = do CMR.getRandom
+
+getRndW256 :: CMR.MonadRandom m => m W256
+getRndW256 = do
+      val <- getRndW8s 32
+      pure $ bytesToW256 val
+
+getRndW8s :: CMR.MonadRandom m => Int -> m [Word8]
+getRndW8s n = replicateM n getRndW8

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -134,7 +134,7 @@ withSolvers solver count timeout cont = do
           then do
             when (conf.debug) $ putStrLn $ "Cex found via fuzzing:" <> (show fuzzResult)
             writeChan r (Sat $ fromJust fuzzResult)
-          else do
+          else if not conf.onlyCexFuzz then do
             when (conf.debug) $ putStrLn "Fuzzing failed to find a Cex"
             -- reset solver and send all lines of provided script
             out <- sendScript inst (SMT2 ("(reset)" : cmds) mempty mempty ps)
@@ -163,6 +163,9 @@ withSolvers solver count timeout cont = do
                                       _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat2
                       _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat
                 writeChan r res
+          else do
+            when (conf.debug) $ putStrLn "Fuzzing failed to find a Cex, not trying SMT due to onlyCexFuzz"
+            writeChan r Unknown
 
         -- put the instance back in the list of available instances
         writeChan availableInstances inst

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -16,7 +16,7 @@ import Control.Monad.IO.Unlift
 import Data.Char (isSpace)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust, fromJust)
 import Data.Text qualified as TS
 import Data.Text.Lazy (Text)
 import Data.Text.Lazy qualified as T
@@ -25,6 +25,7 @@ import Data.Text.Lazy.Builder
 import System.Process (createProcess, cleanupProcess, proc, ProcessHandle, std_in, std_out, std_err, StdStream(..))
 import Witch (into)
 import EVM.Effects
+import EVM.Fuzz (tryCexFuzz)
 
 import EVM.SMT
 import EVM.Types (W256, Expr(AbstractBuf), internalError)
@@ -126,35 +127,42 @@ withSolvers solver count timeout cont = do
     runTask :: (MonadIO m, ReadConfig m) => Task -> SolverInstance -> Chan SolverInstance -> Int -> m ()
     runTask (Task smt2@(SMT2 cmds (RefinementEqs refineEqs refps) cexvars ps) r) inst availableInstances fileCounter = do
       conf <- readConfig
+      let fuzzResult = tryCexFuzz ps conf.numCexFuzz
       liftIO $ do
         when (conf.dumpQueries) $ writeSMT2File smt2 fileCounter "abstracted"
-        -- reset solver and send all lines of provided script
-        out <- sendScript inst (SMT2 ("(reset)" : cmds) mempty mempty ps)
-        case out of
-          -- if we got an error then return it
-          Left e -> writeChan r (Error ("error while writing SMT to solver: " <> T.toStrict e))
-          -- otherwise call (check-sat), parse the result, and send it down the result channel
-          Right () -> do
-            sat <- sendLine inst "(check-sat)"
-            res <- do
-                case sat of
-                  "unsat" -> pure Unsat
-                  "timeout" -> pure Unknown
-                  "unknown" -> pure Unknown
-                  "sat" -> if null refineEqs then Sat <$> getModel inst cexvars
-                           else do
-                                let refinedSMT2 = SMT2 refineEqs mempty mempty (ps <> refps)
-                                writeSMT2File refinedSMT2 fileCounter "refined"
-                                _ <- sendScript inst refinedSMT2
-                                sat2 <- sendLine inst "(check-sat)"
-                                case sat2 of
-                                  "unsat" -> pure Unsat
-                                  "timeout" -> pure Unknown
-                                  "unknown" -> pure Unknown
-                                  "sat" -> Sat <$> getModel inst cexvars
-                                  _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat2
-                  _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat
-            writeChan r res
+        if (isJust fuzzResult)
+          then do
+            when (conf.debug) $ putStrLn $ "Cex found via fuzzing:" <> (show fuzzResult)
+            writeChan r (Sat $ fromJust fuzzResult)
+          else do
+            when (conf.debug) $ putStrLn "Fuzzing failed to find a Cex"
+            -- reset solver and send all lines of provided script
+            out <- sendScript inst (SMT2 ("(reset)" : cmds) mempty mempty ps)
+            case out of
+              -- if we got an error then return it
+              Left e -> writeChan r (Error ("error while writing SMT to solver: " <> T.toStrict e))
+              -- otherwise call (check-sat), parse the result, and send it down the result channel
+              Right () -> do
+                sat <- sendLine inst "(check-sat)"
+                res <- do
+                    case sat of
+                      "unsat" -> pure Unsat
+                      "timeout" -> pure Unknown
+                      "unknown" -> pure Unknown
+                      "sat" -> if null refineEqs then Sat <$> getModel inst cexvars
+                               else do
+                                    let refinedSMT2 = SMT2 refineEqs mempty mempty (ps <> refps)
+                                    writeSMT2File refinedSMT2 fileCounter "refined"
+                                    _ <- sendScript inst refinedSMT2
+                                    sat2 <- sendLine inst "(check-sat)"
+                                    case sat2 of
+                                      "unsat" -> pure Unsat
+                                      "timeout" -> pure Unknown
+                                      "unknown" -> pure Unknown
+                                      "sat" -> Sat <$> getModel inst cexvars
+                                      _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat2
+                      _ -> pure . Error $ T.toStrict $ "Unable to parse solver output: " <> sat
+                writeChan r res
 
         -- put the instance back in the list of available instances
         writeChan availableInstances inst

--- a/test/test.hs
+++ b/test/test.hs
@@ -2659,6 +2659,8 @@ tests = testGroup "hevm"
               uint x;
               uint y;
               function fun(uint256 a) external{
+                require(x != 0);
+                require(y != 0);
                 assert (x == y);
               }
             }
@@ -2691,11 +2693,11 @@ tests = testGroup "hevm"
               a = getVar cex "arg1"
               testCex = Map.size cex.store == 1 &&
                         case Map.lookup addr cex.store of
-                          Just s -> Map.size s == 2 &&
-                                    case (Map.lookup 0 s, Map.lookup (10 + a) s) of
+                          Just s -> case (Map.lookup 0 s, Map.lookup (10 + a) s) of
                                       (Just x, Just y) -> x >= y
+                                      (Just x, Nothing) -> x > 0 -- arr1 can be Nothing, it'll then be zero
                                       _ -> False
-                          _ -> False
+                          Nothing -> False -- arr2 must contain an element, or it'll be 0
           assertBoolM "Did not find expected storage cex" testCex
           putStrLnM "Expected counterexample found"
         ,
@@ -2706,6 +2708,8 @@ tests = testGroup "hevm"
               uint x;
               uint y;
               function fun(uint256 a) external{
+                require (x != 0);
+                require (y != 0);
                 assert (x != y);
               }
             }


### PR DESCRIPTION
## Description
This is a early-stage concrete fuzzer for `Expr`. It can, however, be quite useful in case the `Expr` is easy to satisfy. Added is an example use-case, `fuzz-complicated-mul` that takes forever for CVC5/Z3 to satisfy, but is instantaneous with this fuzzer. 

There are a number limitations that this fuzzer currently has. In particular, I would prefer if this was not just a fuzzer, but a local search system. For that it would (1) need to calculate the distance it's from a target solution and (2) need to calculate a vector to get closer to the target.

The system is using the generator from QuickCheck, which allows for e.g. `frequency` and other helper functions, and does not use `IO`, instead uses a deterministic RNG. Note that some tests were incorrect in `test.hs`, they have been fixed.

**NEW** Apparently, we forgot to call `slt` completely, so we never did constant replacement for `SLT` or `SGT`. This has now been fixed. I had to fix it as part of this PR, because my tests didn't pass without it. Oops.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
