### PR TITLE
Use let expression in copySlice to decrease expression size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - Improved printing of results. Should be more intuitive to understand what hevm found.
 - More complete and precise array/mapping slot rewrite, along with a copySlice improvement
+- Use a let expression in copySlice to decrease expression size
 
 ## Added
 - More POr and PAnd rules


### PR DESCRIPTION
## Description
This PR changes `copySlice` so that it returns an expression of the form `(let ((src [value of src])) (store (store [value of dst] 0 (select src 0)) 1 (select src 1))`, rather than `(store (store [value of dst] 0 (select [value of src] 0)) 1 (select [value of src] 1))`. This reduces the number of times src has to be written out in the SMT expression from `size` times to only 1 time. This can drastically reduce the size of the resulting SMT expression, especially in the case of nested `CopySlice`s.
Fixes #487 .

## Checklist

- [X] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [X] updated the changelog
