### PR TITLE
Add `--num-solvers` option to equivalance checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for MCOPY and TSTORE/TLOAD, i.e. EIP 5656 + 1153 + 4788
 - All fuzz tests now run twice, once with expected SAT and once with expected UNSAT to check
   against incorrectly trivial UNSAT queries
+- Allow --num-solvers option for equivalence checking, use num cores by default
 
 ## Fixed
 - `concat` is a 2-ary, not an n-ary function in SMT2LIB, declare-const does not exist in QF_AUFBV, replacing


### PR DESCRIPTION
## Description
Adds `--num-solvers` option to equivalance checking AND makes it use the number of cores by default.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
