### PR TITLE
SMT generation was wrong in more ways than one. Fixing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Traces now correctly perform source mapping to display contract details
 - Event traces now correctly display indexed arguments and argument names
 - JSON reading of foundry JSONs was dependent on locale and did not work with many locales.
+- `concat` is a 2-ary, not an n-ary function in SMT2LIB
+- CVC5 needs `--incremental` flag to work properly in abstraction-refinement mode
 
 ## [0.52.0] - 2023-10-26
 

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -429,39 +429,39 @@ declareBufs props bufEnv storeEnv = SMT2 ("; buffers" : fmap declareBuf allBufs 
   where
     cexvars = (mempty :: CexVars){ buffers = discoverMaxReads props bufEnv storeEnv }
     allBufs = fmap fromLazyText $ Map.keys cexvars.buffers
-    declareBuf n = "(declare-const " <> n <> " (Array (_ BitVec 256) (_ BitVec 8)))"
-    declareLength n = "(declare-const " <> n <> "_length" <> " (_ BitVec 256))"
+    declareBuf n = "(declare-fun " <> n <> " () (Array (_ BitVec 256) (_ BitVec 8)))"
+    declareLength n = "(declare-fun " <> n <> "_length" <> " () (_ BitVec 256))"
 
 -- Given a list of variable names, create an SMT2 object with the variables declared
 declareVars :: [Builder] -> SMT2
 declareVars names = SMT2 (["; variables"] <> fmap declare names) mempty cexvars mempty
   where
-    declare n = "(declare-const " <> n <> " (_ BitVec 256))"
+    declare n = "(declare-fun " <> n <> " () (_ BitVec 256))"
     cexvars = (mempty :: CexVars){ calldata = fmap toLazyText names }
 
 -- Given a list of variable names, create an SMT2 object with the variables declared
 declareAddrs :: [Builder] -> SMT2
 declareAddrs names = SMT2 (["; symbolic addresseses"] <> fmap declare names) mempty cexvars mempty
   where
-    declare n = "(declare-const " <> n <> " Addr)"
+    declare n = "(declare-fun " <> n <> " () Addr)"
     cexvars = (mempty :: CexVars){ addrs = fmap toLazyText names }
 
 declareFrameContext :: [(Builder, [Prop])] -> SMT2
 declareFrameContext names = SMT2 (["; frame context"] <> concatMap declare names) mempty cexvars mempty
   where
-    declare (n,props) = [ "(declare-const " <> n <> " (_ BitVec 256))" ]
+    declare (n,props) = [ "(declare-fun " <> n <> " () (_ BitVec 256))" ]
                         <> fmap (\p -> "(assert " <> propToSMT p <> ")") props
     cexvars = (mempty :: CexVars){ txContext = fmap (toLazyText . fst) names }
 
 declareAbstractStores :: [Builder] -> SMT2
 declareAbstractStores names = SMT2 (["; abstract base stores"] <> fmap declare names) mempty mempty mempty
   where
-    declare n = "(declare-const " <> n <> " Storage)"
+    declare n = "(declare-fun " <> n <> " () Storage)"
 
 declareBlockContext :: [(Builder, [Prop])] -> SMT2
 declareBlockContext names = SMT2 (["; block context"] <> concatMap declare names) mempty cexvars mempty
   where
-    declare (n, props) = [ "(declare-const " <> n <> " (_ BitVec 256))" ]
+    declare (n, props) = [ "(declare-fun " <> n <> " () (_ BitVec 256))" ]
                          <> fmap (\p -> "(assert " <> propToSMT p <> ")") props
     cexvars = (mempty :: CexVars){ blockContext = fmap (toLazyText . fst) names }
 
@@ -470,9 +470,14 @@ prelude =  SMT2 src mempty mempty mempty
   where
   src = fmap (fromLazyText . T.drop 2) . T.lines $ [i|
   ; logic
-  ; TODO: this creates an error when used with z3?
+  (set-info :smt-lib-version 2.6)
   ;(set-logic QF_AUFBV)
   (set-logic ALL)
+  (set-info :source |
+  Generator: hevm
+  Application: hevm symbolic execution system
+  |)
+  (set-info :category "industrial")
 
   ; types
   (define-sort Byte () (_ BitVec 8))
@@ -564,37 +569,38 @@ prelude =  SMT2 src mempty mempty mempty
   (define-fun readWord ((idx Word) (buf Buf)) Word
     (concat
       (select buf idx)
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000001))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000002))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000003))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000004))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000005))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000006))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000007))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000008))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000009))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000a))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000b))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000c))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000d))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000e))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000f))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000010))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000011))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000012))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000013))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000014))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000015))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000016))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000017))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000018))
-      (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000019))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001a))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001b))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001c))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001d))
-      (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001e))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000001))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000002))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000003))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000004))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000005))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000006))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000007))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000008))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000009))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000a))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000b))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000c))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000d))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000e))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000000f))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000010))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000011))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000012))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000013))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000014))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000015))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000016))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000017))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000018))
+      (concat (select buf (bvadd idx #x0000000000000000000000000000000000000000000000000000000000000019))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001a))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001b))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001c))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001d))
+      (concat (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001e))
       (select buf (bvadd idx #x000000000000000000000000000000000000000000000000000000000000001f))
+      ))))))))))))))))))))))))))))))
     )
   )
 

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -269,6 +269,7 @@ solverArgs solver timeout = case solver of
     , "--produce-models"
     , "--print-success"
     , "--interactive"
+    , "--incremental"
     , "--tlimit-per=" <> mkTimeout timeout
     ]
   Custom _ -> []


### PR DESCRIPTION
## Description
`concat` is a 2-ary, not an n-ary function in SMTLIB2. This fixes this error

`declare-const` does not exist in `QF_AUFBV`, replacing with `declare-fun ()`

Closes #456

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
