### PR TITLE
Drop brick remnants

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -184,10 +184,6 @@ library
     filepattern                       >= 0.1.2 && < 0.2,
     witch                             >= 1.1 && < 1.3,
     unliftio-core                     >= 0.2.1.0
-  if !os(windows)
-    build-depends:
-      brick                           >= 1.4 && < 2.0,
-      vty                             >= 5.37 && < 5.39
   hs-source-dirs:
     src
 
@@ -209,7 +205,6 @@ executable hevm
     base,
     base16,
     binary,
-    brick,
     bytestring,
     containers,
     cryptonite,
@@ -230,7 +225,6 @@ executable hevm
     text,
     unordered-containers,
     vector,
-    vty,
     stm,
     spawn,
     optics-core,


### PR DESCRIPTION
## Description

hevm does not use brick or vty any longer

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
