### PR TITLE
ci: windows: pin Foundry version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
         with:
+          # Pinning to a version in June 2024, so in case a build fails, our CI doesn't fail
           version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559
       - run: |
           echo FOUNDRY_PATH="$(dirname "$(which forge)")" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559
       - run: |
           echo FOUNDRY_PATH="$(dirname "$(which forge)")" >> "$GITHUB_ENV"
         shell: bash


### PR DESCRIPTION
## Description

Sometimes Foundry's CI can fail and e.g. not upload the releases. Pin the version instead so we're not subject to those sorts of issues.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
