### PR TITLE
Implement label cheatcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - More POr and PAnd rules
 - More PEq, PLEq, and PLT rules
+- New `label` cheatcode.
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing

--- a/doc/src/controlling-the-unit-testing-environment.md
+++ b/doc/src/controlling-the-unit-testing-environment.md
@@ -47,3 +47,6 @@ These can be accessed by calling into a contract (typically called `Vm`) at addr
 
 - `function activeFork() external returns (uint256)`
   Returns the identifier of the current fork.
+
+- `function label(address addr, string calldata label) external`
+  Labels the address in traces

--- a/src/EVM/Dapp.hs
+++ b/src/EVM/Dapp.hs
@@ -45,7 +45,8 @@ data Code = Code
 
 data DappContext = DappContext
   { info :: DappInfo
-  , env  :: Map (Expr EAddr) Contract
+  , contracts :: Map (Expr EAddr) Contract
+  , labels :: Map Addr Text
   }
 
 dappInfo :: FilePath -> BuildOutput -> DappInfo

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -218,9 +218,9 @@ data Expr (a :: EType) where
 
   -- control flow
 
-  Partial        :: [Prop] -> Traces -> PartialExec -> Expr End
-  Failure        :: [Prop] -> Traces -> EvmError -> Expr End
-  Success        :: [Prop] -> Traces -> Expr Buf -> Map (Expr EAddr) (Expr EContract) -> Expr End
+  Partial        :: [Prop] -> TraceContext -> PartialExec -> Expr End
+  Failure        :: [Prop] -> TraceContext -> EvmError -> Expr End
+  Success        :: [Prop] -> TraceContext -> Expr Buf -> Map (Expr EAddr) (Expr EContract) -> Expr End
   ITE            :: Expr EWord -> Expr End -> Expr End -> Expr End
 
   -- integers
@@ -624,6 +624,7 @@ data VM (t :: VMType) s = VM
   , config         :: RuntimeConfig
   , forks          :: Seq ForkState
   , currentFork    :: Int
+  , labels         :: Map Addr Text
   }
   deriving (Generic)
 
@@ -896,16 +897,17 @@ data TraceData
   deriving (Eq, Ord, Show, Generic)
 
 -- | Wrapper type containing vm traces and the context needed to pretty print them properly
-data Traces = Traces
+data TraceContext = TraceContext
   { traces :: Forest Trace
   , contracts :: Map (Expr EAddr) Contract
+  , labels :: Map Addr Text
   }
   deriving (Eq, Ord, Show, Generic)
 
-instance Semigroup Traces where
-  (Traces a b) <> (Traces c d) = Traces (a <> c) (b <> d)
-instance Monoid Traces where
-  mempty = Traces mempty mempty
+instance Semigroup TraceContext where
+  (TraceContext a b c) <> (TraceContext d e f) = TraceContext (a <> d) (b <> e) (c <> f)
+instance Monoid TraceContext where
+  mempty = TraceContext mempty mempty mempty
 
 
 -- VM Initialization -------------------------------------------------------------------------------

--- a/test/contracts/pass/cheatCodes.sol
+++ b/test/contracts/pass/cheatCodes.sol
@@ -13,6 +13,7 @@ interface Hevm {
     function addr(uint256) external returns (address);
     function ffi(string[] calldata) external returns (bytes memory);
     function prank(address) external;
+    function label(address addr, string calldata label) external;
 }
 
 contract HasStorage {
@@ -211,4 +212,8 @@ contract CheatCodes is DSTest {
         assertEq(b.balance, 1);
     }
 
+    function prove_label_works() public {
+        hevm.label(address(this), "label");
+        assert(true);
+    }
 }


### PR DESCRIPTION
## Description

Closes https://github.com/ethereum/hevm/issues/442.

I did a bit more work and fixed bugs in this PR too:
- There was a bug in cheatcode `CallContext` creation where the calldata was missing the first 4 bytes and was not displayed correctly in traces
- Unified address pretty printing
- Fixed address printing with leading @ when there is no source name / label
- Added "emit" before events, Foundry does this too
- Pretty print if bytes32 are valid string
- Changed colors a bit but I'll be revamping this anyway in a future PR. I want to turn this into prettyprinter Doc so it can be also used with Brick 
- If there is any name (from source or label) don't print address unless creating
- I reformatted other cheat actions, no semantic changes there

Here is how it looks like (the code doesn't make sense, it was just for my testing):
![image](https://github.com/ethereum/hevm/assets/4679721/cb751d6a-4575-4f87-9a88-5f647aa892c3)


## Checklist

- [x] tested locally
- [x] added automated tests
- [x] updated the docs
- [x] updated the changelog
