### PR TITLE
SymExec: fix data race for concurrent exploration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `caller` option of `hevm symbolic` is now respected
 * Thanks to the new simplification rules, we can now enable more conformance tests
 * Multi-threaded running of Tracing.hs was not possible due to IO race. Fixed.
+* Fixed multi-threading bug in symbolic interpretation
 
 ## [0.53.0] - 2024-02-23
 


### PR DESCRIPTION
## Description

Fixes the data race due to the sharing of a `vm` instance to both branches of a call to `concurrently` in the symbolic interpreter. The race was caused by the sharing of mutable memory between threads, fixed by copying memory before passing the vm to each branch.

You can check the fix with the following, which should quickly fail on `main`, but run fine on this branch:

```
while cabal run -f devel test -- -p '/access-out-of-bounds-array/'; do :; done
```

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
