### PR TITLE
Mark FFI calls as `unsafe`

### DIFF
--- a/src/EVM/Precompiled.hs
+++ b/src/EVM/Precompiled.hs
@@ -12,11 +12,11 @@ import System.IO.Unsafe
 -- | Opaque representation of the C library's context struct.
 data EthjetContext
 
-foreign import ccall "ethjet_init"
+foreign import ccall unsafe "ethjet_init"
   ethjet_init :: IO (Ptr EthjetContext)
-foreign import ccall "&ethjet_free"
+foreign import ccall unsafe "&ethjet_free"
   ethjet_free :: FunPtr (Ptr EthjetContext -> IO ())
-foreign import ccall "ethjet"
+foreign import ccall unsafe "ethjet"
   ethjet
     :: Ptr EthjetContext     -- initialized context
     -> CInt                  -- operation


### PR DESCRIPTION
## Description
`unsafe` calls are slightly faster, but come with a few restrictions like not being able to reenter into Haskell code, and not releasing the capability. As we don't reenter, and the native code is short-lived, using `unsafe` makes more sense.

Echidna built with this change showed a ~1.5% improvement in execution time on 1000000 runs in a test codebase.

References:
  * https://wiki.haskell.org/Performance/FFI
  * https://wiki.haskell.org/Foreign_Function_Interface#Unsafe_calls

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
