### PR TITLE
Fix nixpkgs ghc96

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -58,6 +58,7 @@ common shared
     -Wno-unticked-promoted-constructors
     -Wno-orphans
     -Wno-ambiguous-fields
+    -Wunused-packages
     -optc-Wno-ignored-attributes
     -fspecialize-aggressively
     -fexpose-all-unfoldings
@@ -133,11 +134,8 @@ library
     QuickCheck                        >= 2.13.2 && < 2.15,
     Decimal                           >= 0.5.1 && < 0.6,
     containers                        >= 0.6.0 && < 0.7,
-    deepseq                           >= 1.4.4 && < 1.5,
-    time                              >= 1.11 && < 1.14,
     transformers                      >= 0.5.6 && < 0.6,
     tree-view                         >= 0.5 && < 0.6,
-    abstract-par                      >= 0.3.3 && < 0.4,
     aeson                             >= 2.0.0 && < 2.2,
     bytestring                        >= 0.11.3.1 && < 0.12,
     scientific                        >= 0.3.6 && < 0.4,
@@ -148,46 +146,32 @@ library
     base16                            >= 0.3.2.0 && < 0.3.3.0,
     megaparsec                        >= 9.0.0 && < 10.0,
     mtl                               >= 2.2.2 && < 2.3,
-    directory                         >= 1.3.3 && < 1.4,
     filepath                          >= 1.4.2 && < 1.5,
     cereal                            >= 0.5.8 && < 0.6,
     cryptonite                        >= 0.30 && < 0.31,
     memory                            >= 0.16.0 && < 0.20,
     data-dword                        >= 0.3.1 && < 0.4,
-    free                              >= 5.1.3 && < 5.2,
-    haskeline                         >= 0.8.0 && < 0.9,
     process                           >= 1.6.5 && < 1.7,
     optics-core                       >= 0.4.1 && < 0.5,
     optics-extra                      >= 0.4.2.1 && < 0.5,
     optics-th                         >= 0.4.1 && < 0.5,
     aeson-optics                      >= 1.2.0.1 && < 1.3,
-    monad-par                         >= 0.3.5 && < 0.4,
     async                             >= 2.2.4 && < 2.3,
-    multiset                          >= 0.3.4 && < 0.4,
     operational                       >= 0.2.3 && < 0.3,
     optparse-generic                  >= 1.3.1 && < 1.5,
     pretty-hex                        >= 1.1 && < 1.2,
-    quickcheck-text                   >= 0.1.2 && < 0.2,
-    restless-git                      >= 0.7 && < 0.8,
     rosezipper                        >= 0.2 && < 0.3,
-    temporary                         >= 1.3 && < 1.4,
-    witherable                        >= 0.3.5 && < 0.5,
     wreq                              >= 0.5.3 && < 0.6,
     regex-tdfa                        >= 1.2.3 && < 1.4,
     base                              >= 4.9 && < 5,
     here                              >= 1.2.13 && < 1.3,
     smt2-parser                       >= 0.1.0.1,
-    word-wrap                         >= 0.5 && < 0.6,
     spool                             >= 0.1 && < 0.2,
     stm                               >= 2.5.0 && < 2.6.0,
     spawn                             >= 0.3 && < 0.4,
     filepattern                       >= 0.1.2 && < 0.2,
     witch                             >= 1.1 && < 1.3,
     unliftio-core                     >= 0.2.1.0
-  if !os(windows)
-    build-depends:
-      brick                           >= 1.4 && < 2.0,
-      vty                             >= 5.37 && < 5.39
   hs-source-dirs:
     src
 
@@ -203,36 +187,14 @@ executable hevm
   if os(darwin)
     extra-libraries: c++
   build-depends:
-    QuickCheck,
-    aeson,
-    async,
     base,
-    base16,
-    binary,
-    brick,
     bytestring,
-    containers,
-    cryptonite,
     data-dword,
-    deepseq,
     directory,
     filepath,
-    free,
     hevm,
-    memory,
-    mtl,
     optparse-generic,
-    operational,
-    process,
-    quickcheck-text,
-    regex-tdfa,
-    temporary,
     text,
-    unordered-containers,
-    vector,
-    vty,
-    stm,
-    spawn,
     optics-core,
     githash                       >= 0.1.6 && < 0.2,
     witch,
@@ -252,13 +214,10 @@ common test-base
   autogen-modules:
     Paths_hevm
   build-depends:
-    HUnit >= 1.6,
     QuickCheck,
     quickcheck-instances,
     aeson,
     base,
-    base16,
-    binary,
     containers,
     directory,
     bytestring,
@@ -267,7 +226,6 @@ common test-base
     here,
     hevm,
     mtl,
-    data-dword,
     process,
     tasty >= 1.0,
     tasty-hunit >= 0.10,
@@ -275,23 +233,14 @@ common test-base
     tasty-expected-failure >= 0.12,
     temporary,
     text,
-    regex-tdfa,
-    regex,
-    time,
-    array,
     vector,
-    tasty-bench,
-    stm >= 2.5.0,
-    spawn >= 0.3,
     witherable,
-    smt2-parser >= 0.1.0.1,
     operational,
     optics-core,
     optics-extra,
     witch,
     unliftio-core,
     exceptions,
-    MissingH
 
 library test-utils
   import:
@@ -326,6 +275,13 @@ test-suite test
     test-common
   type:
     exitcode-stdio-1.0
+  build-depends:
+    base16,
+    binary,
+    data-dword,
+    regex,
+    time,
+    MissingH
   main-is:
     test.hs
 
@@ -372,10 +328,8 @@ benchmark bench
     bytestring,
     text,
     hevm,
-    here,
     test-utils,
     filemanip,
     filepath,
     containers,
-    mtl,
     unliftio-core

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -23,6 +23,7 @@ import EVM.Types qualified as Expr (Expr(Gas))
 import EVM.Sign qualified
 import EVM.Concrete qualified as Concrete
 
+import Control.Monad (unless, when)
 import Control.Monad.ST (ST)
 import Control.Monad.State.Strict hiding (state)
 import Data.Bits (FiniteBits, countLeadingZeros, finiteBitSize)

--- a/src/EVM/ABI.hs
+++ b/src/EVM/ABI.hs
@@ -471,7 +471,7 @@ bytesP :: ReadP ByteStringS
 bytesP = do
   _ <- string "0x"
   hex <- munch isHexDigit
-  case BS16.decodeBase16 (encodeUtf8 (Text.pack hex)) of
+  case BS16.decodeBase16Untyped (encodeUtf8 (Text.pack hex)) of
     Right d -> pure $ ByteStringS d
     Left _ -> pfail
 

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -26,6 +26,7 @@ only.
 
 module EVM.Effects where
 
+import Control.Monad (when)
 import Control.Monad.Reader
 import Control.Monad.IO.Unlift
 import EVM.Dapp (DappInfo)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -8,6 +8,7 @@
 module EVM.Expr where
 
 import Prelude hiding (LT, GT)
+import Control.Monad (when)
 import Control.Monad.ST
 import Data.Bits hiding (And, Xor)
 import Data.ByteString (ByteString)

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -39,7 +39,7 @@ import EVM (traceForest, traceForest', traceContext, cheatCode)
 import EVM.ABI (getAbiSeq, parseTypeName, AbiValue(..), AbiType(..), SolError(..), Indexed(..), Event(..))
 import EVM.Dapp (DappContext(..), DappInfo(..), findSrc, showTraceLocation)
 import EVM.Expr qualified as Expr
-import EVM.Solidity (SolcContract(..), Method(..), contractName, abiMap)
+import EVM.Solidity (SolcContract(..), Method(..))
 
 import Control.Arrow ((>>>))
 import Optics.Core
@@ -823,13 +823,13 @@ strip0x' s = if "0x" `isPrefixOf` s then drop 2 s else s
 
 hexByteString :: String -> ByteString -> ByteString
 hexByteString msg bs =
-  case BS16.decodeBase16 bs of
+  case BS16.decodeBase16Untyped bs of
     Right x -> x
     _ -> internalError $ "invalid hex bytestring for " ++ msg
 
 hexText :: Text -> ByteString
 hexText t =
-  case BS16.decodeBase16 (T.encodeUtf8 (T.drop 2 t)) of
+  case BS16.decodeBase16Untyped (T.encodeUtf8 (T.drop 2 t)) of
     Right x -> x
     _ -> internalError $ "invalid hex bytestring " ++ show t
 

--- a/src/EVM/Fuzz.hs
+++ b/src/EVM/Fuzz.hs
@@ -8,6 +8,7 @@
 module EVM.Fuzz where
 
 import Prelude hiding (LT, GT, lookup)
+import Control.Monad (replicateM)
 import Control.Monad.State
 import Data.Maybe (fromMaybe)
 import Data.Map.Strict as Map (fromList, Map, (!), (!?), insert)

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -49,7 +49,7 @@ import Optics.Operators.Unsafe
 import Control.Applicative
 import Control.Monad
 import Control.Monad.IO.Unlift
-import Data.Aeson hiding (json)
+import Data.Aeson
 import Data.Aeson.Types
 import Data.Aeson.Optics
 import Data.Aeson.Key qualified as Key
@@ -658,7 +658,7 @@ containsLinkerHole :: Text -> Bool
 containsLinkerHole = regexMatches "__\\$[a-z0-9]{34}\\$__"
 
 toCode :: Text -> Text -> ByteString
-toCode contractName t = case BS16.decodeBase16 (encodeUtf8 t) of
+toCode contractName t = case BS16.decodeBase16Untyped (encodeUtf8 t) of
   Right d -> d
   Left e -> if containsLinkerHole t
             then error $ T.unpack ("Error toCode: unlinked libraries detected in bytecode, in " <> contractName)

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -7,6 +7,7 @@ module EVM.SymExec where
 import Control.Concurrent.Async (concurrently, mapConcurrently)
 import Control.Concurrent.Spawn (parMapIO, pool)
 import Control.Concurrent.STM (atomically, TVar, readTVarIO, readTVar, newTVarIO, writeTVar)
+import Control.Monad (when, forM_)
 import Control.Monad.Operational qualified as Operational
 import Control.Monad.ST (RealWorld, stToIO, ST)
 import Control.Monad.State.Strict

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -6,7 +6,8 @@ module EVM.Traversals where
 
 import Prelude hiding (LT, GT)
 
-import Control.Monad.Identity
+import Control.Monad (void, forM)
+import Control.Monad.Identity (runIdentity, Identity (..))
 import qualified Data.Map.Strict as Map
 import Data.List (foldl')
 

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -10,8 +10,9 @@ module EVM.Types where
 
 import GHC.Stack (HasCallStack, prettyCallStack, callStack)
 import Control.Arrow ((>>>))
+import Control.Monad (mzero)
 import Control.Monad.ST (ST)
-import Control.Monad.State.Strict (StateT, mzero)
+import Control.Monad.State.Strict (StateT)
 import Crypto.Hash (hash, Keccak_256, Digest)
 import Data.Aeson
 import Data.Aeson qualified as JSON
@@ -1055,7 +1056,7 @@ instance Show ByteStringS where
         T.decodeUtf8 . toStrict . toLazyByteString . byteStringHex
 
 instance JSON.FromJSON ByteStringS where
-  parseJSON (JSON.String x) = case BS16.decodeBase16' x of
+  parseJSON (JSON.String x) = case BS16.decodeBase16Untyped (T.encodeUtf8 x) of
                                 Left _ -> mzero
                                 Right bs -> pure (ByteStringS bs)
   parseJSON _ = mzero

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -21,6 +21,7 @@ import EVM.Transaction (initTx)
 import EVM.Stepper (Stepper)
 import EVM.Stepper qualified as Stepper
 
+import Control.Monad (void, when, forM)
 import Control.Monad.ST (RealWorld, ST, stToIO)
 import Optics.Core hiding (elements)
 import Optics.State

--- a/test/test.hs
+++ b/test/test.hs
@@ -7,6 +7,7 @@ import Prelude hiding (LT, GT)
 
 import GHC.TypeLits
 import Data.Proxy
+import Control.Monad
 import Control.Monad.ST (RealWorld, stToIO)
 import Control.Monad.State.Strict
 import Control.Monad.IO.Unlift
@@ -3615,7 +3616,7 @@ loadVM x = do
 
 hex :: ByteString -> ByteString
 hex s =
-  case BS16.decodeBase16 s of
+  case BS16.decodeBase16Untyped s of
     Right x -> x
     Left e -> internalError $ T.unpack e
 


### PR DESCRIPTION
## Description

To fix the upstream nixpkgs, I took few hours to tackle couple of issues I encountered.

I realized https://github.com/ethereum/hevm/pull/471 is ongoing. So this may be duplicate work, partially.

What I did:

1. I did want to see if I could make `cabal --allow-newer --enable-tests --enable-bench build all ` work. In doing so, I was guided by `-Wunused-packages` option  to remove bunch of red-herring dependency issues.
2. I fixed build errors due to newer packages or ghc 9.6, some already present in https://github.com/ethereum/hevm/pull/471
    - I did not use the test suite thoroughly, since I am not familiar with hevm test suite.
3. update nixpkgs flake input.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog

