### PR TITLE
Fix `--root` option for `test` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   abstract gas execution but concrete running. In these cases, the interpreter can out-of-heap
   as the only check is that the size allocated is less than $2**{64}$, but that is too large to fit in memory. Now,
   we check more stringently, and still return an IllegalOverflow
+- Fixed `--root` option for the `test` subcommand
 
 ## Added
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -216,21 +216,20 @@ main = do
     Exec {} -> runEnv env $ launchExec cmd
     Test {} -> do
       root <- getRoot cmd
-      withCurrentDirectory root $ do
-        solver <- getSolver cmd
-        cores <- liftIO $ unsafeInto <$> getNumProcessors
-        let solverCount = fromMaybe cores cmd.numSolvers
-        runEnv env $ withSolvers solver solverCount cmd.smttimeout $ \solvers -> do
-          buildOut <- liftIO $ readBuildOutput root (getProjectType cmd)
-          case buildOut of
-            Left e -> liftIO $ do
-              putStrLn $ "Error: " <> e
-              exitFailure
-            Right out -> do
-              -- TODO: which functions here actually require a BuildOutput, and which can take it as a Maybe?
-              testOpts <- liftIO $ unitTestOptions cmd solvers (Just out)
-              res <- unitTest testOpts out.contracts
-              liftIO $ unless res exitFailure
+      solver <- getSolver cmd
+      cores <- liftIO $ unsafeInto <$> getNumProcessors
+      let solverCount = fromMaybe cores cmd.numSolvers
+      runEnv env $ withSolvers solver solverCount cmd.smttimeout $ \solvers -> do
+        buildOut <- liftIO $ readBuildOutput root (getProjectType cmd)
+        case buildOut of
+          Left e -> liftIO $ do
+            putStrLn $ "Error: " <> e
+            exitFailure
+          Right out -> do
+            -- TODO: which functions here actually require a BuildOutput, and which can take it as a Maybe?
+            testOpts <- liftIO $ unitTestOptions cmd solvers (Just out)
+            res <- unitTest testOpts out.contracts
+            liftIO $ unless res exitFailure
 
 equivalence :: App m => Command Options.Unwrapped -> m ()
 equivalence cmd = do

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -23,7 +23,7 @@ import Optics.Core ((&), set)
 import Witch (unsafeInto)
 import Options.Generic as Options
 import Paths_hevm qualified as Paths
-import System.Directory (withCurrentDirectory, getCurrentDirectory, doesDirectoryExist)
+import System.Directory (withCurrentDirectory, getCurrentDirectory, doesDirectoryExist, makeAbsolute)
 import System.FilePath ((</>))
 import System.Exit (exitFailure, exitWith, ExitCode(..))
 
@@ -287,7 +287,7 @@ getProjectType :: Command Options.Unwrapped -> ProjectType
 getProjectType cmd = fromMaybe Foundry cmd.projectType
 
 getRoot :: Command Options.Unwrapped -> IO FilePath
-getRoot cmd = maybe getCurrentDirectory pure (cmd.root)
+getRoot cmd = maybe getCurrentDirectory makeAbsolute (cmd.root)
 
 
 -- | Builds a buffer representing calldata based on the given cli arguments


### PR DESCRIPTION
## Description

The `--root` option for the `test` subcommand didn't work actually. This is because we `cwd`-d into the directory, then called all the functions with the directory name as a prefix, so the directory was in a sense prefixed twice. This is easy to test -- create a `tmp` subdirectory and `cd` into it, call `git init`, call `forge init --force`, add a solidity file under `src/` run `forge build` then go back with `cd ..` and then run `hevm test --root "tmp/"` it will fail.

With this change, it now succeeds, as expected.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
