### PR TITLE
Add test to expose a bug in our checking of Expr equivalence for CopySlice

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -536,6 +536,12 @@ tests = testGroup "hevm"
           b = Expr.simplify a
         ret <- checkEquiv a b
         assertBoolM "must be equivalent" ret
+    , ignoreTest $ test "read-beyond-bound (negative-test)" $ do
+      let
+        e1 = CopySlice (Lit 1) (Lit 0) (Lit 2) (ConcreteBuf "a") (ConcreteBuf "")
+        e2 = ConcreteBuf "Definitely not the same!"
+      equal <- checkEquiv e1 e2
+      assertBoolM "Should not be equivalent!" $ not equal
     ]
   -- These tests fuzz the simplifier by generating a random expression,
   -- applying some simplification rules, and then using the smt encoding to


### PR DESCRIPTION
## Description
There is a bug in our SMT encoding that deals with reading of multiple bytes beyond buffer size.
I am adding a test to expose this bug. Currently, the function `checkEquiv` says the two expressions in the tests are equivalent, even though they definitely are not. (You have to delete `ignoreTest` to actually run the test.)

I was trying to trigger this problem on a full `hevm` run on some contract, but I was unable to find an example where the problem would be triggered. However, in the checking equivalence of `Expr`, it is pretty easy to trigger it.

The problem in the encoding is in the function `assertReads`, and I will try to fix it next.