### PR TITLE
cli: fix --initial-storage option for hevm symbolic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Printing panic uint256 as hex, not as int
 - Decomposition does not take place when entire states are compared, as that would necessitate
   a different approach.
+- `initial-storage` option of `hevm symbolic` is respected
 
 ## [0.53.0] - 2024-02-23
 


### PR DESCRIPTION
## Description

We weren't respect the `initial-storage` option when creating the initial contract in `symVmFromCommand`

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
