### PR TITLE
Changing default --max-iterations to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `--debug` flag now dumps the internal expressions as well
 - hevm now uses the forge-std library's way of detecting failures, i.e. through
   reverting with a specific error code unless --assertion-type DSTest is passed
+- Default max iterations is 5 now. `--max-iters -1` now signals no bound. This change is to match other
+  symbolic execution frameworks' default bound and to not go into an infinite loop by default when
+  there could be other, interesting and reachable bugs in the code
 
 ## Added
 - More POr and PAnd rules

--- a/doc/src/equivalence.md
+++ b/doc/src/equivalence.md
@@ -19,7 +19,7 @@ Available options:
   --calldata TEXT          Tx: calldata
   --smttimeout NATURAL     Timeout given to SMT solver in seconds (default: 300)
   --max-iterations INTEGER Number of times we may revisit a particular branching
-                           point
+                           point. Default is 5. Setting to -1 allows infinite looping
   --solver TEXT            Used SMT solver: z3 (default), cvc5, or bitwuzla
   --smtoutput              Print verbose smt output
   --smtdebug               Print smt queries sent to the solver

--- a/doc/src/symbolic.md
+++ b/doc/src/symbolic.md
@@ -52,7 +52,7 @@ Available options:
   --show-reachable-tree    Print only reachable branches explored in tree view
   --smttimeout NATURAL     Timeout given to SMT solver in seconds (default: 300)
   --max-iterations INTEGER Number of times we may revisit a particular branching
-                           point
+                           point. Default is 5. Setting to -1 allows infinite looping
   --solver TEXT            Used SMT solver: z3 (default), cvc5, or bitwuzla
   --smtdebug               Print smt queries sent to the solver
   --assertions [WORD256]   Comma separated list of solc panic codes to check for

--- a/doc/src/test.md
+++ b/doc/src/test.md
@@ -30,7 +30,7 @@ Available options:
                            your machine)
   --smttimeout NATURAL     Timeout given to SMT solver in seconds (default: 300)
   --max-iterations INTEGER Number of times we may revisit a particular branching
-                           point
+                           point. Default is 5. Setting to -1 allows infinite looping
   --loop-detection-heuristic LOOPHEURISTIC
                            Which heuristic should be used to determine if we are
                            in a loop: StackBased (default) or Naive

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -467,7 +467,7 @@ formatPartial = \case
       , indent 2 $ T.unlines . fmap formatSomeExpr $ args
       ]
     ]
-  MaxIterationsReached pc addr -> "Max Iterations Reached in contract: " <> formatAddr addr <> " pc: " <> pack (show pc)
+  MaxIterationsReached pc addr -> "Max Iterations Reached in contract: " <> formatAddr addr <> " pc: " <> pack (show pc) <> " To increase the maximum, set a fixed large (or negative) value for `--max-iterations` on the command line"
   JumpIntoSymbolicCode pc idx -> "Encountered a jump into a potentially symbolic code region while executing initcode. pc: " <> pack (show pc) <> " jump dst: " <> pack (show idx)
 
 formatSomeExpr :: SomeExpr -> Text


### PR DESCRIPTION
## Description
Maximum iterations explored of loops has been set to 5 by default instead of the infinite before. This is to:
- Keep more in line with other symbolic execution systems' defaults (e.g hevm). They tend to a have a fixed default, usually 1. However, 1 is so low that it can cause issues with std-test.
- Not get stuck on a single loop and find potential issues outside of the loop. Otherwise, users would have a very bad experience of getting stuck on one thing where there could be bugs elsewhere.

We now print a better warning, with explanation how to increase the loop bound.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [x] updated the docs
- [x] updated the changelog
