### PR TITLE
Adding fuzzer for BufLength

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -552,8 +552,8 @@ tests = testGroup "hevm"
         let simplified = Expr.simplify expr
         checkEquivAndLHS expr simplified
     , testProperty  "buffer-simplification-len" $ \(expr :: Expr Buf) -> prop $ do
-        let simplified2 = Expr.simplify (BufLength expr)
-        checkEquivAndLHS (BufLength expr) simplified2
+        let simplified = Expr.simplify (BufLength expr)
+        checkEquivAndLHS (BufLength expr) simplified
     , testProperty "store-simplification" $ \(expr :: Expr Storage) -> prop $ do
         let simplified = Expr.simplify expr
         checkEquivAndLHS expr simplified

--- a/test/test.hs
+++ b/test/test.hs
@@ -551,6 +551,9 @@ tests = testGroup "hevm"
     [ testProperty  "buffer-simplification" $ \(expr :: Expr Buf) -> prop $ do
         let simplified = Expr.simplify expr
         checkEquivAndLHS expr simplified
+    , testProperty  "buffer-simplification-len" $ \(expr :: Expr Buf) -> prop $ do
+        let simplified2 = Expr.simplify (BufLength expr)
+        checkEquivAndLHS (BufLength expr) simplified2
     , testProperty "store-simplification" $ \(expr :: Expr Storage) -> prop $ do
         let simplified = Expr.simplify expr
         checkEquivAndLHS expr simplified


### PR DESCRIPTION
## Description
Adds buflength fuzzing which we seem to have been missing. Thanks to @blishko for finding the UNSAT generation bug we had :S Without that, this fuzzer does nothing, as everything comes out as UNSAT :S

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
