### PR TITLE
Trying to fix multi-threaded test running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `initial-storage` option of `hevm symbolic` is respected
 - `caller` option of `hevm symbolic` is now respected
 * Thanks to the new simplification rules, we can now enable more conformance tests
+* Multi-threaded running of Tracing.hs was not possible due to IO race. Fixed.
 
 ## [0.53.0] - 2024-02-23
 

--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -121,7 +121,7 @@ mkbench c name iters counts = localOption WallTime $ env c (bgroup name . bmarks
 erc20 :: IO ByteString
 erc20 = do
   source <- readFile =<< Paths.getDataFileName "bench/contracts/erc20.sol"
-  Just c <- solcRuntime "ERC20" (T.pack source)
+  Just c <- runApp $ solcRuntime "ERC20" (T.pack source)
   pure c
 
 -- requires solc-0.6.12 to build from source


### PR DESCRIPTION
## Description
This is to make sure we can run `cabal run -f devel test`, i.e. multi-threaded `test` running. However, some tests use file IO (mainly tracing(?)) so they need to be sequential or they fail. This is to speed up testing as per #552 

Unfortunately, 1.5 of Tasty has not come to nix yet, so `sequentialTestGroup` is not yet available: https://hackage.haskell.org/package/tasty Hence using `after`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
