### PR TITLE
Cheatcodes as per new std-forge library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More complete and precise array/mapping slot rewrite, along with a copySlice improvement
 - Use a let expression in copySlice to decrease expression size
 - The `--debug` flag now dumps the internal expressions as well
-- hevm now uses the std-forge library's way of detecting failures, i.e. through
-  reverting with a specific error code
+- hevm now uses the forge-std library's way of detecting failures, i.e. through
+  reverting with a specific error code unless --assertion-type DSTest is passed
 
 ## Added
 - More POr and PAnd rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More complete and precise array/mapping slot rewrite, along with a copySlice improvement
 - Use a let expression in copySlice to decrease expression size
 - The `--debug` flag now dumps the internal expressions as well
-- hevm now uses the std-forge library's way of detecting failures, i.e. through
+- hevm now uses the forge-std library's way of detecting failures, i.e. through
   reverting with a specific error code
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More complete and precise array/mapping slot rewrite, along with a copySlice improvement
 - Use a let expression in copySlice to decrease expression size
 - The `--debug` flag now dumps the internal expressions as well
+- hevm now uses the std-forge library's way of detecting failures, i.e. through
+  reverting with a specific error code
 
 ## Added
 - More POr and PAnd rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More complete and precise array/mapping slot rewrite, along with a copySlice improvement
 - Use a let expression in copySlice to decrease expression size
 - The `--debug` flag now dumps the internal expressions as well
-- hevm now uses the forge-std library's way of detecting failures, i.e. through
+- hevm now uses the std-forge library's way of detecting failures, i.e. through
   reverting with a specific error code
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   partial results instead of erroring out
 - Fix interpreter's MCOPY handling so that it doesn't error out on symbolic arguments
 - More desciptive errors in case of a cheatcode issue
+- Better and more pretty debug messages
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing
@@ -65,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Respect --smt-timeout in equivalence checking
 - Fixed the handling of returndata with an abstract size during transaction finalization
 - Error handling for user-facing cli commands is much improved
+- Fixed call signature generation for test cases
 
 ## [0.53.0] - 2024-02-23
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -77,7 +77,7 @@ data Command w
 
   -- symbolic execution opts
       , root          :: w ::: Maybe String       <?> "Path to  project root directory (default: . )"
-      , projectType   :: w ::: Maybe ProjectType  <?> "Is this a Foundry or DappTools project (default: Foundry)"
+      , projectType   :: w ::: Maybe ProjectType  <?> "Is this a CombinedJSON | Foundry | FoundryStdLib project (default: Foundry)"
       , initialStorage :: w ::: Maybe (InitialStorage) <?> "Starting state for storage: Empty, Abstract (default Abstract)"
       , sig           :: w ::: Maybe Text         <?> "Signature of types to decode / encode"
       , arg           :: w ::: [String]           <?> "Values to encode"
@@ -147,11 +147,11 @@ data Command w
       , rpc         :: w ::: Maybe URL         <?> "Fetch state from a remote node"
       , block       :: w ::: Maybe W256        <?> "Block state is be fetched from"
       , root        :: w ::: Maybe String      <?> "Path to  project root directory (default: . )"
-      , projectType :: w ::: Maybe ProjectType <?> "Is this a Foundry or DappTools project (default: Foundry)"
+      , projectType :: w ::: Maybe ProjectType <?> "Is this a CombinedJSON | Foundry | FoundryStdLib project (default: Foundry)"
       }
-  | Test -- Run DSTest unit tests
+  | Test -- Run Foundry unit tests
       { root        :: w ::: Maybe String               <?> "Path to  project root directory (default: . )"
-      , projectType   :: w ::: Maybe ProjectType        <?> "Is this a Foundry or DappTools project (default: Foundry)"
+      , projectType   :: w ::: Maybe ProjectType        <?> "Is this a CombinedJSON | Foundry | FoundryStdLib project (default: Foundry)"
       , rpc           :: w ::: Maybe URL                <?> "Fetch state from a remote node"
       , number        :: w ::: Maybe W256               <?> "Block: number"
       , verbose       :: w ::: Maybe Int                <?> "Append call trace: {1} failures {2} all"

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -47,6 +47,9 @@ import EVM.Types qualified
 import EVM.UnitTest
 import EVM.Effects
 
+data AssertionType = DSTest | Forge
+  deriving (Eq, Show, Read, ParseField)
+
 -- This record defines the program's command-line options
 -- automatically via the `optparse-generic` package.
 data Command w
@@ -77,7 +80,8 @@ data Command w
 
   -- symbolic execution opts
       , root          :: w ::: Maybe String       <?> "Path to  project root directory (default: . )"
-      , projectType   :: w ::: Maybe ProjectType  <?> "Is this a CombinedJSON, Foundry, or DSTest project (default: Foundry)"
+      , projectType   :: w ::: Maybe ProjectType  <?> "Is this a CombinedJSON or Foundry project (default: Foundry)"
+      , assertionType :: w ::: Maybe AssertionType <?> "Assertions as per Forge or DSTest (default: Forge)"
       , initialStorage :: w ::: Maybe (InitialStorage) <?> "Starting state for storage: Empty, Abstract (default Abstract)"
       , sig           :: w ::: Maybe Text         <?> "Signature of types to decode / encode"
       , arg           :: w ::: [String]           <?> "Values to encode"
@@ -147,11 +151,13 @@ data Command w
       , rpc         :: w ::: Maybe URL         <?> "Fetch state from a remote node"
       , block       :: w ::: Maybe W256        <?> "Block state is be fetched from"
       , root        :: w ::: Maybe String      <?> "Path to  project root directory (default: . )"
-      , projectType :: w ::: Maybe ProjectType  <?> "Is this a CombinedJSON, Foundry, or DSTest project (default: Foundry)"
+      , projectType :: w ::: Maybe ProjectType <?> "Is this a CombinedJSON or Foundry project (default: Foundry)"
+      , assertionType :: w ::: Maybe AssertionType <?> "Assertions as per Forge or DSTest (default: Forge)"
       }
   | Test -- Run Foundry unit tests
       { root        :: w ::: Maybe String               <?> "Path to  project root directory (default: . )"
-      , projectType :: w ::: Maybe ProjectType          <?> "Is this a CombinedJSON, Foundry, or DSTest project (default: Foundry)"
+      , projectType   :: w ::: Maybe ProjectType        <?> "Is this a CombinedJSON or Foundry project (default: Foundry)"
+      , assertionType :: w ::: Maybe AssertionType <?> "Assertions as per Forge or DSTest (default: Forge)"
       , rpc           :: w ::: Maybe URL                <?> "Fetch state from a remote node"
       , number        :: w ::: Maybe W256               <?> "Block: number"
       , verbose       :: w ::: Maybe Int                <?> "Append call trace: {1} failures {2} all"
@@ -308,9 +314,7 @@ getSrcInfo cmd = do
     else pure emptyDapp
 
 getProjectType :: Command Options.Unwrapped -> ProjectType
-getProjectType cmd =
-  let pt = fromMaybe Foundry cmd.projectType
-  in if elem pt [Foundry, DSTest] then Foundry else CombinedJSON
+getProjectType cmd = fromMaybe Foundry cmd.projectType
 
 getRoot :: Command Options.Unwrapped -> IO FilePath
 getRoot cmd = maybe getCurrentDirectory makeAbsolute (cmd.root)
@@ -676,7 +680,7 @@ unitTestOptions cmd solvers buildOutput = do
     , testParams = params
     , dapp = srcInfo
     , ffiAllowed = cmd.ffi
-    , checkFailBit = cmd.projectType == Just DSTest
+    , checkFailBit = (fromMaybe Forge cmd.assertionType) == DSTest
     }
 parseInitialStorage :: InitialStorage -> BaseState
 parseInitialStorage Empty = EmptyBase

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -77,7 +77,7 @@ data Command w
 
   -- symbolic execution opts
       , root          :: w ::: Maybe String       <?> "Path to  project root directory (default: . )"
-      , projectType   :: w ::: Maybe ProjectType  <?> "Is this a CombinedJSON | Foundry | FoundryStdLib project (default: Foundry)"
+      , projectType   :: w ::: Maybe ProjectType  <?> "Is this a CombinedJSON or Foundry project (default: Foundry)"
       , initialStorage :: w ::: Maybe (InitialStorage) <?> "Starting state for storage: Empty, Abstract (default Abstract)"
       , sig           :: w ::: Maybe Text         <?> "Signature of types to decode / encode"
       , arg           :: w ::: [String]           <?> "Values to encode"
@@ -147,11 +147,11 @@ data Command w
       , rpc         :: w ::: Maybe URL         <?> "Fetch state from a remote node"
       , block       :: w ::: Maybe W256        <?> "Block state is be fetched from"
       , root        :: w ::: Maybe String      <?> "Path to  project root directory (default: . )"
-      , projectType :: w ::: Maybe ProjectType <?> "Is this a CombinedJSON | Foundry | FoundryStdLib project (default: Foundry)"
+      , projectType :: w ::: Maybe ProjectType <?> "Is this a CombinedJSON or Foundry project (default: Foundry)"
       }
   | Test -- Run Foundry unit tests
       { root        :: w ::: Maybe String               <?> "Path to  project root directory (default: . )"
-      , projectType   :: w ::: Maybe ProjectType        <?> "Is this a CombinedJSON | Foundry | FoundryStdLib project (default: Foundry)"
+      , projectType   :: w ::: Maybe ProjectType        <?> "Is this a CombinedJSON or Foundry project (default: Foundry)"
       , rpc           :: w ::: Maybe URL                <?> "Fetch state from a remote node"
       , number        :: w ::: Maybe W256               <?> "Block: number"
       , verbose       :: w ::: Maybe Int                <?> "Append call trace: {1} failures {2} all"

--- a/doc/src/exec.md
+++ b/doc/src/exec.md
@@ -39,12 +39,10 @@ Available options:
   --block W256             Block state is be fetched from
   --root STRING            Path to project root directory (default: . )
   --project-type PROJECTTYPE
-                           Is this a Foundry or DappTools project (default:
-                           Foundry)
 ```
 
 Minimum required flags: either you must provide `--code` or you must both pass
-`--rpc` and `--address`. 
+`--rpc` and `--address`.
 
 If the execution returns an output, it will be written
 to stdout. Exit code indicates whether the execution was successful or

--- a/doc/src/exec.md
+++ b/doc/src/exec.md
@@ -38,7 +38,7 @@ Available options:
   --rpc TEXT               Fetch state from a remote node
   --block W256             Block state is be fetched from
   --root STRING            Path to project root directory (default: . )
-  --project-type PROJECTTYPE
+  --project-type PROJECTTYPE Foundry or CombinedJSON project
 ```
 
 Minimum required flags: either you must provide `--code` or you must both pass

--- a/doc/src/getting-started.md
+++ b/doc/src/getting-started.md
@@ -28,9 +28,9 @@ be larger than or equal to 100. Let's see the contract and its associated check:
 
 ```solidity
 pragma solidity ^0.8.19;
-import "ds-test/test.sol";
+import "foge-std/Test.sol";
 
-contract MyContract is DSTest {
+contract MyContract is Test {
   mapping (address => uint) balances;
   function prove_add_value(address recv, uint amt) public {
     require(balances[recv] < 100);
@@ -65,9 +65,9 @@ $ chmod +x ./hevm-x86_64-linux
 $ forge init .
 $ cat <<EOF > src/contract.sol
 pragma solidity ^0.8.19;
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract MyContract is DSTest {
+contract MyContract is Test {
   mapping (address => uint) balances;
   function prove_add_value(address recv, uint amt) public {
     require(balances[recv] < 100);

--- a/doc/src/symbolic.md
+++ b/doc/src/symbolic.md
@@ -41,7 +41,7 @@ Available options:
   --rpc TEXT               Fetch state from a remote node
   --block W256             Block state is be fetched from
   --root STRING            Path to project root directory (default: . )
-  --project-type PROJECTTYPE
+  --project-type PROJECTTYPE Foundry or CombinedJSON project
   --initial-storage INITIALSTORAGE
                            Starting state for storage: Empty, Abstract (default
                            Abstract)

--- a/doc/src/symbolic.md
+++ b/doc/src/symbolic.md
@@ -42,8 +42,6 @@ Available options:
   --block W256             Block state is be fetched from
   --root STRING            Path to project root directory (default: . )
   --project-type PROJECTTYPE
-                           Is this a Foundry or DappTools project (default:
-                           Foundry)
   --initial-storage INITIALSTORAGE
                            Starting state for storage: Empty, Abstract (default
                            Abstract)

--- a/doc/src/test.md
+++ b/doc/src/test.md
@@ -14,8 +14,6 @@ Available options:
   -h,--help                Show this help text
   --root STRING            Path to project root directory (default: . )
   --project-type PROJECTTYPE
-                           Is this a Foundry or DappTools project (default:
-                           Foundry)
   --rpc TEXT               Fetch state from a remote node
   --number W256            Block: number
   --verbose INT            Append call trace: {1} failures {2} all

--- a/doc/src/test.md
+++ b/doc/src/test.md
@@ -13,7 +13,7 @@ Usage: hevm test [--root STRING] [--project-type PROJECTTYPE] [--rpc TEXT]
 Available options:
   -h,--help                Show this help text
   --root STRING            Path to project root directory (default: . )
-  --project-type PROJECTTYPE
+  --project-type PROJECTTYPE Foundry or CombinedJSON project
   --rpc TEXT               Fetch state from a remote node
   --number W256            Block: number
   --verbose INT            Append call trace: {1} failures {2} all

--- a/doc/src/when-to-use.md
+++ b/doc/src/when-to-use.md
@@ -26,9 +26,9 @@ bytecode, postconditions need to be explicit. Let's see an example:
 ```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract MyContract is DSTest {
+contract MyContract is Test {
   uint balance;
   function test_overflow(uint amt) public {
     unchecked {
@@ -50,9 +50,9 @@ towards them. Let's see a simple one:
 ```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
-import "ds-test/test.sol";
+import "foge-std/Test.sol";
 
-contract MyContract is DSTest {
+contract MyContract is Test {
   uint balance;
   function prove_multiply(uint amt, uint amt2) public {
     require(amt != 1);

--- a/funding.json
+++ b/funding.json
@@ -1,5 +1,0 @@
-{
-  "opRetro": {
-    "projectId": "0x2c97e213fef2bd3f30a71edf6ed48232640368d0083dc0a134a1b59391639bde"
-  }
-}

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1696,7 +1696,7 @@ cheat gas (inOffset, inSize) (outOffset, outSize) xs = do
     Nothing -> partial $ UnexpectedSymbolicArg vm.state.pc (getOpName vm.state) "symbolic cheatcode selector" (wrap [abi])
     Just (unsafeInto -> abi') ->
       case Map.lookup abi' cheatActions of
-        Nothing -> vmError (BadCheatCode "Cannot understand cheatcode. " abi')
+        Nothing -> vmError (BadCheatCode "Cannot understand cheatcode." abi')
         Just action -> action input
 
 type CheatAction t s = Expr Buf -> EVM t s ()

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2330,7 +2330,7 @@ finishFrame how = do
               push 0
 
             -- Case 3: Error during a call?
-            FrameErrored e -> do
+            FrameErrored _ -> do
               revertContracts
               revertSubstate
               assign (#state % #returndata) mempty
@@ -2377,7 +2377,7 @@ finishFrame how = do
               push 0
 
             -- Case 6: Error during a creation?
-            FrameErrored e -> do
+            FrameErrored _ -> do
               revertContracts
               revertSubstate
               assign (#state % #returndata) mempty

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2382,10 +2382,8 @@ finishFrame how = do
             FrameErrored e -> do
               revertContracts
               revertSubstate
-              if (isInterpretFailure e) then finishFrame (FrameErrored e)
-              else do
-                assign (#state % #returndata) mempty
-                push 0
+              assign (#state % #returndata) mempty
+              push 0
         -- Or were we creating?
         CreationContext _ _ reversion subState' -> do
           creator <- use (#state % #contract)
@@ -2431,10 +2429,8 @@ finishFrame how = do
             FrameErrored e -> do
               revertContracts
               revertSubstate
-              if (isInterpretFailure e) then finishFrame (FrameErrored e)
-              else do
-                assign (#state % #returndata) mempty
-                push 0
+              assign (#state % #returndata) mempty
+              push 0
 
 
 -- * Memory helpers

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2381,10 +2381,10 @@ finishFrame how = do
               push 0
 
             -- Case 3: Error during a call?
-            FrameErrored _ -> do
+            FrameErrored e -> do
               revertContracts
               revertSubstate
-              assign (#state % #returndata) mempty
+              assign (#state % #returndata) (ConcreteBuf (BS8.pack $ show e))
               push 0
         -- Or were we creating?
         CreationContext _ _ reversion subState' -> do

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1995,7 +1995,7 @@ cheatActions = Map.fromList
         CAbi [a, b] -> revertErr a b "!="
         SAbi [ew1, ew2] -> case (Expr.simplify (Expr.eq ew1 ew2)) of
           Lit 0 -> revertErr ew1 ew2 "!="
-          Lit 1 -> doStop
+          Lit _ -> doStop
           ew -> branch ew $ \case
             False ->revertErr ew1 ew2 "!="
             True -> doStop
@@ -2003,13 +2003,13 @@ cheatActions = Map.fromList
     assertNotEq abitype sig input = do
       case decodeBuf [abitype, abitype] input of
         CAbi [a, b] | a /= b -> doStop
-        CAbi [a, b] -> revertErr a b "!="
-        SAbi [ew1, ew2] -> case (Expr.simplify (Expr.iszero $ Expr.eq ew1 ew2)) of
-          Lit 0 -> revertErr ew1 ew2 "!="
-          Lit 1 -> doStop
+        CAbi [a, b] -> revertErr a b "=="
+        SAbi [ew1, ew2] -> case (Expr.simplify (Expr.eq ew1 ew2)) of
+          Lit 1 -> revertErr ew1 ew2 "=="
+          Lit _ -> doStop
           ew -> branch ew $ \case
-            False ->revertErr ew1 ew2 "!="
-            True -> doStop
+            True ->revertErr ew1 ew2 "=="
+            False -> doStop
         abivals -> vmError (BadCheatCode (paramDecodeErr abitype "assertNotEq" abivals) sig)
     assertLt abitype sig input = do
       case decodeBuf [abitype, abitype] input of
@@ -2017,7 +2017,7 @@ cheatActions = Map.fromList
         CAbi [a, b] -> revertErr a b ">="
         SAbi [ew1, ew2] -> case (Expr.simplify (Expr.lt ew1 ew2)) of
           Lit 0 -> revertErr ew1 ew2 ">="
-          Lit 1 -> doStop
+          Lit _ -> doStop
           ew -> branch ew $ \case
             False ->revertErr ew1 ew2 ">="
             True -> doStop
@@ -2028,7 +2028,7 @@ cheatActions = Map.fromList
         CAbi [a, b] -> revertErr a b "<="
         SAbi [ew1, ew2] -> case (Expr.simplify (Expr.gt ew1 ew2)) of
           Lit 0 -> revertErr ew1 ew2 "<="
-          Lit 1 -> doStop
+          Lit _ -> doStop
           ew -> branch ew $ \case
             False ->revertErr ew1 ew2 "<="
             True -> doStop
@@ -2039,7 +2039,7 @@ cheatActions = Map.fromList
         CAbi [a, b] -> revertErr a b ">"
         SAbi [ew1, ew2] -> case (Expr.simplify (Expr.leq ew1 ew2)) of
           Lit 0 -> revertErr ew1 ew2 ">"
-          Lit 1 -> doStop
+          Lit _ -> doStop
           ew -> branch ew $ \case
             False ->revertErr ew1 ew2 ">"
             True -> doStop

--- a/src/EVM/ABI.hs
+++ b/src/EVM/ABI.hs
@@ -58,7 +58,7 @@ module EVM.ABI
   , showAlter
   ) where
 
-import EVM.Expr (readWord, isLitWord)
+import EVM.Expr (readWord, readByte, readBytes, isLitWord)
 import EVM.Types
 
 import Control.Applicative ((<|>))
@@ -71,7 +71,7 @@ import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as BS16
 import Data.ByteString.Char8 qualified as Char8
 import Data.ByteString.Lazy qualified as BSLazy
-import Data.Char (isHexDigit)
+import Data.Char (isHexDigit, chr)
 import Data.Data (Data)
 import Data.DoubleWord (Word256, Int256, signedWord)
 import Data.Functor (($>))
@@ -82,7 +82,7 @@ import Data.Text qualified as Text
 import Data.Text.Encoding (encodeUtf8)
 import Data.Vector (Vector, toList)
 import Data.Vector qualified as Vector
-import Data.Word (Word32)
+import Data.Word (Word32, Word8)
 import GHC.Generics (Generic)
 import Test.QuickCheck hiding ((.&.), label)
 import Numeric (showHex)
@@ -498,7 +498,7 @@ bytesP = do
     Right d -> pure $ ByteStringS d
     Left _ -> pfail
 
-data AbiVals = NoVals | CAbi [AbiValue] | SAbi [Expr EWord]
+data AbiVals = NoVals | CAbi [AbiValue] | SAbi [Expr EWord] | MixAbi ([Expr EWord], AbiValue)
   deriving (Show)
 
 decodeBuf :: [AbiType] -> Expr Buf -> AbiVals
@@ -506,27 +506,57 @@ decodeBuf tps (ConcreteBuf b) =
   case runGetOrFail (getAbiSeq (length tps) tps) (BSLazy.fromStrict b) of
     Right ("", _, args) -> CAbi (toList args)
     _ -> NoVals
-decodeBuf tps buf =
-  if any isDynamic tps then NoVals
-  else
-    let
-      vs = decodeStaticArgs 0 (length tps) buf
-      asBS = mconcat $ fmap word256Bytes (mapMaybe maybeLitWord vs)
-    in if not (all isLitWord vs)
-       then SAbi vs
-       else case runGetOrFail (getAbiSeq (length tps) tps) (BSLazy.fromStrict asBS) of
-         Right ("", _, args) -> CAbi (toList args)
-         _ -> NoVals
-
+decodeBuf tpsOrig bufOrig = go tpsOrig bufOrig 0 NoVals
   where
     isDynamic t = abiKind t == Dynamic
+    go :: [AbiType] -> Expr Buf -> Int -> AbiVals -> AbiVals
+    go [] _ _ ret = ret
+    go [AbiStringType] buf off (SAbi acc) = MixAbi (acc, decodeStringArg off buf)
+    go (x:_) _ _ _ | isDynamic x = internalError "Dynamic type must be last in the list"
+    go (_:tps) buf off (SAbi acc) =
+      let
+        v = readWord (Lit (unsafeInto off)) buf
+      in if not (isLitWord v) then go tps buf (off+32) (SAbi (acc++[v]))
+         else internalError "can't mix Symbolic and Concrete"
+    go (t:tps) buf off (CAbi acc) =
+      let v = readWord (Lit (unsafeInto off)) buf
+          asBS = mconcat $ fmap word256Bytes (mapMaybe maybeLitWord [v])
+      in case runGetOrFail (getAbiSeq 1 [t]) (BSLazy.fromStrict asBS) of
+        Right ("", _, args) -> go tps buf (off+32) $ CAbi (acc++(toList args))
+        _ -> NoVals
+    go _ _ _ _ = internalError "decodeBuf: expected concrete buffer"
+-- decodeBuf tps buf =
+--   let
+--     vs = decodeStaticArgs 0 (length tps) buf
+--     asBS = mconcat $ fmap word256Bytes (mapMaybe maybeLitWord vs)
+--   in if not (all isLitWord vs)
+--      then SAbi vs
+--      else case runGetOrFail (getAbiSeq (length tps) tps) (BSLazy.fromStrict asBS) of
+--        Right ("", _, args) -> CAbi (toList args)
+--        _ -> NoVals
+-- decodeBuf _ _ = internalError "decodeBuf: expected concrete buffer"
 
 decodeStaticArgs :: Int -> Int -> Expr Buf -> [Expr EWord]
 decodeStaticArgs offset numArgs b =
   [readWord (Lit . unsafeInto $ i) b | i <- [offset,(offset+32) .. (offset + (numArgs-1)*32)]]
 
--- QuickCheck instances
+decodeStringArg :: Int -> Expr Buf -> AbiValue
+decodeStringArg offs (ConcreteBuf b) =
+  let len = forceLit $ readBytes 4 (Lit . unsafeInto $ offs) (ConcreteBuf b)
+      str = [readByte (Lit . unsafeInto $ (offs + 4 + (unsafeInto i))) (ConcreteBuf b) | i <- [0..len]]
+      bs = (map toLitByte str)
+  in AbiString $ BS.pack bs
+  where
+    toLitByte :: Expr Byte -> Word8
+    toLitByte (LitByte w) = w
+    toLitByte _ = internalError "String part of calldata should be concrete"
+    forceLit :: Expr EWord -> W256
+    forceLit (Lit w) = w
+    forceLit _ = internalError "String part of calldata should be concrete"
+decodeStringArg _ _  = internalError "decodeStringArg: expected concrete buffer"
 
+-- QuickCheck instances
+--
 genAbiValue :: AbiType -> Gen AbiValue
 genAbiValue = \case
    AbiUIntType n -> AbiUInt n <$> genUInt n

--- a/src/EVM/Dapp.hs
+++ b/src/EVM/Dapp.hs
@@ -100,7 +100,7 @@ mkSig method
   | "check" `isPrefixOf` testname = Just (Sig testname argtypes)
   | otherwise = Nothing
   where
-    testname = method.methodSignature
+    testname = method.name
     argtypes = snd <$> method.inputs
 
 findUnitTests :: Text -> ([SolcContract] -> [(Text, [Sig])])

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -185,7 +185,7 @@ instance Monoid BuildOutput where
   mempty = BuildOutput mempty mempty
 
 -- | The various project types understood by hevm
-data ProjectType = CombinedJSON | Foundry
+data ProjectType = CombinedJSON | Foundry | DSTest
   deriving (Eq, Show, Read, ParseField)
 
 data SourceCache = SourceCache

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -185,7 +185,7 @@ instance Monoid BuildOutput where
   mempty = BuildOutput mempty mempty
 
 -- | The various project types understood by hevm
-data ProjectType = CombinedJSON | Foundry | FoundryStdLib
+data ProjectType = CombinedJSON | Foundry
   deriving (Eq, Show, Read, ParseField)
 
 data SourceCache = SourceCache

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -185,7 +185,7 @@ instance Monoid BuildOutput where
   mempty = BuildOutput mempty mempty
 
 -- | The various project types understood by hevm
-data ProjectType = DappTools | CombinedJSON | Foundry | FoundryStdLib
+data ProjectType = CombinedJSON | Foundry | FoundryStdLib
   deriving (Eq, Show, Read, ParseField)
 
 data SourceCache = SourceCache
@@ -285,13 +285,6 @@ makeSrcMaps = (\case (_, Fe, _) -> Nothing; x -> Just (done x))
 
 -- | Reads all solc output json files found under the provided filepath and returns them merged into a BuildOutput
 readBuildOutput :: App m => FilePath -> ProjectType -> m (Either String BuildOutput)
-readBuildOutput root DappTools = do
-  let outDir = root </> "out"
-  jsons <- liftIO $ findJsonFiles outDir
-  case jsons of
-    [x] -> readSolc DappTools root (outDir </> x)
-    [] -> pure . Left $ "no json files found in: " <> outDir
-    _ -> pure . Left $ "multiple json files found in: " <> outDir
 readBuildOutput root CombinedJSON = do
   let outDir = root </> "out"
   jsons <- liftIO $ findJsonFiles outDir
@@ -413,7 +406,6 @@ force :: String -> Maybe a -> a
 force s = fromMaybe (internalError s)
 
 readJSON :: ProjectType -> Text -> Text -> Maybe (Contracts, Asts, Sources)
-readJSON DappTools _ json = readStdJSON json
 readJSON CombinedJSON _ json = readCombinedJSON json
 readJSON _ contractName json = readFoundryJSON contractName json
 

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -185,7 +185,7 @@ instance Monoid BuildOutput where
   mempty = BuildOutput mempty mempty
 
 -- | The various project types understood by hevm
-data ProjectType = CombinedJSON | Foundry | DSTest
+data ProjectType = CombinedJSON | Foundry
   deriving (Eq, Show, Read, ParseField)
 
 data SourceCache = SourceCache

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -129,10 +129,10 @@ withSolvers solver count threads timeout cont = do
         when (conf.dumpQueries) $ writeSMT2File smt2 fileCounter "abstracted"
         if (isJust fuzzResult)
           then do
-            when (conf.debug) $ putStrLn $ "Cex found via fuzzing:" <> (show fuzzResult)
+            when (conf.debug) $ putStrLn $ "   Cex found via fuzzing:" <> (show fuzzResult)
             writeChan r (Sat $ fromJust fuzzResult)
           else if not conf.onlyCexFuzz then do
-            when (conf.debug) $ putStrLn "Fuzzing failed to find a Cex"
+            when (conf.debug) $ putStrLn "   Fuzzing failed to find a Cex"
             -- reset solver and send all lines of provided script
             out <- sendScript inst (SMT2 ("(reset)" : cmds) mempty mempty ps)
             case out of

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -627,8 +627,10 @@ verify solvers opts preState maybepost = do
         -- Dispatch the remaining branches to the solver to check for violations
         results <- flip mapConcurrently withQueries $ \(query, leaf) -> do
           res <- checkSat solvers query
+          when conf.debug $ putStrLn $ "   SMT result: " <> show res
           pure (res, leaf)
         let cexs = filter (\(res, _) -> not . isUnsat $ res) results
+        when conf.debug $ putStrLn $ "   Found " <> show (length cexs) <> " potential counterexample(s) in call " <> call
         pure $ if Prelude.null cexs then (expr, [Qed ()]) else (expr, fmap toVRes cexs)
   where
     getCallPrefix :: Expr Buf -> String

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -596,16 +596,16 @@ verify
 verify solvers opts preState maybepost = do
   conf <- readConfig
   let call = mconcat ["prefix 0x", getCallPrefix preState.state.calldata]
-  when conf.debug $ liftIO $ putStrLn $ "Exploring call " <> call
+  when conf.debug $ liftIO $ putStrLn $ "   Exploring call " <> call
 
   exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.maxIter opts.askSmtIters opts.loopHeuristic preState runExpr
   when conf.dumpExprs $ liftIO $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
   liftIO $ do
-    when conf.debug $ putStrLn "Simplifying expression"
+    when conf.debug $ putStrLn "   Simplifying expression"
     let expr = if opts.simp then (Expr.simplify exprInter) else exprInter
     when conf.dumpExprs $ T.writeFile "simplified.expr" (formatExpr expr)
 
-    when conf.debug $ putStrLn $ "Exploration finished, " <> show (Expr.numBranches expr) <> " branch(es) to check in call " <> call
+    when conf.debug $ putStrLn $ "   Exploration finished, " <> show (Expr.numBranches expr) <> " branch(es) to check in call " <> call
 
     let flattened = flattenExpr expr
     when (any isPartial flattened) $ do

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -550,17 +550,6 @@ data EvmError
   | NonexistentFork Int
   deriving (Show, Eq, Ord)
 
-isInterpretFailure :: EvmError -> Bool
-isInterpretFailure = \case
-  (BadCheatCode {}) -> True
-  (NonexistentFork {}) -> True
-  _ -> False
-
-isInterpretFailEnd :: Expr a -> Bool
-isInterpretFailEnd = \case
-  (Failure _ _ k) -> isInterpretFailure k
-  _ -> False
-
 evmErrToString :: EvmError -> String
 evmErrToString = \case
   -- NOTE: error text made to closely match go-ethereum's errors.go file

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -550,6 +550,46 @@ data EvmError
   | NonexistentFork Int
   deriving (Show, Eq, Ord)
 
+isInterpretFailure :: EvmError -> Bool
+isInterpretFailure = \case
+  (BadCheatCode {}) -> True
+  (NonexistentFork {}) -> True
+  PrecompileFailure -> True
+  StateChangeWhileStatic -> True
+  UnrecognizedOpcode _ -> True
+  _ -> False
+
+isInterpretFailEnd :: Expr a -> Bool
+isInterpretFailEnd = \case
+  (Failure _ _ k) -> isInterpretFailure k
+  _ -> False
+
+evmErrToString :: EvmError -> String
+evmErrToString = \case
+  -- NOTE: error text made to closely match go-ethereum's errors.go file
+  OutOfGas {}             -> "Out of gas"
+  -- TODO "contract creation code storage out of gas" not handled
+  CallDepthLimitReached   -> "Max call depth exceeded"
+  BalanceTooLow {}        -> "Insufficient balance for transfer"
+  -- TODO "contract address collision" not handled
+  Revert {}               -> "Execution reverted"
+  -- TODO "max initcode size exceeded" not handled
+  MaxCodeSizeExceeded {}  -> "Max code size exceeded"
+  BadJumpDestination      -> "Invalid jump destination"
+  StateChangeWhileStatic  -> "Attempting to modify state while in static context"
+  ReturnDataOutOfBounds   -> "Return data out of bounds"
+  IllegalOverflow         -> "Gas uint64 overflow"
+  UnrecognizedOpcode op   -> "Invalid opcode: 0x" <> showHex op ""
+  NonceOverflow           -> "Nonce uint64 overflow"
+  StackUnderrun           -> "Stack underflow"
+  StackLimitExceeded      -> "Stack limit reached"
+  InvalidMemoryAccess     -> "Write protection"
+  (BadCheatCode err fun)  -> err <> " Cheatcode function selector: " <> show fun
+  NonexistentFork fork    -> "Nonexistent fork: " <> show fork
+  PrecompileFailure       -> "Precompile failure"
+  err                     -> "hevm error: " <> show err
+
+
 -- | Sometimes we can only partially execute a given program
 data PartialExec
   = UnexpectedSymbolicArg { pc :: Int, opcode :: String, msg  :: String, args  :: [SomeExpr] }

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -554,9 +554,6 @@ isInterpretFailure :: EvmError -> Bool
 isInterpretFailure = \case
   (BadCheatCode {}) -> True
   (NonexistentFork {}) -> True
-  PrecompileFailure -> True
-  StateChangeWhileStatic -> True
-  UnrecognizedOpcode _ -> True
   _ -> False
 
 isInterpretFailEnd :: Expr a -> Bool

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -227,11 +227,16 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
     -- check postconditions against vm
     (e, results) <- verify solvers (makeVeriOpts opts) (symbolify vm') (Just postcondition)
     let allReverts = not . (any Expr.isSuccess) . flattenExpr $ e
-    let fails = filter (Expr.isFailure) $ flattenExpr e
-    unless (null fails) $ liftIO $ do
+    let interpFails = filter (isInterpretFailEnd) $ flattenExpr e
+
+    conf <- readConfig
+    when conf.debug $ liftIO $ forM_ (filter Expr.isFailure (flattenExpr e)) $ \case
+      (Failure _ _ a) ->  putStrLn $ "   -> debug of func: " <> Text.unpack testName <> " Failure at the end of expr: " <> show a;
+      _ -> internalError "cannot be, filtered for failure"
+    unless (null interpFails) $ liftIO $ do
       putStrLn $ "      \x1b[33mWARNING\x1b[0m: hevm was only able to partially explore the test " <> Text.unpack testName <> " due to: ";
-      forM_ (fails) $ \case
-        (Failure _ _ err) -> putStrLn $ "      -> " <> show err
+      forM_ (interpFails) $ \case
+        (Failure _ _ f) -> putStrLn $ "      -> " <> evmErrToString f
         _ -> internalError "unexpected failure"
     when (any isUnknown results || any isError results) $ liftIO $ do
       putStrLn $ "      \x1b[33mWARNING\x1b[0m: hevm was only able to partially explore the test " <> Text.unpack testName <> " due to: ";

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -15,13 +15,13 @@ import EVM.FeeSchedule (feeSchedule)
 import EVM.Fetch qualified as Fetch
 import EVM.Format
 import EVM.Solidity
-import EVM.SymExec (defaultVeriOpts, symCalldata, verify, isQed, extractCex, runExpr, prettyCalldata, panicMsg, VeriOpts(..), flattenExpr, isUnknown, isError, groupIssues)
+import EVM.SymExec (defaultVeriOpts, symCalldata, verify, isQed, extractCex, prettyCalldata, panicMsg, VeriOpts(..), flattenExpr, isUnknown, isError, groupIssues)
 import EVM.Types
 import EVM.Transaction (initTx)
 import EVM.Stepper (Stepper)
 import EVM.Stepper qualified as Stepper
 
-import Control.Monad (void, when, forM, forM_, unless)
+import Control.Monad (void, when, forM, forM_)
 import Control.Monad.ST (RealWorld, ST, stToIO)
 import Control.Monad.State.Strict (execState, get, put, liftIO)
 import Optics.Core

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -275,7 +275,7 @@ symFailure UnitTestOptions {..} testName cd types failures' =
       showRes = \case
         Success _ _ _ _ -> if "proveFail" `isPrefixOf` testName
                            then "Successful execution"
-                           else "Failed: DSTest Assertion Violation"
+                           else "Failed: Test Assertion Violation"
         res ->
           let ?context = dappContext (traceContext res)
           in Text.pack $ prettyvmresult res

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -210,9 +210,8 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
             Success _ _ _ store -> PNeg (failed store)
             Failure _ _ (Revert msg) -> case msg of
               ConcreteBuf b -> do
-                if (BS.isPrefixOf (BS.pack "assert failed") b) ||
-                  b == panicMsg 0x01 then PBool True
-                else PBool False
+                if (BS.isPrefixOf (BS.pack "assert failed") b) || b == panicMsg 0x01 then PBool False
+                else PBool True
               b -> b ./= ConcreteBuf (panicMsg 0x01)
             Failure _ _ _ -> PBool True
             Partial _ _ _ -> PBool True

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -204,13 +204,13 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
           Nothing -> And (readStorage' (Lit 0) (testContract store).storage) (Lit 2) .== Lit 2
         postcondition = curry $ case shouldFail of
           True -> \(_, post) -> case post of
-                                  Success _ _ _ store -> failed store
-                                  _ -> PBool True
+            Success _ _ _ store -> failed store
+            _ -> PBool True
           False -> \(_, post) -> case post of
             Success _ _ _ store -> PNeg (failed store)
             Failure _ _ (Revert msg) -> case msg of
-              ConcreteBuf b -> do
-                if (BS.isPrefixOf (BS.pack "assert failed") b) || b == panicMsg 0x01 then PBool False
+              ConcreteBuf b ->
+                if (BS.isPrefixOf (selector "Error(string)") b) || b == panicMsg 0x01 then PBool False
                 else PBool True
               b -> b ./= ConcreteBuf (panicMsg 0x01)
             Failure _ _ _ -> PBool True

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -513,26 +513,7 @@ vmtrace vm =
              }
   where
     readoutError :: Maybe (VMResult t s) -> Maybe String
-    readoutError (Just (VMFailure e)) = case e of
-      -- NOTE: error text made to closely match go-ethereum's errors.go file
-      OutOfGas {}             -> Just "out of gas"
-      -- TODO "contract creation code storage out of gas" not handled
-      CallDepthLimitReached   -> Just "max call depth exceeded"
-      BalanceTooLow {}        -> Just "insufficient balance for transfer"
-      -- TODO "contract address collision" not handled
-      Revert {}           -> Just "execution reverted"
-      -- TODO "max initcode size exceeded" not handled
-      MaxCodeSizeExceeded {}  -> Just "max code size exceeded"
-      BadJumpDestination  -> Just "invalid jump destination"
-      StateChangeWhileStatic  -> Just "write protection"
-      ReturnDataOutOfBounds   -> Just "return data out of bounds"
-      IllegalOverflow     -> Just "gas uint64 overflow"
-      UnrecognizedOpcode op   -> Just $ "invalid opcode: 0x" <> showHex op ""
-      NonceOverflow       -> Just "nonce uint64 overflow"
-      StackUnderrun       -> Just "stack underflow"
-      StackLimitExceeded  -> Just "stack limit reached"
-      InvalidMemoryAccess -> Just "write protection"
-      err                     -> Just $ "HEVM error: " <> show err
+    readoutError (Just (VMFailure e)) = Just $ evmErrToString e
     readoutError _ = Nothing
 
 vmres :: VM Concrete s -> VMTraceResult

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -84,7 +84,7 @@ callProcessCwd cmd args cwd = do
 
 compile :: App m => ProjectType -> FilePath -> FilePath -> m (Either String BuildOutput)
 compile CombinedJSON _root _src = internalError  "unsupported compile type: CombinedJSON"
-compile foundryType root src = do
+compile Foundry root src = do
   liftIO $ createDirectory (root </> "src")
   liftIO $ writeFile (root </> "src" </> "unit-tests.t.sol") =<< readFile =<< Paths.getDataFileName src
   liftIO $ initLib (root </> "lib" </> "tokens") ("test" </> "contracts" </> "lib" </> "erc20.sol") "erc20.sol"

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -59,6 +59,7 @@ testOpts solvers root buildOutput match maxIter allowFFI rpcinfo = do
     , testParams = params
     , dapp = srcInfo
     , ffiAllowed = allowFFI
+    , checkFailBit = False
     }
 
 processFailedException :: String -> String -> [String] -> Int -> IO a
@@ -78,7 +79,7 @@ callProcessCwd cmd args cwd = do
 
 compile :: App m => ProjectType -> FilePath -> FilePath -> m (Either String BuildOutput)
 compile CombinedJSON _root _src = internalError  "unsupported compile type: CombinedJSON"
-compile Foundry root src = do
+compile _ root src = do
   liftIO $ createDirectory (root </> "src")
   liftIO $ writeFile (root </> "src" </> "unit-tests.t.sol") =<< readFile =<< Paths.getDataFileName src
   liftIO $ initLib (root </> "lib" </> "tokens") ("test" </> "contracts" </> "lib" </> "erc20.sol") "erc20.sol"

--- a/test/contracts/fail/check-prefix.sol
+++ b/test/contracts/fail/check-prefix.sol
@@ -1,6 +1,6 @@
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract SolidityTest is DSTest {
+contract SolidityTest is Test {
 
     function setUp() public {
     }

--- a/test/contracts/fail/dsProveFail.sol
+++ b/test/contracts/fail/dsProveFail.sol
@@ -1,7 +1,7 @@
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "tokens/erc20.sol";
 
-contract SolidityTest is DSTest {
+contract SolidityTest is Test {
     ERC20 token;
 
     function setUp() public {

--- a/test/contracts/fail/trivial.sol
+++ b/test/contracts/fail/trivial.sol
@@ -1,7 +1,7 @@
-import {DSTest} from "ds-test/test.sol";
+import {Test} from "forge-std/Test.sol";
 
 // should run and pass
-contract Trivial is DSTest {
+contract Trivial is Test {
     function prove_false() public {
         assertTrue(false);
     }

--- a/test/contracts/pass/abstract.sol
+++ b/test/contracts/pass/abstract.sol
@@ -1,7 +1,7 @@
-import {DSTest} from "ds-test/test.sol";
+import {Test} from "forge-std/Test.sol";
 
 // should not be run (no code)
-abstract contract MyTest is DSTest {
+abstract contract MyTest is Test {
     function testAbstract() public {
         assertTrue(true);
     }

--- a/test/contracts/pass/cheatCodes.sol
+++ b/test/contracts/pass/cheatCodes.sol
@@ -52,6 +52,8 @@ contract Empty {}
 
 contract CheatCodes is Test {
     address store = address(new HasStorage());
+    address constant HEVM_ADDRESS =
+        address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
     Hevm hevm = Hevm(HEVM_ADDRESS);
 
     function prove_warp_concrete() public {

--- a/test/contracts/pass/cheatCodes.sol
+++ b/test/contracts/pass/cheatCodes.sol
@@ -1,6 +1,6 @@
 pragma experimental ABIEncoderV2;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
 interface Hevm {
     function warp(uint256) external;
@@ -50,7 +50,7 @@ contract Payable {
 
 contract Empty {}
 
-contract CheatCodes is DSTest {
+contract CheatCodes is Test {
     address store = address(new HasStorage());
     Hevm hevm = Hevm(HEVM_ADDRESS);
 

--- a/test/contracts/pass/cheatCodesFork.sol
+++ b/test/contracts/pass/cheatCodesFork.sol
@@ -1,6 +1,6 @@
 pragma experimental ABIEncoderV2;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
 interface Hevm {
     function warp(uint256) external;
@@ -28,7 +28,9 @@ contract TestState {
 }
 
 /// @dev This contract's state should be persistent across forks, because it's the contract calling `selectFork`
-contract CheatCodesForkDeployee is DSTest {
+contract CheatCodesForkDeployee is Test {
+    address constant HEVM_ADDRESS =
+        address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
     Hevm hevm = Hevm(HEVM_ADDRESS);
     address stateContract;
     uint256 forkId1;
@@ -91,7 +93,7 @@ contract CheatCodesForkDeployee is DSTest {
 /// @dev This contract's state should be persistent across forks, because it's the `msg.sender` when running `deployee_prove_ForkedState`.
 ///  We need this "deployer/deployee" architecture so that `msg.sender` will be concrete when running `deployee_prove_ForkedState`.
 ///  If we were to only use the `CheatCodesForkDeployee` contract, the `msg.sender` would be abstract.
-contract CheatCodesFork is DSTest {
+contract CheatCodesFork is Test {
   CheatCodesForkDeployee testContract = new CheatCodesForkDeployee();
   function prove_ForkedState() external {
     testContract.deployee_prove_ForkedState();

--- a/test/contracts/pass/constantinople.sol
+++ b/test/contracts/pass/constantinople.sol
@@ -1,10 +1,10 @@
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
 contract DeadCode{
     function dummy() external returns (uint256) {}
 }
 
-contract ConstantinopleTests is DSTest {
+contract ConstantinopleTests is Test {
     DeadCode notmuch;
     function setUp() public {
       notmuch = new DeadCode();

--- a/test/contracts/pass/constantinople_min.sol
+++ b/test/contracts/pass/constantinople_min.sol
@@ -1,10 +1,10 @@
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
 contract DeadCode{
     function dummy() external returns (uint256) {}
 }
 
-contract ConstantinopleTests is DSTest {
+contract ConstantinopleTests is Test {
     DeadCode notmuch;
     function setUp() public {
       notmuch = new DeadCode();

--- a/test/contracts/pass/dsProvePass.sol
+++ b/test/contracts/pass/dsProvePass.sol
@@ -1,4 +1,4 @@
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import "tokens/erc20.sol";
 
 contract ConstructorArg {
@@ -8,7 +8,7 @@ contract ConstructorArg {
     }
 }
 
-contract SolidityTest is DSTest {
+contract SolidityTest is Test {
     ERC20 token;
 
     function setUp() public {

--- a/test/contracts/pass/loops.sol
+++ b/test/contracts/pass/loops.sol
@@ -1,6 +1,6 @@
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 
-contract Loops is DSTest {
+contract Loops is Test {
 
     function prove_loop(uint n) public {
         uint counter = 0;

--- a/test/contracts/pass/rpc.sol
+++ b/test/contracts/pass/rpc.sol
@@ -1,7 +1,9 @@
-import {DSTest} from "ds-test/test.sol";
+pragma solidity ^0.8.19;
+
+import {Test} from "forge-std/Test.sol";
 import {ERC20} from "tokens/erc20.sol";
 
-contract C is DSTest {
+contract C is Test {
     // BAL: https://etherscan.io/address/0xba100000625a3754423978a60c9317c58a424e3D#code
     ERC20 bal = ERC20(0xba100000625a3754423978a60c9317c58a424e3D);
 

--- a/test/contracts/pass/transfer.sol
+++ b/test/contracts/pass/transfer.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.8.19;
 
-import "ds-test/test.sol";
+import "forge-std/Test.sol";
 import {ERC20} from "tokens/erc20.sol";
 
-contract SolidityTestFail2 is DSTest {
+contract SolidityTestFail2 is Test {
     ERC20 token;
 
     function setUp() public {
@@ -11,6 +11,7 @@ contract SolidityTestFail2 is DSTest {
     }
 
     function prove_transfer(uint supply, address usr, uint amt) public {
+        // require(supply >= amt, "supply must be greater than or equal to amt");
         token.mint(address(this), supply);
 
         uint prebal = token.balanceOf(usr);
@@ -20,7 +21,7 @@ contract SolidityTestFail2 is DSTest {
         uint expected = usr == address(this)
                         ? 0    // self transfer is a noop
                         : amt; // otherwise `amt` has been transferred to `usr`
-        assert(expected == postbal - prebal);
+        assertTrue(expected == postbal - prebal);
     }
 }
 

--- a/test/contracts/pass/trivial.sol
+++ b/test/contracts/pass/trivial.sol
@@ -1,7 +1,7 @@
-import {DSTest} from "ds-test/test.sol";
+import {Test} from "forge-std/Test.sol";
 
 // should run and pass
-contract Trivial is DSTest {
+contract Trivial is Test {
     function prove_true() public {
         assertTrue(true);
     }

--- a/test/contracts/pass/unwind.sol
+++ b/test/contracts/pass/unwind.sol
@@ -1,7 +1,7 @@
-import {DSTest} from "ds-test/test.sol";
+import {Test} from "forge-std/Test.sol";
 
 // tests unwind support in precompiles
-contract Unwind is DSTest {
+contract Unwind is Test {
     function prove_invalid_sum() public {
         bytes32 x = hex"01";
         try this.callBn256Add(x, x, x, x) returns (bytes32[2] memory) {

--- a/test/test.hs
+++ b/test/test.hs
@@ -78,7 +78,7 @@ testEnv = Env { config = defaultConfig {
   dumpQueries = False
   , dumpExprs = False
   , dumpEndStates = False
-  , debug = False
+  , debug = True
   , abstRefineArith = False
   , abstRefineMem   = False
   , dumpTrace = False
@@ -1436,8 +1436,8 @@ tests = testGroup "hevm"
     [ test "Trivial-Pass" $ do
         let testFile = "test/contracts/pass/trivial.sol"
         runSolidityTest testFile ".*" >>= assertEqualM "test result" True
-    , test "DappTools" $ do
-        -- quick smokecheck to make sure that we can parse dapptools style build outputs
+    , test "Foundry" $ do
+        -- quick smokecheck to make sure that we can parse ForgeStdLib style build outputs
         let cases =
               [ ("test/contracts/pass/trivial.sol", ".*", True)
               , ("test/contracts/pass/dsProvePass.sol", "proveEasy", True)
@@ -1445,7 +1445,7 @@ tests = testGroup "hevm"
               , ("test/contracts/fail/dsProveFail.sol", "prove_add", False)
               ]
         results <- forM cases $ \(testFile, match, expected) -> do
-          actual <- runSolidityTestCustom testFile match Nothing Nothing False Nothing DappTools
+          actual <- runSolidityTestCustom testFile match Nothing Nothing False Nothing FoundryStdLib
           pure (actual == expected)
         assertBoolM "test result" (and results)
     , test "Trivial-Fail" $ do
@@ -1474,17 +1474,17 @@ tests = testGroup "hevm"
         runSolidityTestCustom testFile "prove_BadVault_usingExploitLaunchPad"  Nothing Nothing True Nothing FoundryStdLib >>= assertEqualM "Must find counterexample" False
     , test "Prove-Tests-Fail" $ do
         let testFile = "test/contracts/fail/dsProveFail.sol"
-        runSolidityTest testFile "prove_trivial" >>= assertEqualM "test result" False
+        -- runSolidityTest testFile "prove_trivial" >>= assertEqualM "test result" False
         runSolidityTest testFile "prove_trivial_dstest" >>= assertEqualM "test result" False
-        runSolidityTest testFile "prove_add" >>= assertEqualM "test result" False
-        runSolidityTestCustom testFile "prove_smtTimeout" (Just 1) Nothing False Nothing FoundryStdLib >>= assertEqualM "test result" False
-        runSolidityTest testFile "prove_multi" >>= assertEqualM "test result" False
+        -- runSolidityTest testFile "prove_add" >>= assertEqualM "test result" False
+        -- runSolidityTestCustom testFile "prove_smtTimeout" (Just 1) Nothing False Nothing FoundryStdLib >>= assertEqualM "test result" False
+        -- runSolidityTest testFile "prove_multi" >>= assertEqualM "test result" False
         -- TODO: implement overflow checking optimizations and enable, currently this runs forever
         --runSolidityTest testFile "prove_distributivity" >>= assertEqualM "test result" False
     , test "Loop-Tests" $ do
         let testFile = "test/contracts/pass/loops.sol"
-        runSolidityTestCustom testFile "prove_loop" Nothing (Just 10) False Nothing Foundry >>= assertEqualM "test result" True
-        runSolidityTestCustom testFile "prove_loop" Nothing (Just 100) False Nothing Foundry >>= assertEqualM "test result" False
+        runSolidityTestCustom testFile "prove_loop" Nothing (Just 10) False Nothing FoundryStdLib  >>= assertEqualM "test result" True
+        runSolidityTestCustom testFile "prove_loop" Nothing (Just 100) False Nothing FoundryStdLib >>= assertEqualM "test result" False
     , test "Cheat-Codes-Pass" $ do
         let testFile = "test/contracts/pass/cheatCodes.sol"
         runSolidityTest testFile ".*" >>= assertEqualM "test result" True

--- a/test/test.hs
+++ b/test/test.hs
@@ -1562,6 +1562,28 @@ tests = testGroup "hevm"
         (e, [Qed _]) <- withDefaultSolver $
           \s -> checkAssert s defaultPanicCodes c sig [] opts
         assertBoolM "The expression is not partial" $ Expr.containsNode isPartial e
+    , test "mem-tuple" $ do
+        Just c <- solcRuntime "C"
+          [i|
+            contract C {
+              struct Pair {
+                uint x;
+                uint y;
+              }
+              function prove_tuple_pass(Pair memory p) public pure {
+                uint256 f = p.x;
+                uint256 g = p.y;
+                unchecked {
+                  p.x+=p.y;
+                  assert(p.x == (f + g));
+                }
+              }
+            }
+          |]
+        let opts = defaultVeriOpts
+        let sig = Nothing
+        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] opts
+        putStrLnM "Qed, memory tuple is good"
     , test "symbolic-loops-not-reached" $ do
         Just c <- solcRuntime "C"
             [i|

--- a/test/test.hs
+++ b/test/test.hs
@@ -1477,7 +1477,7 @@ tests = testGroup "hevm"
         runSolidityTest testFile "prove_trivial" >>= assertEqualM "test result" False
         runSolidityTest testFile "prove_trivial_dstest" >>= assertEqualM "test result" False
         runSolidityTest testFile "prove_add" >>= assertEqualM "test result" False
-        runSolidityTestCustom testFile "prove_smtTimeout" (Just 1) Nothing False Nothing Foundry >>= assertEqualM "test result" False
+        runSolidityTestCustom testFile "prove_smtTimeout" (Just 1) Nothing False Nothing FoundryStdLib >>= assertEqualM "test result" False
         runSolidityTest testFile "prove_multi" >>= assertEqualM "test result" False
         -- TODO: implement overflow checking optimizations and enable, currently this runs forever
         --runSolidityTest testFile "prove_distributivity" >>= assertEqualM "test result" False

--- a/test/test.hs
+++ b/test/test.hs
@@ -1768,7 +1768,7 @@ tests = testGroup "hevm"
           check coinbase (SymAddr "coinbase")
           check a (SymAddr "freshSymAddr1")
           check arg (SymAddr "arg1")
-    , test "vm.load fails for a potentially aliased address" $ do
+    , ignoreTest $ test "vm.load fails for a potentially aliased address" $ do
         Just c <- solcRuntime "C"
           [i|
             interface Vm {
@@ -1784,7 +1784,7 @@ tests = testGroup "hevm"
         (_, [Cex _]) <- withDefaultSolver $ \s ->
           verifyContract s c Nothing [] defaultVeriOpts Nothing (Just $ checkBadCheatCode "load(address,bytes32)")
         pure ()
-    , test "vm.store fails for a potentially aliased address" $ do
+    , ignoreTest $ test "vm.store fails for a potentially aliased address" $ do
         Just c <- solcRuntime "C"
           [i|
             interface Vm {

--- a/test/test.hs
+++ b/test/test.hs
@@ -1581,7 +1581,7 @@ tests = testGroup "hevm"
             }
           |]
         let opts = defaultVeriOpts
-        let sig = Nothing
+        let sig = Just $ Sig "prove_tuple_pass((uint256,uint256))" [AbiTupleType (V.fromList [AbiUIntType 256, AbiUIntType 256])]
         (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] opts
         putStrLnM "Qed, memory tuple is good"
     , test "symbolic-loops-not-reached" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -1768,7 +1768,7 @@ tests = testGroup "hevm"
           check coinbase (SymAddr "coinbase")
           check a (SymAddr "freshSymAddr1")
           check arg (SymAddr "arg1")
-    , ignoreTest $ test "vm.load fails for a potentially aliased address" $ do
+    , test "vm.load fails for a potentially aliased address" $ do
         Just c <- solcRuntime "C"
           [i|
             interface Vm {
@@ -1784,7 +1784,7 @@ tests = testGroup "hevm"
         (_, [Cex _]) <- withDefaultSolver $ \s ->
           verifyContract s c Nothing [] defaultVeriOpts Nothing (Just $ checkBadCheatCode "load(address,bytes32)")
         pure ()
-    , ignoreTest $ test "vm.store fails for a potentially aliased address" $ do
+    , test "vm.store fails for a potentially aliased address" $ do
         Just c <- solcRuntime "C"
           [i|
             interface Vm {

--- a/test/test.hs
+++ b/test/test.hs
@@ -78,7 +78,7 @@ testEnv = Env { config = defaultConfig {
   dumpQueries = False
   , dumpExprs = False
   , dumpEndStates = False
-  , debug = True
+  , debug = False
   , abstRefineArith = False
   , abstRefineMem   = False
   , dumpTrace = False
@@ -1445,7 +1445,7 @@ tests = testGroup "hevm"
               , ("test/contracts/fail/dsProveFail.sol", "prove_add", False)
               ]
         results <- forM cases $ \(testFile, match, expected) -> do
-          actual <- runSolidityTestCustom testFile match Nothing Nothing False Nothing FoundryStdLib
+          actual <- runSolidityTestCustom testFile match Nothing Nothing False Nothing Foundry
           pure (actual == expected)
         assertBoolM "test result" (and results)
     , test "Trivial-Fail" $ do
@@ -1471,20 +1471,19 @@ tests = testGroup "hevm"
         runSolidityTest testFile "prove_transfer" >>= assertEqualM "should prove transfer" True
     , test "badvault-sym-branch" $ do
         let testFile = "test/contracts/fail/10_BadVault.sol"
-        runSolidityTestCustom testFile "prove_BadVault_usingExploitLaunchPad"  Nothing Nothing True Nothing FoundryStdLib >>= assertEqualM "Must find counterexample" False
+        runSolidityTestCustom testFile "prove_BadVault_usingExploitLaunchPad"  Nothing Nothing True Nothing Foundry >>= assertEqualM "Must find counterexample" False
     , test "Prove-Tests-Fail" $ do
         let testFile = "test/contracts/fail/dsProveFail.sol"
-        -- runSolidityTest testFile "prove_trivial" >>= assertEqualM "test result" False
+        runSolidityTest testFile "prove_trivial" >>= assertEqualM "test result" False
         runSolidityTest testFile "prove_trivial_dstest" >>= assertEqualM "test result" False
-        -- runSolidityTest testFile "prove_add" >>= assertEqualM "test result" False
-        -- runSolidityTestCustom testFile "prove_smtTimeout" (Just 1) Nothing False Nothing FoundryStdLib >>= assertEqualM "test result" False
-        -- runSolidityTest testFile "prove_multi" >>= assertEqualM "test result" False
-        -- TODO: implement overflow checking optimizations and enable, currently this runs forever
-        --runSolidityTest testFile "prove_distributivity" >>= assertEqualM "test result" False
+        runSolidityTest testFile "prove_add" >>= assertEqualM "test result" False
+        runSolidityTestCustom testFile "prove_smtTimeout" (Just 1) Nothing False Nothing Foundry >>= assertEqualM "test result" False
+        runSolidityTest testFile "prove_multi" >>= assertEqualM "test result" False
+        runSolidityTest testFile "prove_distributivity" >>= assertEqualM "test result" False
     , test "Loop-Tests" $ do
         let testFile = "test/contracts/pass/loops.sol"
-        runSolidityTestCustom testFile "prove_loop" Nothing (Just 10) False Nothing FoundryStdLib  >>= assertEqualM "test result" True
-        runSolidityTestCustom testFile "prove_loop" Nothing (Just 100) False Nothing FoundryStdLib >>= assertEqualM "test result" False
+        runSolidityTestCustom testFile "prove_loop" Nothing (Just 10) False Nothing Foundry  >>= assertEqualM "test result" True
+        runSolidityTestCustom testFile "prove_loop" Nothing (Just 100) False Nothing Foundry >>= assertEqualM "test result" False
     , test "Cheat-Codes-Pass" $ do
         let testFile = "test/contracts/pass/cheatCodes.sol"
         runSolidityTest testFile ".*" >>= assertEqualM "test result" True

--- a/test/test.hs
+++ b/test/test.hs
@@ -1781,6 +1781,7 @@ tests = testGroup "hevm"
               }
             }
           |]
+        -- NOTE: we have a postcondition here, not just a regular verification
         (_, [Cex _]) <- withDefaultSolver $ \s ->
           verifyContract s c Nothing [] defaultVeriOpts Nothing (Just $ checkBadCheatCode "load(address,bytes32)")
         pure ()
@@ -1797,6 +1798,7 @@ tests = testGroup "hevm"
               }
             }
           |]
+        -- NOTE: we have a postcondition here, not just a regular verification
         (_, [Cex _]) <- withDefaultSolver $ \s ->
           verifyContract s c Nothing [] defaultVeriOpts Nothing (Just $ checkBadCheatCode "store(address,bytes32,bytes32)")
         pure ()


### PR DESCRIPTION
## Goal

The way forge-std is doing things has changed. It no longer sets a value in ds-test, but instead `Revert`-s with a specific message. So we have to match:

```
forge test --match-test "test_set_get()" -vvvv
[...]
  [31205] MateFailContractTest::test_set_get()
    ├─ [22216] MateFailContract::set_mate()
    │   └─ ← [Stop]
    ├─ [268] MateFailContract::get_mate() [staticcall]
    │   └─ ← [Return] 3
    ├─ [0] VM::assertEq(2, 3) [staticcall]
    │   └─ ← [Revert] assertion failed: 3 != 2
    └─ ← [Revert] assertion failed: 3 != 2
```

Instead of the current:

```
Traces:
  [42786] MateFailContractTest::test_set_get()
    ├─ [22216] MateFailContract::set_mate()
    │   └─ ← [Stop]
    ├─ [268] MateFailContract::get_mate() [staticcall]
    │   └─ ← [Return] 3
    ├─ emit log(val: "Error: a == b not satisfied [uint]")
    ├─ emit log_named_uint(key: "      Left", val: 3)
    ├─ emit log_named_uint(key: "     Right", val: 2)
    ├─ [0] VM::store(VM: [0x7109709ECfa91a80626fF3989D68f67F5b1DD12D], 0x6661696c65640000000000000000000000000000000000000000000000000000, 0x0000000000000000000000000000000000000000000000000000000000000001)
    │   └─ ← [Return]
    └─ ← [Stop]
```

The most prominent part of this change is the disappearance of line 202 from `UnitTest.hs`, where we'd check for failure bit being set in the cheat contract (i.e. `0x7109709EC...`)

## Implementation

* Emilio has changed things around already in `EVM.hs` to have a separate frame, which allows this to be coded in a relatively compact way. I have now added a number of required (but not all) cheatcodes. 
* Moved all relevant test cases to `std-forge/Test.hs` and `{Test}` from `ds-test/test.hs` and `{DSTest}`
* Added most of the required `assert...` methods, though some are still missing. The ones still missing would require dynamic ABI handling, such as `assertTrue(uint,string)`, where `string` is dynamic.
* Fixed the function signature generation for types such as tuples. Now `prove_tuple_fail1(uint256[5] memory amounts)` actually works
* Better debug output. Cleaner and more thorough. It should be a lot easier to debug things.

## Future work

I haven't added:
* `assertEq(T[], T[])` type asserts
* `assertNotEq(T[], T[])` type asserts
* `assertXXDecimal`
* `assertApproxXX
* assertEqCall`

Mostly due to the above mentioned issue with dynamic ABI type issue.

## TODO in a future PR

* Move cheatcodes into a new file
* Would be nice to accumulate errors when e.g. we have trouble with cheatcodes

## Checklist

- [x] tested locally
- [x] added automated tests
- [x] updated the docs
- [x] updated the changelog
