### PR TITLE
Enforce that LHS are constants for commutative operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `freshAddresses` field in `VMOpts` so that initial fresh address can be given as input
 - Add documentation about limitations and workarounds
 - More verbose error messages in case of symbolic arguments to opcode
+* Tests to enforce that in Expr and Prop, constants are on the LHS whenever possible
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1609,7 +1609,7 @@ concKeccakOnePass orig@(Keccak (CopySlice (Lit 0) (Lit 0) (Lit 64) orig2@(WriteW
     _ -> orig
 concKeccakOnePass x = x
 
-lhsConstHelper ::Expr a -> State Bool (Expr a)
+lhsConstHelper :: Expr a -> State Bool (Expr a)
 lhsConstHelper = go
   where
     go :: Expr a -> State Bool (Expr a)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1613,14 +1613,6 @@ lhsConstHelper :: Expr a -> State Bool (Expr a)
 lhsConstHelper = go
   where
     go :: Expr a -> State Bool (Expr a)
-    go e@(Mul (Lit _) _) = pure e
-    go e@(Add (Lit _) _) = pure e
-    go e@(Min (Lit _) _) = pure e
-    go e@(Max (Lit _) _) = pure e
-    go e@(Eq (Lit _) _)  = pure e
-    go e@(And (Lit _) _) = pure e
-    go e@(Or (Lit _) _)  = pure e
-    go e@(Xor (Lit _) _) = pure e
     go e@(Mul _ (Lit _)) = put False >> pure e
     go e@(Add _ (Lit _)) = put False >> pure e
     go e@(Min _ (Lit _)) = put False >> pure e

--- a/test/test.hs
+++ b/test/test.hs
@@ -3642,7 +3642,7 @@ checkEquivProp = checkEquivBase (\l r -> PNeg (PImpl l r .&& PImpl r l))
 checkEquivPropAndLHS :: App m => Prop -> Prop -> m Bool
 checkEquivPropAndLHS orig simp = do
   let lhsConst = Expr.checkLHSConstProp simp
-  equiv <- checkEquivBase (\l r -> PNeg (PImpl l r .&& PImpl r l)) orig simp
+  equiv <- checkEquivProp orig simp
   pure $ lhsConst && equiv
 
 checkEquiv :: (Typeable a, App m) => Expr a -> Expr a -> m Bool

--- a/test/test.hs
+++ b/test/test.hs
@@ -3651,7 +3651,7 @@ checkEquiv = checkEquivBase (./=)
 checkEquivAndLHS :: (Typeable a, App m) => Expr a -> Expr a -> m Bool
 checkEquivAndLHS orig simp = do
   let lhsConst =  Expr.checkLHSConst simp
-  equiv <- checkEquivBase (./=) orig simp
+  equiv <- checkEquiv orig simp
   pure $ lhsConst && equiv
 
 checkEquivBase :: (Eq a, App m) => (a -> a -> Prop) -> a -> a -> m Bool

--- a/test/test.hs
+++ b/test/test.hs
@@ -3640,7 +3640,7 @@ checkEquivProp :: App m => Prop -> Prop -> m Bool
 checkEquivProp = checkEquivBase (\l r -> PNeg (PImpl l r .&& PImpl r l))
 
 checkEquivPropAndLHS :: App m => Prop -> Prop -> m Bool
-checkEquivPropAndLHS orig simp= do
+checkEquivPropAndLHS orig simp = do
   let lhsConst = Expr.checkLHSConstProp simp
   equiv <- checkEquivBase (\l r -> PNeg (PImpl l r .&& PImpl r l)) orig simp
   pure $ lhsConst && equiv


### PR DESCRIPTION
## Description
This runs a check for LHS being a constant whenever possible on the fuzz-generated `Expr`-s and `Prop`-s

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
