### PR TITLE
Added `startPrank()` and `stopPrank()` cheatcodes to hevm. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More PEq, PLEq, and PLT rules
 - New `label` cheatcode.
 - Updated Bitwuzla to newer version
+- New cheatcodes `startPrank()` & `stopPrank()`
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing

--- a/doc/src/ds-test-tutorial.md
+++ b/doc/src/ds-test-tutorial.md
@@ -191,6 +191,8 @@ implementing the following methods:
 | Function | Description |
 | --- | --- |
 |`function prank(address sender) public`| Sets `msg.sender` to the specified `sender` for the next call.|
+|`function startPrank(address sender) public`| Sets `msg.sender` to the specified `sender` until `stopPrank()` is called.|
+|`function stopPrank() public`| Resets `msg.sender` to the default sender.|
 |`function deal(address usr, uint amt) public`| Sets the eth balance of `usr` to `amt`. Note that if `usr` is a symbolic address, then it must be the address of a contract that has already been deployed. This restriction is in place to ensure soundness of our symbolic address encoding with respect to potential aliasing of symbolic addresses.|
 |`function store(address c, bytes32 loc, bytes32 val) public`| Sets the slot `loc` of contract `c` to `val`.|
 |`function warp(uint x) public`| Sets the block timestamp to `x`.|

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -652,6 +652,7 @@ data BaseState
 data RuntimeConfig = RuntimeConfig
   { allowFFI :: Bool
   , overrideCaller :: Maybe (Expr EAddr)
+  , resetCaller :: Bool
   , baseState :: BaseState
   }
   deriving (Show)

--- a/test/contracts/pass/cheatCodesFork.sol
+++ b/test/contracts/pass/cheatCodesFork.sol
@@ -11,6 +11,8 @@ interface Hevm {
     function addr(uint256) external returns (address);
     function ffi(string[] calldata) external returns (bytes memory);
     function prank(address) external;
+    function startPrank(address) external;
+    function stopPrank() external;
     function deal(address,uint256) external;
     function createFork(string calldata urlOrAlias) external returns (uint256);
     function selectFork(uint256 forkId) external;


### PR DESCRIPTION
## Description

Added `startPrank()` and `stopPrank()` cheatcodes to hevm. 

This should assist in testing smart contracts when using tools that rely on `hevm` such as [Echidna](https://github.com/crytic/echidna) or [Medusa](https://github.com/medusajs/medusa).

Auditors are creating complex proxy patterns to do external testing of contracts using tools such as Echidna / Medusa: [How to set up Multi Actor Invariant Testing](https://www.youtube.com/watch?v=JvGjQAeSBB4)

Note Alex The Entrepenerd's response in Discord stating `startPrank()` would eliminate the need for this testing pattern: [link to discord conversation](https://discord.com/channels/1199312177727799336/1199314315312889967/1239605053267120159)

## Testing

Tested locally with 
```bash
cabal test --test-options='-p /Cheat-Codes-Pass/'
```

Look for tests `prove_startPrank(address)` and `prove_startPrank_val()`

## Checklist

- [x] tested locally
- [x] added automated tests
- [x] updated the docs
- [x] updated the changelog

## Additional Notes

Edge cases such as stacks of startPrank() were not tested/considered. 
For example, this code will not work - although I am unsure how this operates in Foundry anyway. 

```solidity
.. code 1 ..
hevm.startPrank(address1);
 .. code 2 ..
hevm.startPrank(address2);
 .. code 3 .. 
hevm.stopPrank();
.. code 4 ..
hevm.stopPrank();
.. code 5 ..
```

While untested, I would expect:
`code 1` to have `msg.sender = default`
`code 2` to have `msg.sender = address1`
`code 3` to have `msg.sender = address2`
`code 4` to have `msg.sender = default`
`code 5` to have `msg.sender = default`

<hr> 

I have never written code in Haskell before nor do I have experience with this codebase, please let me know if there are edge cases to consider or any other styling I should do to conform to this repo's standards. 

