### PR TITLE
Fixing capitalization of subState

### DIFF
--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -673,7 +673,7 @@ data FrameContext
     { address         :: Expr EAddr
     , codehash        :: Expr EWord
     , createreversion :: Map (Expr EAddr) Contract
-    , substate        :: SubState
+    , subState        :: SubState
     }
   | CallContext
     { target        :: Expr EAddr
@@ -739,7 +739,7 @@ data TxState = TxState
   , origin      :: Expr EAddr
   , toAddr      :: Expr EAddr
   , value       :: Expr EWord
-  , substate    :: SubState
+  , subState    :: SubState
   , isCreate    :: Bool
   , txReversion :: Map (Expr EAddr) Contract
   }


### PR DESCRIPTION
## Description
It was capitalized in different ways in different places: subState vs substate

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
