### PR TITLE
Small nit in pretty printing writes 

### DIFF
--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -714,9 +714,10 @@ formatExpr = go
           , "size:      " <> formatExpr size
           , "src:"
           , indent 2 $ formatExpr src
+          , "dst:"
+          , indent 2 $ formatExpr dst
           ]
         , ")"
-        , formatExpr dst
         ]
       WriteWord idx val buf -> T.unlines
         [ "(WriteWord"
@@ -725,18 +726,19 @@ formatExpr = go
           , indent 2 $ formatExpr idx
           , "val:"
           , indent 2 $ formatExpr val
+          , "buf:"
+          , indent 2 $ formatExpr buf
           ]
         , ")"
-        , formatExpr buf
         ]
       WriteByte idx val buf -> T.unlines
         [ "(WriteByte"
         , indent 2 $ T.unlines
           [ "idx: " <> formatExpr idx
           , "val: " <> formatExpr val
+          , "buf: " <> formatExpr buf
           ]
         , ")"
-        , formatExpr buf
         ]
       ConcreteBuf bs -> case bs of
         "" -> "(ConcreteBuf \"\")"

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -687,9 +687,10 @@ formatExpr = go
           , indent 2 $ formatExpr slot
           , "val:"
           , indent 2 $ formatExpr val
+          , "store:"
+          , indent 2 $ formatExpr prev          
           ]
         , ")"
-        , formatExpr prev
         ]
       AbstractStore a idx ->
         "(AbstractStore " <> formatExpr a <> " " <> T.pack (show idx) <> ")"


### PR DESCRIPTION
## Description

In the formatting of `WriteWord`, `WriteBuf`, and `CopySlice` destination buffers were printed outside of the parentheses, which made it hard to parse the expressions visually. Now they are printed within the parenthesis and in the same indentation block.