### PR TITLE
SymExec: symbolic abi encoding for tuples (+ fuzzing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PAnd props are now recursively flattened
 - Double negation in Prop are removed
 - Updated forge to modern version, thereby fixing JSON parsing of new forge JSONs
+- Symbolic ABI encoding for tuples, fuzzer for encoder
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -227,6 +227,7 @@ common test-base
     base,
     containers,
     directory,
+    extra,
     bytestring,
     filemanip,
     filepath,

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -103,6 +103,25 @@ data SMTCex = SMTCex
   }
   deriving (Eq, Show)
 
+instance Semigroup SMTCex where
+  a <> b = SMTCex
+    { vars = a.vars <> b.vars
+    , addrs = a.addrs <> b.addrs
+    , buffers = a.buffers <> b.buffers
+    , store = a.store <> b.store
+    , blockContext = a.blockContext <> b.blockContext
+    , txContext = a.txContext <> b.txContext
+    }
+
+instance Monoid SMTCex where
+  mempty = SMTCex
+    { vars = mempty
+    , addrs = mempty
+    , buffers = mempty
+    , store = mempty
+    , blockContext = mempty
+    , txContext = mempty
+    }
 
 -- | Used for abstraction-refinement of the SMT formula. Contains assertions that make our query fully precise. These will be added to the assertion stack if we get `sat` with the abstracted query.
 data RefinementEqs = RefinementEqs [Builder] [Prop]


### PR DESCRIPTION
## Description
Originally by @d-xo. There was a little bug in there, which I had a hard time finding, but it's fixed now. Basically `y101` is ambiguous. So now it's `y-a-1-a-01` which is not ambiguous.

I left in a bunch of debug code for `symbolic-abi-enc-vs-solidity`. I think that may come handy one day. It certainly helped me understand the encoding and find the bug.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
