### PR TITLE
UnitTest: simplify failure checking for ds-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keccak concretization is now done only after all simplifications are performed. This helps with simplification pre-concretization
 
 ## Added
+
 - Optimized smt queries that significantly improve performance when dealing with solidity mappings and arrays
 - Support for using Bitwuzla as a solver
+- More efficient encoding for failure in ds-test style tests
 - Symbolic tests now support statically sized arrays as parameters
 - `hevm test` now has a `num-solvers` parameter that controls how many solver instances to spawn
 - New solc-specific simplification rules that should make the final Props a lot more readable

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -204,8 +204,7 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
     -- we need to read from slot 0 in the test contract and mask it with 0x10 to get the value of _failed
     -- we don't need to do this when reading the failed from the cheatcode address since we don't do any packing there
     let failed store = case Map.lookup cheatCode store of
-          Just cheatContract -> (And (readStorage' (Lit 0) (testContract store).storage) (Lit 0x10) .== Lit 0x10)
-                               .|| (readStorage' (Lit 0x6661696c65640000000000000000000000000000000000000000000000000000) cheatContract.storage .== Lit 1)
+          Just cheatContract -> readStorage' (Lit 0x6661696c65640000000000000000000000000000000000000000000000000000) cheatContract.storage .== Lit 1
           Nothing -> And (readStorage' (Lit 0) (testContract store).storage) (Lit 2) .== Lit 2
         postcondition = curry $ case shouldFail of
           True -> \(_, post) -> case post of


### PR DESCRIPTION
## Description

Simplifies the condition that we use for checking failure in symbolic tests. This was initially needed for backwards compatibility reasons, but I think it's been long enough, and any spurious results introduced by this change can be fixed by upgrading ds-test to the latest.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
