### PR TITLE
Adding MacOS-ARM64 release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           path: ./hevm-x86_64-macos
   macosARMRelease:
     name: Build MacOS Binary
+    needs: macosx86Release
     # macos-14 is arm, see https://github.com/orgs/community/discussions/102846
     #   "Workflows executed on this image will run exclusively on the 3 vCPU M1 runner"
     runs-on: macos-14
@@ -40,7 +41,7 @@ jobs:
           path: ./hevm-arm64-macos
   linuxRelease:
     name: Create Release
-    needs: macosRelease
+    needs: macosARMRelease
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,16 +49,33 @@ jobs:
         run: |
           nix build .#redistributable --out-link hevmLinux
           cp ./hevmLinux/bin/hevm ./hevm-x86_64-linux
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hevm-x86_64-linux
+          path: ./hevm-x86_64-linux
+  Upload:
+    name: Upload
+    needs: [linuxRelease, macosx86Release, macosARMRelease]
+    steps:
+      - name: download macos binary
+        uses: actions/download-artifact@v4
+        with:
+          name: hevm-arm64-macos
       - name: download macos binary
         uses: actions/download-artifact@v4
         with:
           name: hevm-x86_64-macos
+      - name: download linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: hevm-x86_64-linux
       - name: create github release & upload binaries
         uses: softprops/action-gh-release@v2.0.4
         with:
           files: |
             ./hevm-x86_64-linux
             ./hevm-x86_64-macos
+            ./hevm-arm64-macos
       - name: prepare hackage artifacts
         run: |
           nix-shell --command "cabal sdist --builddir=${{ runner.temp }}/packages"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
   Upload:
     name: Upload
     needs: [linuxRelease, macosx86Release, macosARMRelease]
+    runs-on: ubuntu-latest
     steps:
       - name: download macos binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,9 @@ jobs:
     needs: [linuxRelease, macosx86Release, macosARMRelease]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: download macos binary
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
           path: ./hevm-x86_64-macos
   macosARMRelease:
     name: Build MacOS Binary
-    needs: macosx86Release
     # macos-14 is arm, see https://github.com/orgs/community/discussions/102846
     #   "Workflows executed on this image will run exclusively on the 3 vCPU M1 runner"
     runs-on: macos-14
@@ -41,7 +40,6 @@ jobs:
           path: ./hevm-arm64-macos
   linuxRelease:
     name: Create Release
-    needs: macosARMRelease
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,10 @@ on:
       - 'release/[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  macosRelease:
+  macosx86Release:
     name: Build MacOS Binary
-    runs-on: macos-latest
+    # macos-13 is x86
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
@@ -20,6 +21,23 @@ jobs:
         with:
           name: hevm-x86_64-macos
           path: ./hevm-x86_64-macos
+  macosARMRelease:
+    name: Build MacOS Binary
+    # macos-14 is arm, see https://github.com/orgs/community/discussions/102846
+    #   "Workflows executed on this image will run exclusively on the 3 vCPU M1 runner"
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: build hevm
+        run: |
+          nix build .#redistributable --out-link hevmMacos
+          cp ./hevmMacos/bin/hevm ./hevm-arm64-macos
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hevm-arm64-macos
+          path: ./hevm-arm64-macos
   linuxRelease:
     name: Create Release
     needs: macosRelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           name: hevm-arm64-macos
           path: ./hevm-arm64-macos
   linuxRelease:
-    name: Create Release
+    name: Build Linux Binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `label` cheatcode.
 - Updated Bitwuzla to newer version
 - New cheatcodes `startPrank()` & `stopPrank()`
+- ARM64 and x86_64 Mac along with Linux x86_64 static binaries for releases
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing


### PR DESCRIPTION
## Description
This should finally make sure we release a MacOS ARM as well as x86 build. I will have to check it in a separate personal repo, as this requires a release to be made to check. Once it works there, I'll ask for review and merge.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
