### PR TITLE
Fix keccak + sha256 to take 2 params: buf + len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More verbose error messages in case of symbolic arguments to opcode
 - Tests to enforce that in Expr and Prop, constants are on the LHS whenever possible
 - Support for MCOPY and TSTORE/TLOAD, i.e. EIP 5656 + 1153 + 4788
-* Fuzz via both SAT and UNSAT, not just UNSAT
+- All fuzz tests now run twice, once with expected SAT and once with expected UNSAT to check
+  against incorrectly trivial UNSAT queries
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing
@@ -50,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed multi-threading bug in symbolic interpretation
 - Fixed simplification of concrete CopySlice with destination offset beyond destination size
 - Fixed a bug in our SMT encoding of reading multiple consecutive bytes from concrete index
+- Fixed bug in SMT encoding that caused empty and all-zero byte arrays to be considered equal
+  and hence lead to false negatives through trivially UNSAT SMT expressions
 
 ## [0.53.0] - 2024-02-23
 

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -792,11 +792,11 @@ exprToSMT = \case
     "(ite " <> cond `sp` one `sp` zero <> ")"
   Keccak a -> let
       enc = exprToSMT a
-      sz = exprToSMT $ Expr.simplify $ BufLength a
+      sz = exprToSMT $ Expr.bufLength a
     in "(keccak " <> enc <> " " <> sz <> ")"
   SHA256 a -> let
       enc = exprToSMT a
-      sz = exprToSMT $ Expr.simplify $ BufLength a
+      sz = exprToSMT $ Expr.bufLength a
     in "(sha256 " <> enc <> " " <> sz <> ")"
 
   TxValue -> fromString "txvalue"


### PR DESCRIPTION
This changes Keccak and SHA256 to take 2 parameters: buf + length instead of only a buf. This is as per our call last Friday as the (potential) solution the problem highlighted in #578 

I have also changed the way the number of tests for the Keccak simplification is handled. Before, it was capped at 50. [Default is 100](https://www.reddit.com/r/haskell/comments/51cew3/quickcheck_test_count/). So now I set it to half whatever number is passed, so it'll still be 50 when default is passed, but if a large number is passed, e.g. `--quickcheck-tests 10000` it will run 5000, instead of 50.

Closes #578

## Description

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
