### PR TITLE
ci: correct build matrix OSes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,19 +13,16 @@ jobs:
   nix-build:
     strategy:
       matrix:
-        runtime: [ linux-x64, linux-arm64, osx-x64, osx-arm64 ]
+        runtime: [ linux-x64, osx-x64, osx-arm64 ]
         include:
         - runtime: linux-x64
           os: ubuntu-latest
 
-        - runtime: linux-arm64
-          os: ubuntu-latest
-
         - runtime: osx-x64
-          os: macOS-latest
+          os: macos-13
 
         - runtime: osx-arm64
-          os: macOS-latest
+          os: macos-14
 
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,6 @@
           cvc5
           git
           bitwuzla
-        ] ++ lib.optional (!(pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64)) [
           foundry.defaultPackage.${system}
         ];
 


### PR DESCRIPTION
## Description

GitHub only has x86 Ubuntu runners. For macOS, out of the runners available for public repositories, `macos-14` is ARM while `macos-13` is Intel.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
