### PR TITLE
[DRAFT] Allow symbolic starting state for "test" (not working correctly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Printing `Addrs` when running `symbolic` for counterexamples and reachable end states
 - Improved symbolic execution tutorial
 - Add `freshAddresses` filed in `VMOpts` so that initial fresh address can be given as input
-- Add `freshAddresses` field in `VMOpts` so that initial fresh address can be given as input
 - Add documentation about limitations and workarounds
+* Add `--symbolic-start` to allow starting state to be symbolic in "test" mode
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -156,6 +156,7 @@ data Command w
       , match         :: w ::: Maybe String             <?> "Test case filter - only run methods matching regex"
       , solver        :: w ::: Maybe Text               <?> "Used SMT solver: z3 (default), cvc5, or bitwuzla"
       , numSolvers    :: w ::: Maybe Natural            <?> "Number of solver instances to use (default: number of cpu cores)"
+      , symbolicStart :: w ::: Bool                     <?> "Use symbolic starting state of contract"
       , smtdebug      :: w ::: Bool                     <?> "Print smt queries sent to the solver"
       , debug         :: w ::: Bool                     <?> "Debug printing of internal behaviour, and dump internal expressions"
       , trace         :: w ::: Bool                     <?> "Dump trace"
@@ -619,6 +620,7 @@ unitTestOptions cmd solvers buildOutput = do
     , testParams = params
     , dapp = srcInfo
     , ffiAllowed = cmd.ffi
+    , symbStart = cmd.symbolicStart
     }
 parseInitialStorage :: InitialStorage -> BaseState
 parseInitialStorage Empty = EmptyBase

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1665,7 +1665,7 @@ cheatActions = Map.fromList
           Just a -> assign (#config % #overrideCaller) (Just a)
           Nothing -> vmError (BadCheatCode sig)
         _ -> vmError (BadCheatCode sig)
-          
+
   , action "startPrank(address)" $
       \sig _ _ input -> case decodeStaticArgs 0 1 input of
         [addr]  -> case wordToAddr addr of

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -829,6 +829,13 @@ showModel cd (expr, res) = do
       putStrLn "End State:"
       T.putStrLn $ indent 2 $ formatExpr expr
 
+formatStorage:: Map (Expr EAddr) (Map W256 W256) -> [Text]
+formatStorage store = [ "Storage:" ]  <> (map (indent 2) addrs)
+  where
+    addrs = Map.foldrWithKey (\key val acc ->
+      ("Addr " <> (T.pack . show $ key)
+          <> ": " <> (T.pack $ show (Map.toList val))) : acc
+      ) mempty store
 
 formatCex :: Expr Buf -> Maybe Sig -> SMTCex -> Text
 formatCex cd sig m@(SMTCex _ addrs _ store blockContext txContext) = T.unlines $
@@ -854,13 +861,7 @@ formatCex cd sig m@(SMTCex _ addrs _ store blockContext txContext) = T.unlines $
     storeCex :: [Text]
     storeCex
       | Map.null store = []
-      | otherwise =
-          [ "Storage:"
-          , indent 2 $ T.unlines $ Map.foldrWithKey (\key val acc ->
-              ("Addr " <> (T.pack . show $ key)
-                <> ": " <> (T.pack $ show (Map.toList val))) : acc
-            ) mempty store
-          ]
+      | otherwise = formatStorage store
 
     txCtx :: [Text]
     txCtx

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -266,8 +266,8 @@ symFailure UnitTestOptions {..} testName cd types failures' =
           in Text.pack $ prettyvmresult res
       mkMsg (leaf, cex) = intercalate "\n" $
         ["Counterexample:"
-        ,"  result:   " <> showRes leaf
-        ,"  calldata: " <> let ?context = dappContext (traceContext leaf)
+        ,"  Result:   " <> showRes leaf
+        ,"  Calldata: " <> let ?context = dappContext (traceContext leaf)
                            in prettyCalldata cex cd testName types
         ] <> map (indent 2) (formatStorage cex.store) <> verbText leaf
       verbText leaf = case verbose of


### PR DESCRIPTION
## Description
This is a bit of a crazy thing but maybe not stupid. It allows `--symbolic-start` so that the starting state can be symbolic for "test" runs. I think this is actually quite useful...

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
