### PR TITLE
Better printing of symbolic results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Double negation in Prop are removed
 - Updated forge to modern version, thereby fixing JSON parsing of new forge JSONs
 - Symbolic ABI encoding for tuples, fuzzer for encoder
+- Printing `Addrs` when running `symbolic` for counterexamples and reachable end states
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -343,14 +343,14 @@ assert cmd = do
               | null cexs = []
               | otherwise =
                  [ ""
-                 , "Discovered the following counterexamples:"
+                 , ("Discovered the following " <> (T.pack $ show (length cexs)) <> " counterexample(s):")
                  , ""
                  ] <> fmap (formatCex (fst calldata) Nothing) cexs
             unknowns
               | null timeouts = []
               | otherwise =
                  [ ""
-                 , "Could not determine reachability of the following end states:"
+                 , "Could not determine reachability of the following end state(s):"
                  , ""
                  ] <> fmap (formatExpr) timeouts
         liftIO $ T.putStrLn $ T.unlines (counterexamples <> unknowns)
@@ -370,7 +370,7 @@ showExtras solvers cmd calldata expr = do
       T.putStrLn (formatExpr . snd $ reached)
       putStrLn ""
   when cmd.getModels $ do
-    liftIO $ putStrLn $ "=== Models for " <> show (Expr.numBranches expr) <> " branches ===\n"
+    liftIO $ putStrLn $ "=== Models for " <> show (Expr.numBranches expr) <> " branches ==="
     ms <- produceModels solvers expr
     liftIO $ forM_ ms (showModel (fst calldata))
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -870,13 +870,14 @@ formatCex cd sig m@(SMTCex _ addrs _ store blockContext txContext) = T.unlines $
             (showTxCtx key <> ": " <> (T.pack $ show val)) : acc
           ) mempty (filterSubCtx txContext)
         ]
+
     addrsCex :: [Text]
     addrsCex
       | Map.null addrs = []
       | otherwise =
           [ "Addrs:"
-          , indent 2 $ Map.foldrWithKey (\key val _ ->
-              ((T.pack . show $ key) <> ": " <> (T.pack $ show val))
+          , indent 2 $ T.unlines $ Map.foldrWithKey (\key val acc ->
+              ((T.pack . show $ key) <> ": " <> (T.pack $ show val)) : acc
             ) mempty addrs
           ]
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -815,34 +815,29 @@ showModel cd (expr, res) = do
     Unsat -> pure () -- ignore unreachable branches
     Error e -> internalError $ "smt solver returned an error: " <> show e
     EVM.Solvers.Unknown -> do
+      putStrLn ""
       putStrLn "--- Branch ---"
-      putStrLn ""
       putStrLn "Unable to produce a model for the following end state:"
-      putStrLn ""
       T.putStrLn $ indent 2 $ formatExpr expr
       putStrLn ""
     Sat cex -> do
+      putStrLn ""
       putStrLn "--- Branch ---"
-      putStrLn ""
       putStrLn "Inputs:"
-      putStrLn ""
       T.putStrLn $ indent 2 $ formatCex cd Nothing cex
-      putStrLn ""
       putStrLn "End State:"
-      putStrLn ""
       T.putStrLn $ indent 2 $ formatExpr expr
-      putStrLn ""
 
 
 formatCex :: Expr Buf -> Maybe Sig -> SMTCex -> Text
-formatCex cd sig m@(SMTCex _ _ _ store blockContext txContext) = T.unlines $
+formatCex cd sig m@(SMTCex _ addrs _ store blockContext txContext) = T.unlines $
   [ "Calldata:"
   , indent 2 cd'
-  , ""
   ]
   <> storeCex
   <> txCtx
   <> blockCtx
+  <> addrsCex
   where
     -- we attempt to produce a model for calldata by substituting all variables
     -- and buffers provided by the model into the original calldata expression.
@@ -864,7 +859,6 @@ formatCex cd sig m@(SMTCex _ _ _ store blockContext txContext) = T.unlines $
               ("Addr " <> (T.pack . show $ key)
                 <> ": " <> (T.pack $ show (Map.toList val))) : acc
             ) mempty store
-          , ""
           ]
 
     txCtx :: [Text]
@@ -875,8 +869,16 @@ formatCex cd sig m@(SMTCex _ _ _ store blockContext txContext) = T.unlines $
         , indent 2 $ T.unlines $ Map.foldrWithKey (\key val acc ->
             (showTxCtx key <> ": " <> (T.pack $ show val)) : acc
           ) mempty (filterSubCtx txContext)
-        , ""
         ]
+    addrsCex :: [Text]
+    addrsCex
+      | Map.null addrs = []
+      | otherwise =
+          [ "Addrs:"
+          , indent 2 $ Map.foldrWithKey (\key val _ ->
+              ((T.pack . show $ key) <> ": " <> (T.pack $ show val))
+            ) mempty addrs
+          ]
 
     -- strips the frame arg from frame context vars to make them easier to read
     showTxCtx :: Expr EWord -> Text
@@ -901,7 +903,6 @@ formatCex cd sig m@(SMTCex _ _ _ store blockContext txContext) = T.unlines $
         , indent 2 $ T.unlines $ Map.foldrWithKey (\key val acc ->
             (T.pack $ show key <> ": " <> show val) : acc
           ) mempty txContext
-        , ""
         ]
 
     prettyBuf :: Expr Buf -> Text


### PR DESCRIPTION
## Description
As per: https://github.com/ethereum/hevm/issues/534 `Addrs` was not printed, and also, the printing was a bit unaesthetic. It's a bit more tight printing now, and `Addrs` are printed.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
