### PR TITLE
Fixing out-of-heap error due to large memory copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keccak concretization is now done only after all simplifications are performed. This helps with simplification pre-concretization
 - Added an IllegalOverflow error in case the system tries to allocate a large amount of memory during
   abstract gas execution but concrete running. In these cases, the interpreter can out-of-heap
-  as the only check is that the size allocated $<2^{64}$, but that is too large to fit in memory. Now,
-  we check more stringengly, and still return an IllegalOverflow
+  as the only check is that the size allocated is less than $2**{64}$, but that is too large to fit in memory. Now,
+  we check more stringently, and still return an IllegalOverflow
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimum distance requirements are now asserted for Keccak function calls. They assert that it's hard to generate two Keccak's that are less than 256 afar.
 - Keccak concretization is now done only after all simplifications are performed. This helps with simplification pre-concretization
-- Added an (OutOfGas 0 0) error in case the system tries to allocate a large amount of memory during
+- Added an IllegalOverflow error in case the system tries to allocate a large amount of memory during
   abstract gas execution but concrete running. In these cases, the interpreter can out-of-heap
-  as the only check is that the size allocated $<2^{64}$, but that is too large to fit in memory
+  as the only check is that the size allocated $<2^{64}$, but that is too large to fit in memory. Now,
+  we check more stringengly, and still return an IllegalOverflow
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minimum distance requirements are now asserted for Keccak function calls. They assert that it's hard to generate two Keccak's that are less than 256 afar.
 - Keccak concretization is now done only after all simplifications are performed. This helps with simplification pre-concretization
+- Added an (OutOfGas 0 0) error in case the system tries to allocate a large amount of memory during
+  abstract gas execution but concrete running. In these cases, the interpreter can out-of-heap
+  as the only check is that the size allocated $<2^{64}$, but that is too large to fit in memory
 
 ## Added
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2089,9 +2089,8 @@ accessMemoryRange (Lit offs) (Lit sz) continue =
         -- in e.g. OpCalldatacopy and subsequent memory allocation when running with abstract gas.
         -- In these cases, the system would try to allocate a large (but <2**64 bytes) memory
         -- that leads to out-of-heap. Real-world scenarios cannot allocate 256MB of memory due to gas
-        -- In these cases, we return an OutOfGas 0 0, since we have no concrete value
         else if offs64 >= 0x0fffffff || sz64 >= 0x0fffffff
-             then vmError $ OutOfGas (0::Word64) (0::Word64)
+             then vmError IllegalOverflow
              else accessUnboundedMemoryRange offs64 sz64 continue
 -- we just ignore gas if we get symbolic inputs
 accessMemoryRange _ _ continue = continue


### PR DESCRIPTION
## Description
This issue is related to #444. I am fixing it by returning `IllegalOverflow`, which is what we already do, although we only check $2^{64}$, not 2^{28}$. However, it's mostly the same thing -- way too large of a number.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
