### PR TITLE
Bump nixpkgs and ethereum tests, use cabal-install from nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,35 +1,18 @@
 {
   "nodes": {
-    "cabal-3-12": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719273538,
-        "narHash": "sha256-/TECd3cdqGDdlEur88H0KbV7jcE/czc0jecj9921T5c=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "260ecdc3d848782d4df49e629cb0a5dc9e96ca9e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "Cabal-v3.12.1.0",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "ethereum-tests": {
       "flake": false,
       "locked": {
-        "lastModified": 1682506704,
-        "narHash": "sha256-PyFZhdUQRUbmohoMS+w41rmSFfKeTO2RqHLetWlU4Jw=",
+        "lastModified": 1695037072,
+        "narHash": "sha256-rza1ecAHCwlmUx2AhtheBdUpTC5ZMbPz8vLZDNsC4E8=",
         "owner": "ethereum",
         "repo": "tests",
-        "rev": "b25623d4d7df10e38498cace7adc7eb413c4b20d",
+        "rev": "661356317ac6df52208d54187e692472a25a01f8",
         "type": "github"
       },
       "original": {
         "owner": "ethereum",
-        "ref": "v12.2",
+        "ref": "v12.4",
         "repo": "tests",
         "type": "github"
       }
@@ -153,11 +136,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1720368505,
-        "narHash": "sha256-5r0pInVo5d6Enti0YwUSQK4TebITypB42bWy5su3MrQ=",
+        "lastModified": 1725194671,
+        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab82a9612aa45284d4adf69ee81871a389669a9e",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
         "type": "github"
       },
       "original": {
@@ -169,7 +152,6 @@
     },
     "root": {
       "inputs": {
-        "cabal-3-12": "cabal-3-12",
         "ethereum-tests": "ethereum-tests",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,8 @@
                 if (with ps.stdenv; hostPlatform.isDarwin && hostPlatform.isx86)
                 then ps.haskell.lib.compose.overrideCabal (_ : { extraLibraries = [ps.libiconv]; }) hprev.with-utf8
                 else hprev.with-utf8;
+              # TODO: temporary fix for static build which is still on 9.4
+              witch = ps.haskell.lib.doJailbreak hprev.witch;
             };
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,11 +15,7 @@
       flake = false;
     };
     ethereum-tests = {
-      url = "github:ethereum/tests/v12.2";
-      flake = false;
-    };
-    cabal-3-12 = {
-      url = "github:haskell/cabal?ref=Cabal-v3.12.1.0";
+      url = "github:ethereum/tests/v12.4";
       flake = false;
     };
     forge-std = {
@@ -32,7 +28,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, solidity, forge-std, ethereum-tests, foundry, cabal-3-12, solc-pkgs, ... }:
+  outputs = { self, nixpkgs, flake-utils, solidity, forge-std, ethereum-tests, foundry, solc-pkgs, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = (import nixpkgs {
@@ -50,21 +46,6 @@
           bitwuzla
           foundry.defaultPackage.${system}
         ];
-
-        # custom package set for cabal 3.12 (has support for `--enable-multi-repl`)
-        cabal-3-12-pkgs = pkgs.haskellPackages.override {
-          overrides = with pkgs.haskell.lib; self: super: rec {
-            cabal-install = dontCheck (self.callCabal2nix "cabal-install" "${cabal-3-12}/cabal-install" {});
-            cabal-install-solver = dontCheck (self.callCabal2nix "cabal-install-solver" "${cabal-3-12}/cabal-install-solver" {});
-            Cabal-described = dontCheck (self.callCabal2nix "Cabal-described" "${cabal-3-12}/Cabal-described" {});
-            Cabal-QuickCheck = dontCheck (self.callCabal2nix "Cabal-QuickCheck" "${cabal-3-12}/Cabal-QuickCheck" {});
-            Cabal-tree-diff = dontCheck (self.callCabal2nix "Cabal-tree-diff" "${cabal-3-12}/Cabal-tree-diff" {});
-            Cabal-syntax = dontCheck (self.callCabal2nix "Cabal-syntax" "${cabal-3-12}/Cabal-syntax" {});
-            Cabal-tests = dontCheck (self.callCabal2nix "Cabal" "${cabal-3-12}/Cabal-tests" {});
-            Cabal = dontCheck (self.callCabal2nix "Cabal" "${cabal-3-12}/Cabal" {});
-            hackage-security = dontCheck (doJailbreak super.hackage-security_0_6_2_6);
-          };
-        };
 
         secp256k1-static = stripDylib (pkgs.secp256k1.overrideAttrs (attrs: {
           configureFlags = attrs.configureFlags ++ [ "--enable-static" ];
@@ -215,7 +196,7 @@
         in haskellPackages.shellFor {
           packages = _: [ (hevmBase pkgs) ];
           buildInputs = [
-            cabal-3-12-pkgs.cabal-install
+            haskellPackages.cabal-install
             mdbook
             yarn
             haskellPackages.eventlog2html


### PR DESCRIPTION
## Description
We can now use cabal-install 3.12 from nix

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
