### PR TITLE
ethjet: convert blake2 precompile to C

### DIFF
--- a/ethjet/blake2.c
+++ b/ethjet/blake2.c
@@ -1,4 +1,4 @@
-#include <cstdint>
+#include <stdint.h>
 #include "blake2.h"
 
 #define ROTR64(x, y) (((x) >> (y)) ^ ((x) << (64 - (y))))

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -122,9 +122,9 @@ library
   extra-libraries:
     secp256k1, ff, gmp
   c-sources:
-    ethjet/tinykeccak.c, ethjet/ethjet.c
+    ethjet/tinykeccak.c, ethjet/blake2.c, ethjet/ethjet.c
   cxx-sources:
-    ethjet/ethjet-ff.cc, ethjet/blake2.cc
+    ethjet/ethjet-ff.cc
   cxx-options:
     -std=c++0x
   install-includes:


### PR DESCRIPTION
## Description

This changes the blake2 precompile implementation to build with the C compiler and reduces hevm's C++ dependency to just libff.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
