### PR TITLE
Soldity: filter kontrol output from foundry project

### DIFF
--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -310,7 +310,8 @@ readBuildOutput root _ = do
 
 -- | Finds all json files under the provided filepath, searches recursively
 findJsonFiles :: FilePath -> IO [FilePath]
-findJsonFiles root = getDirectoryFiles root ["**/*.json"]
+findJsonFiles root =  filter (/= "kompiled/compiled.json") -- HACK: this gets added to `out` by `kontrol`
+                  <$> getDirectoryFiles root ["**/*.json"]
 
 -- | Filters out metadata json files
 filterMetadata :: [FilePath] -> [FilePath]


### PR DESCRIPTION
## Description

Kontrol (aka kevm) adds it's own folder in `out/`, producing errors if we run `hevm test` over that project. 

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
