### PR TITLE
Remove buggy specializations of CopySlice simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a different approach.
 - `initial-storage` option of `hevm symbolic` is respected
 - `caller` option of `hevm symbolic` is now respected
-* Thanks to the new simplification rules, we can now enable more conformance tests
-* Multi-threaded running of Tracing.hs was not possible due to IO race. Fixed.
-* Fixed multi-threading bug in symbolic interpretation
+- Thanks to the new simplification rules, we can now enable more conformance tests
+- Multi-threaded running of Tracing.hs was not possible due to IO race. Fixed.
+- Fixed multi-threading bug in symbolic interpretation
+- Fixed simplification of concrete CopySlice with destination offset beyond destination size
 
 ## [0.53.0] - 2024-02-23
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -324,37 +324,23 @@ maxBytes = into (maxBound :: Word32) `Prelude.div` 8
 
 copySlice :: Expr EWord -> Expr EWord -> Expr EWord -> Expr Buf -> Expr Buf -> Expr Buf
 
--- Copies from empty buffers
-copySlice _ _ (Lit 0) (ConcreteBuf "") dst = dst
-copySlice a b c@(Lit size) d@(ConcreteBuf "") e@(ConcreteBuf "")
-  | size < maxBytes = ConcreteBuf $ BS.replicate (unsafeInto size) 0
-  | otherwise = CopySlice a b c d e
-copySlice srcOffset dstOffset sz@(Lit size) src@(ConcreteBuf "") dst
-  | size < maxBytes = copySlice srcOffset dstOffset (Lit size) (ConcreteBuf $ BS.replicate (unsafeInto size) 0) dst
-  | otherwise = CopySlice srcOffset dstOffset sz src dst
+-- Copying zero bytes is a no-op
+copySlice _ _ (Lit 0) _ dst = dst
 
--- Fully concrete copies
-copySlice a@(Lit srcOffset) b@(Lit dstOffset) c@(Lit size) d@(ConcreteBuf src) e@(ConcreteBuf "")
-  | srcOffset > unsafeInto (BS.length src), size < maxBytes = ConcreteBuf $ BS.replicate (unsafeInto size) 0
-  | srcOffset <= unsafeInto (BS.length src), dstOffset < maxBytes, size < maxBytes = let
-    hd = BS.replicate (unsafeInto dstOffset) 0
-    sl = padRight (unsafeInto size) $ BS.take (unsafeInto size) (BS.drop (unsafeInto srcOffset) src)
-    in ConcreteBuf $ hd <> sl
-  | otherwise = CopySlice a b c d e
+-- copying 32 bytes can be rewritten to a WriteWord on dst (e.g. CODECOPY of args during constructors)
+copySlice srcOffset dstOffset (Lit 32) src dst = writeWord dstOffset (readWord srcOffset src) dst
 
+-- Fully concrete copy
 copySlice a@(Lit srcOffset) b@(Lit dstOffset) c@(Lit size) d@(ConcreteBuf src) e@(ConcreteBuf dst)
   | dstOffset < maxBytes
   , size < maxBytes =
       let hd = padRight (unsafeInto dstOffset) $ BS.take (unsafeInto dstOffset) dst
           sl = if srcOffset > unsafeInto (BS.length src)
-            then BS.replicate (unsafeInto size) 0
+            then BS.replicate (unsafeInto size) 0 -- TODO: This has to consider wraparound on source as well
             else padRight (unsafeInto size) $ BS.take (unsafeInto size) (BS.drop (unsafeInto srcOffset) src)
           tl = BS.drop (unsafeInto dstOffset + unsafeInto size) dst
       in ConcreteBuf $ hd <> sl <> tl
   | otherwise = CopySlice a b c d e
-
--- copying 32 bytes can be rewritten to a WriteWord on dst (e.g. CODECOPY of args during constructors)
-copySlice srcOffset dstOffset (Lit 32) src dst = writeWord dstOffset (readWord srcOffset src) dst
 
 -- concrete indices & abstract src (may produce a concrete result if we are
 -- copying from a concrete region of src)

--- a/test/test.hs
+++ b/test/test.hs
@@ -483,6 +483,14 @@ tests = testGroup "hevm"
         let e = ReadByte (Lit 0x0) (WriteWord (Lit 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd) (Lit 0x0) (ConcreteBuf "\255\255\255\255"))
         b <- checkEquiv e (Expr.simplify e)
         assertBoolM "Simplifier failed" b
+    , test "buffer-length-copy-slice-beyond-source1" $ do
+        let e = BufLength (CopySlice (Lit 0x2) (Lit 0x2) (Lit 0x1) (ConcreteBuf "a") (ConcreteBuf ""))
+        b <- checkEquiv e (Expr.simplify e)
+        assertBoolM "Simplifier failed" b
+    , test "buffer-length-copy-slice-beyond-source2" $ do
+        let e = BufLength (CopySlice (Lit 0x2) (Lit 0x2) (Lit 0x1) (ConcreteBuf "") (ConcreteBuf ""))
+        b <- checkEquiv e (Expr.simplify e)
+        assertBoolM "Simplifier failed" b
     , test "simp-max-buflength" $ do
       let simp = Expr.simplify $ Max (Lit 0) (BufLength (AbstractBuf "txdata"))
       assertEqualM "max-buflength rules" simp $ BufLength (AbstractBuf "txdata")


### PR DESCRIPTION
## Description

The simplification of fully concrete CopySlice was not always taking into account that slicing beyond the size of the destination buffer should extend the buffer first.

Instead of maintaning multiple specializations, the most general one seems sufficient to cover all cases.
I don't think there is any serious performance penalty and keeping only one version of the simplification lessens the cognitive burden (at least for me) and makes the code less error-prone in my opinion.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
