### PR TITLE
More Prop simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Bitwuzla to newer version
 - New cheatcodes `startPrank()` & `stopPrank()`
 - ARM64 and x86_64 Mac along with Linux x86_64 static binaries for releases
+- PAnd props are now recursively flattened
+- Double negation in Prop are removed
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1298,13 +1298,8 @@ simplifyProp prop =
 flattenProps :: [Prop] -> [Prop]
 flattenProps [] = []
 flattenProps (a:ax) = case a of
-  PAnd x1 x2 -> (subFlatten x1) ++ (subFlatten x2) ++ flattenProps ax
+  PAnd x1 x2 -> flattenProps [x1] ++ flattenProps [x2] ++ flattenProps ax
   x -> x:flattenProps ax
-  where
-    subFlatten :: Prop -> [Prop]
-    subFlatten b = case b of
-      PAnd y1 y2 -> flattenProps [y1,y2]
-      _ -> [b]
 
 -- removes redundant (constant True/False) props
 remRedundantProps :: [Prop] -> [Prop]


### PR DESCRIPTION
## Description

This does a number of Prop simplifications. I needed it to debug another issue. Basically:

* `[PAnd (PAnd x y) z]` now becomes `[x, y, z]`, previously it was `[x, PAnd y z]`
* Double negation not only works for `Eq` inside Prop, but also for `LT`, `GT`, etc

This makes it a lot easier to debug some issues (much less deep trees), and accidentally makes things faster, too. Was not the intention, though.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
