### PR TITLE
Refactor simplifications for bitwise AND and OR

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1109,22 +1109,18 @@ simplify e = if (mapExpr go e == e)
       | otherwise = o
 
     -- Bitwise AND & OR. These MUST preserve bitwise equivalence
-    go o@(And (Lit x) _)
-      | x == 0 = Lit 0
-      | otherwise = o
-    go o@(And v (Lit x))
-      | x == 0 = Lit 0
-      | x == maxLit = v
-      | otherwise = o
-    go (And a b) | a == b = a
-    go (And a (Not b)) | a == b = Lit 0
-    go o@(Or (Lit x) b)
-      | x == 0 = b
-      | otherwise = o
-    go o@(Or a (Lit x))
-      | x == 0 = a
-      | otherwise = o
-    go (Or a b) | a == b = a
+    go (And a b)
+      | a == b = a
+      | b == (Not a) || a == (Not b) = Lit 0
+      | a == (Lit 0) || b == (Lit 0) = Lit 0
+      | a == (Lit maxLit) = b
+      | b == (Lit maxLit) = a
+      | otherwise = EVM.Expr.and a b
+    go (Or a b)
+      | a == b = a
+      | a == (Lit 0) = b
+      | b == (Lit 0) = a
+      | otherwise = EVM.Expr.or a b
 
     -- If x is ever non zero the Or will always evaluate to some non zero value and the false branch will be unreachable
     -- NOTE: with AND this does not work, because and(0x8, 0x4) = 0

--- a/test/test.hs
+++ b/test/test.hs
@@ -746,6 +746,18 @@ tests = testGroup "hevm"
           t = [PAnd (PEq (Add (Lit 5) (Lit 1)) (Var "a")) (PEq (Var "a") (Lit 7))]
           simplified = Expr.simplifyProps t
         assertEqualM "Must be equal" [PBool False] simplified
+    , test "simpProp-inner-expr-bitwise-and" $ do
+        let
+          -- 1 & 2 != 2
+          t = [PEq (And (Lit 1) (Lit 2)) (Lit 2)]
+          simplified = Expr.simplifyProps t
+        assertEqualM "Must be equal" [PBool False] simplified
+    , test "simpProp-inner-expr-bitwise-or" $ do
+        let
+          -- 2 | 4 == 6
+          t = [PEq (Or (Lit 2) (Lit 4)) (Lit 6)]
+          simplified = Expr.simplifyProps t
+        assertEqualM "Must be equal" [] simplified
   ]
   , testGroup "MemoryTests"
     [ test "read-write-same-byte"  $ assertEqualM ""


### PR DESCRIPTION
## Description
We unify handling simplification of bitwise AND and OR with other operations, such as bit shifts and aritmetic operations. After handling some specific cases, we defer to `and` and `or` functions from EVM.Expr, which take care of simplifying the operation when both operators are concrete.

Fixes #531.

## Checklist

- [X] tested locally
- [X] added automated tests
