### PR TITLE
Add tests for detecting unsatisfiability

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -685,6 +685,16 @@ tests = testGroup "hevm"
           t = [PEq (Var "x") (Lit 1), POr (PEq (Var "x") (Lit 2)) (PEq (Var "x") (Lit 0)), PEq (Var "y") (Lit 2)]
           cannotBeSat = Expr.isUnsat t
         assertEqualM "Must be equal" cannotBeSat True
+    , ignoreTest $ test "disequality-and-equality" $ do
+        let
+          t = [PNeg (PEq (Lit 1) (Var "arg1")), PEq (Lit 1) (Var "arg1")]
+          cannotBeSat = Expr.isUnsat t
+        assertEqualM "Must be equal" cannotBeSat True
+    , test "equality-and-disequality" $ do
+        let
+          t = [PEq (Lit 1) (Var "arg1"), PNeg (PEq (Lit 1) (Var "arg1"))]
+          cannotBeSat = Expr.isUnsat t
+        assertEqualM "Must be equal" cannotBeSat True
   ]
   , testGroup "simpProp-concrete-tests" [
       test "simpProp-concrete-trues" $ do


### PR DESCRIPTION
## Description
Our function for detecting unsatisfiability should be improved.
For example, given an equality and its negation, it now only detects unsatisfiability of equality comes before disequality.
Here we add two tests for this functionality, but one is disabled because it would fail at the moment.
The next goal is to make it pass.
