### PR TITLE
Simplify earlier and don't check reachability for FALSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New solc-specific simplification rules that should make the final Props a lot more readable
 - Prop is now correctly ordered, better BufLength and Max simplifications of Expr,
   and further solc-specific simplifications of Expr
+- Simplify earlier and don't check reachability for things statically determined to be FALSE
 
 ## [0.52.0] - 2023-10-26
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -567,14 +567,14 @@ verify solvers opts preState maybepost = do
       Nothing -> pure (expr, [Qed ()])
       Just post -> liftIO $ do
         let
-          -- Filter out any leaves that can be statically shown to be safe
-          canViolate = flip filter flattened $
-            \leaf -> case Expr.simplifyProp (post preState leaf) of
-              PBool True -> False
-              _ -> True
+          -- Filter out any leaves from `flattened` that can be statically shown to be safe
+          tocheck = flip map flattened $ \leaf -> (toPropsFinal leaf, leaf)
+            where
+              toProps leaf = PNeg (post preState leaf) : assumes <> extractProps leaf
+              toPropsFinal leaf = if opts.simp then Expr.simplifyProps $ toProps leaf
+                                               else toProps leaf
           assumes = preState.constraints
-          withQueries = canViolate <&> \leaf ->
-            (assertProps conf (PNeg (post preState leaf) : assumes <> extractProps leaf), leaf)
+          withQueries = filter canBeSat tocheck <&> \(a, leaf) -> (assertProps conf a, leaf)
         putStrLn $ "Checking for reachability of "
                      <> show (length withQueries)
                      <> " potential property violation(s)"
@@ -586,6 +586,9 @@ verify solvers opts preState maybepost = do
         let cexs = filter (\(res, _) -> not . isUnsat $ res) results
         pure $ if Prelude.null cexs then (expr, [Qed ()]) else (expr, fmap toVRes cexs)
   where
+    canBeSat (a, _) = case a of
+        [PBool False] -> False
+        _ -> True
     toVRes :: (CheckSatResult, Expr End) -> VerifyResult
     toVRes (res, leaf) = case res of
       Sat model -> Cex (leaf, expandCex preState model)

--- a/test/test.hs
+++ b/test/test.hs
@@ -2702,7 +2702,16 @@ tests = testGroup "hevm"
   ]
   , testGroup "simplification-working"
   [
-    test "prop-simp-bool1" $ do
+    test "PEq-and-PNot-PEq-1" $ do
+      let a = [PEq (Lit 0x539) (Var "arg1"),PNeg (PEq (Lit 0x539) (Var "arg1"))]
+      assertEqualM "Must simplify to PBool False" (Expr.simplifyProps a) ([PBool False])
+    , test "PEq-and-PNot-PEq-2" $ do
+      let a = [PEq (Var "arg1") (Lit 0x539),PNeg (PEq (Lit 0x539) (Var "arg1"))]
+      assertEqualM "Must simplify to PBool False" (Expr.simplifyProps a) ([PBool False])
+    , test "PEq-and-PNot-PEq-3" $ do
+      let a = [PEq (Var "arg1") (Lit 0x539),PNeg (PEq (Var "arg1") (Lit 0x539))]
+      assertEqualM "Must simplify to PBool False" (Expr.simplifyProps a) ([PBool False])
+    , test "prop-simp-bool1" $ do
       let
         a = successGen [PAnd (PBool True) (PBool False)]
         b = Expr.simplify a


### PR DESCRIPTION
## Description
We can do a bit more with `simplifyProps` and we can check for `[PBool False]` during reachability check, so we don't send a `[PBool False]` to the solver

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
