### PR TITLE
Fix foundry JSON reading that was dependent on locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Traces now correctly perform source mapping to display contract details
 - Event traces now correctly display indexed arguments and argument names
+- JSON reading of foundry JSONs was dependent on locale and did not work with many locales.
 
 ## [0.52.0] - 2023-10-26
 


### PR DESCRIPTION
## Description

This was a VERY weird and annoying bug. See full description here: https://github.com/ethereum/hevm/issues/450

We never caught it because nix happens to set the right locale.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [x] updated the docs
- [ ] updated the changelog
