### PR TITLE
Faster fuzz-testing by not having crazy large buffers

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -4246,7 +4246,7 @@ badStoresInExpr expr = bad
       _ -> pure e
 
 defaultBuf :: Int -> Gen (Expr Buf)
-defaultBuf = genBuf (4_000_000)
+defaultBuf = genBuf (4_000)
 
 defaultWord :: Int -> Gen (Expr EWord)
 defaultWord = genWord 10


### PR DESCRIPTION
## Description
Currently, the max buf size generated is approximated to 4MB during fuzzing. There is no need for such a large thing. We can do this in 4kb, making things faster.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
