### PR TITLE
Respect `--caller` option in `symbolic` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decomposition does not take place when entire states are compared, as that would necessitate
   a different approach.
 - `initial-storage` option of `hevm symbolic` is respected
+- `caller` option of `hevm syhmbolic` is now respected
 
 ## [0.53.0] - 2024-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decomposition does not take place when entire states are compared, as that would necessitate
   a different approach.
 - `initial-storage` option of `hevm symbolic` is respected
-- `caller` option of `hevm syhmbolic` is now respected
+- `caller` option of `hevm symbolic` is now respected
 
 ## [0.53.0] - 2024-02-23
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -515,7 +515,9 @@ symvmFromCommand cmd calldata = do
                              )
 
   let
-    caller = SymAddr "caller"
+    caller = case cmd.caller of
+               Nothing -> SymAddr "caller"
+               Just a -> LitAddr a
     ts = maybe Timestamp Lit cmd.timestamp
     callvalue = maybe TxValue Lit cmd.value
     storageBase = maybe AbstractBase parseInitialStorage (cmd.initialStorage)

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -515,9 +515,7 @@ symvmFromCommand cmd calldata = do
                              )
 
   let
-    caller = case cmd.caller of
-               Nothing -> SymAddr "caller"
-               Just a -> LitAddr a
+    caller = maybe (SymAddr "caller") LitAddr cmd.caller
     ts = maybe Timestamp Lit cmd.timestamp
     callvalue = maybe TxValue Lit cmd.value
     storageBase = maybe AbstractBase parseInitialStorage (cmd.initialStorage)


### PR DESCRIPTION
## Description

As per #524 `--caller` was not respected here:

`cabal run hevm  -- symbolic --caller 0xabab --rpc $ETH_RPC_URL  --show-reachable-tree --code $(jq -r '.deployedBytecode.object' tmp2/out/bug.sol/ERC20_2.json`

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
