### PR TITLE
Using with-utf8 so we don't encounter weird locale issues anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 ## Fixed
--- `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing
+- `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing
    with declare-fun
+- CVC5 needs `--incremental` flag to work properly in abstraction-refinement mode
+- cli.hs now uses with-utf8 so no release binary will have locale issues anymore
 
 ## [0.53.0] - 2024-02-23
-
 
 ## Changed
 
@@ -47,7 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Traces now correctly perform source mapping to display contract details
 - Event traces now correctly display indexed arguments and argument names
 - JSON reading of foundry JSONs was dependent on locale and did not work with many locales.
-- CVC5 needs `--incremental` flag to work properly in abstraction-refinement mode
 
 ## [0.52.0] - 2023-10-26
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -26,6 +26,7 @@ import Paths_hevm qualified as Paths
 import System.Directory (withCurrentDirectory, getCurrentDirectory, doesDirectoryExist, makeAbsolute)
 import System.FilePath ((</>))
 import System.Exit (exitFailure, exitWith, ExitCode(..))
+import Main.Utf8 (withUtf8)
 
 import EVM (initialContract, abstractContract, makeVm)
 import EVM.ABI (Sig(..))
@@ -197,7 +198,7 @@ getFullVersion = showVersion Paths.version <> " [" <> gitVersion <> "]"
       Left _ -> "no git revision present"
 
 main :: IO ()
-main = do
+main = withUtf8 $ do
   cmd <- Options.unwrapRecord "hevm -- Ethereum evaluator"
   let env = Env { config = defaultConfig
     { dumpQueries = cmd.smtdebug

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -236,7 +236,8 @@ executable hevm
     optics-core,
     githash                       >= 0.1.6 && < 0.2,
     witch,
-    unliftio-core
+    unliftio-core,
+    with-utf8                     >= 1.0.0.0
   if os(windows)
     buildable: False
 


### PR DESCRIPTION
## Description

Uses `with-utf8` to fix potential (future) issues with locale in cli.hs. All our tests etc. run in nix-shell so they are fine, no need to complicate them. However, the cli actually gets released as a static binary, we should make sure we don't accidentally have/introduce locale issues

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
