### PR TITLE
Re-enable dapp tests on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
+      - run: |
+          echo FOUNDRY_PATH="$(dirname "$(which forge)")" >> "$GITHUB_ENV"
+        shell: bash
       - uses: msys2/setup-msys2@v2
         with:
           msystem: CLANG64
@@ -213,12 +216,12 @@ jobs:
 
       - name: run tests
         run: |
-          export PATH="$EVM_PATH:$CVC5_PATH:$BITWUZLA_PATH:$DAPP_SOLC_PATH:$HASKELL_PATHS:$PATH"
+          export PATH="$EVM_PATH:$CVC5_PATH:$BITWUZLA_PATH:$DAPP_SOLC_PATH:$FOUNDRY_PATH:$HASKELL_PATHS:$PATH"
           cabal run test
 
       - name: run rpc tests
         run: |
-          export PATH="$HASKELL_PATHS:$PATH"
+          export PATH="$FOUNDRY_PATH:$HASKELL_PATHS:$PATH"
           cabal run rpc-tests
 
       - name: run ethereum tests

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -6,7 +6,7 @@ import Data.String.Here
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as T
-import GHC.IO.Handle (hClose)
+import GHC.IO.Exception (IOErrorType(..))
 import GHC.Natural
 import Paths_hevm qualified as Paths
 import System.Directory
@@ -14,6 +14,8 @@ import System.FilePath ((</>))
 import System.IO.Temp
 import System.Process
 import System.Exit
+import System.IO
+import System.IO.Error (mkIOError)
 
 import EVM.Dapp (dappInfo, emptyDapp)
 import EVM.Fetch (RpcInfo)
@@ -65,6 +67,21 @@ testOpts solvers root buildOutput match maxIter allowFFI rpcinfo = do
     , ffiAllowed = allowFFI
     }
 
+processFailedException :: String -> String -> [String] -> Int -> IO a
+processFailedException fun cmd args exit_code =
+      ioError (mkIOError OtherError (fun ++ ": " ++ cmd ++
+                                     concatMap ((' ':) . show) args ++
+                                     " (exit " ++ show exit_code ++ ")")
+                                 Nothing Nothing)
+
+callProcessCwd :: FilePath -> [String] -> FilePath -> IO ()
+callProcessCwd cmd args cwd = do
+    exit_code <- withCreateProcess (proc cmd args) { cwd = Just cwd, delegate_ctlc = True } $ \_ _ _ p ->
+                 waitForProcess p
+    case exit_code of
+      ExitSuccess   -> return ()
+      ExitFailure r -> processFailedException "callProcess" cmd args r
+
 compile :: App m => ProjectType -> FilePath -> FilePath -> m (Either String BuildOutput)
 compile DappTools root src = do
   json <- liftIO $ compileWithDSTest src
@@ -98,8 +115,8 @@ compile foundryType root src = do
       _ <- readProcessWithExitCode "git" ["init", tld] ""
       callProcess "git" ["config", "--file", tld </> ".git" </> "config", "user.name", "'hevm'"]
       callProcess "git" ["config", "--file", tld </> ".git" </> "config", "user.email", "'hevm@hevm.dev'"]
-      callProcess "git" ["--git-dir", tld </> ".git", "--work-tree", tld, "add", tld]
-      _ <- readProcessWithExitCode "git" ["--git-dir", tld </> ".git", "--work-tree", tld, "--no-gpg-sign", "commit", "-m"] ""
+      callProcessCwd "git" ["add", "."] tld
+      callProcessCwd "git" ["commit", "-m", "", "--allow-empty-message", "--no-gpg-sign"] tld
       pure ()
 
 -- We don't want to depend on dapptools here, so we cheat and just call solc with the same options that dapp itself uses

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -3,9 +3,7 @@
 module Main where
 
 import Test.Tasty
-import Test.Tasty.ExpectedFailure
 import Test.Tasty.HUnit
-import System.Info (os)
 
 import Data.Maybe
 import Data.Map qualified as Map
@@ -33,10 +31,6 @@ rpcEnv = Env { config = defaultConfig }
 
 test :: TestName -> ReaderT Env IO () -> TestTree
 test a b = testCase a $ runEnv rpcEnv b
-
-ignoreTestWindows :: String -> TestTree -> TestTree
-ignoreTestWindows reason t | os == "mingw32" = ignoreTestBecause ("unsupported on Windows: " <> reason) t
-                           | otherwise       = t
 
 main :: IO ()
 main = defaultMain tests
@@ -75,7 +69,7 @@ tests = testGroup "rpc"
     ]
   , testGroup "execution with remote state"
     -- execute against remote state from a ds-test harness
-    [ ignoreTestWindows "git command failure" $ test "dapp-test" $ do
+    [ test "dapp-test" $ do
         let testFile = "test/contracts/pass/rpc.sol"
         res <- runSolidityTestCustom testFile ".*" Nothing Nothing False testRpcInfo Foundry
         liftIO $ assertEqual "test result" True res

--- a/test/test.hs
+++ b/test/test.hs
@@ -34,7 +34,6 @@ import Data.Word (Word8)
 import GHC.Conc (getNumProcessors)
 import System.Directory
 import System.Environment
-import System.Info (os)
 import Test.Tasty
 import Test.Tasty.QuickCheck hiding (Failure, Success)
 import Test.QuickCheck.Instances.Text()
@@ -111,10 +110,6 @@ main = defaultMain tests
 -- https://github.com/UnkindPartition/tasty/tree/ee6fe7136fbcc6312da51d7f1b396e1a2d16b98a#patterns
 runSubSet :: String -> IO ()
 runSubSet p = defaultMain . applyPattern p $ tests
-
-ignoreTestWindows :: String -> TestTree -> TestTree
-ignoreTestWindows reason t | os == "mingw32" = ignoreTestBecause ("unsupported on Windows: " <> reason) t
-                           | otherwise       = t
 
 tests :: TestTree
 tests = testGroup "hevm"
@@ -1248,7 +1243,7 @@ tests = testGroup "hevm"
             Partial _ _ (JumpIntoSymbolicCode _ _) -> assertBoolM "" True
             _ -> assertBoolM "did not encounter expected partial node" False
     ]
-  , ignoreTestWindows "odd Git failures" $ testGroup "Dapp-Tests"
+  , testGroup "Dapp-Tests"
     [ test "Trivial-Pass" $ do
         let testFile = "test/contracts/pass/trivial.sol"
         runSolidityTest testFile ".*" >>= assertEqualM "test result" True


### PR DESCRIPTION
## Description

This reenables all the tests that were disabled on WIndows. Previously, they failed on WIndows with errors such as

````
  Dapp-Tests
fatal: /tmp/dapp-test-91617a5c2e6833e3/lib/ds-test: '/tmp/dapp-test-91617a5c2e6833e3/lib/ds-test' is outside repository at '/tmp/dapp-test-91617a5c2e6833e3/lib/ds-test'
    Trivial-Pass:                                                 FAIL
      Exception: callProcess: git "--git-dir" "D:\\a\\_temp\\msys64\\tmp\\dapp-test-91617a5c2e6833e3\\lib\\ds-test\\.git" "--work-tree" "D:\\a\\_temp\\msys64\\tmp\\dapp-test-91617a5c2e6833e3\\lib\\ds-test" "add" "D:\\a\\_temp\\msys64\\tmp\\dapp-test-91617a5c2e6833e3\\lib\\ds-test" (exit 128): failed
      Use -p '/Trivial-Pass/' to rerun this test only.
````

To get the tests working on Windows, the `git` incantations are modified to stop using `--git-dir` and `--work-tree` and instead indicate the repo with the proper `cwd`. `forge` is also explicitely brought into the PATH as the tests need that program available as well.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
