### PR TITLE
Less crazy long ABI fuzz types

### DIFF
--- a/src/EVM/ABI.hs
+++ b/src/EVM/ABI.hs
@@ -547,11 +547,11 @@ genAbiValue = \case
    AbiStringType ->
      AbiString . BS.pack <$> listOf arbitrary
    AbiArrayDynamicType t ->
-     do xs <- listOf1 (scale (`div` 2) (genAbiValue t))
+     do xs <- listOf1 (scale (`div` 3) (genAbiValue t))
         pure (AbiArrayDynamic t (Vector.fromList xs))
    AbiArrayType n t ->
      AbiArray n t . Vector.fromList <$>
-       replicateM n (scale (`div` 2) (genAbiValue t))
+       replicateM n (scale (`div` 3) (genAbiValue t))
    AbiTupleType ts ->
      AbiTuple <$> mapM genAbiValue ts
    AbiFunctionType ->


### PR DESCRIPTION
## Description
This is to mitigate the occasionally long runtimes due to ABI encoding fuzzing:

Related to https://github.com/ethereum/hevm/issues/553

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
