### PR TITLE
ci: update external actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: build hevm
         run: nix build .#ci -L
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hevm-${{ matrix.runtime }}
           path: result/bin/hevm
@@ -85,7 +85,7 @@ jobs:
             autotools:p
             gmp:p
             openssl:p
-      - uses: haskell-actions/setup@v2.6.1
+      - uses: haskell-actions/setup@v2.7.0
         id: setup
         with:
           ghc-version: '9.4.7'
@@ -130,7 +130,7 @@ jobs:
 
       # Cache dependencies already, so that we do not have to rebuild them should the subsequent steps fail.
       - name: Save cached dependencies
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         # Caches are immutable, trying to save with the same key would error.
         if: ${{ steps.cache.outputs.cache-primary-key != steps.cache.outputs.cache-matched-key }}
         with:

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: lookup nix versions

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
@@ -16,7 +16,7 @@ jobs:
         run: nix-shell --pure --command "cd doc && mdbook build"
 
       - name: publish docs
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4.6.0
         with:
           branch: gh-pages
           folder: doc/book

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,14 @@ jobs:
     name: Build MacOS Binary
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: build hevm
         run: |
           nix build .#redistributable --out-link hevmMacos
           cp ./hevmMacos/bin/hevm ./hevm-x86_64-macos
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: hevm-x86_64-macos
           path: ./hevm-x86_64-macos
@@ -25,7 +25,7 @@ jobs:
     needs: macosRelease
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: build hevm
@@ -33,11 +33,11 @@ jobs:
           nix build .#redistributable --out-link hevmLinux
           cp ./hevmLinux/bin/hevm ./hevm-x86_64-linux
       - name: download macos binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: hevm-x86_64-macos
       - name: create github release & upload binaries
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: |
             ./hevm-x86_64-linux


### PR DESCRIPTION
## Description

This updates external actions used in CI, hopefully silencing all of the node 16 and artifacts v1..v3 deprecation warnings.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
