### PR TITLE
Respect option for timeout in equivalence checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in our SMT encoding of reading multiple consecutive bytes from concrete index
 - Fixed bug in SMT encoding that caused empty and all-zero byte arrays to be considered equal
   and hence lead to false negatives through trivially UNSAT SMT expressions
+- Respect --smt-timeout in equivalence checking
 
 ## [0.53.0] - 2024-02-23
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -252,7 +252,7 @@ equivalence cmd = do
   solver <- liftIO $ getSolver cmd
   cores <- liftIO $ unsafeInto <$> getNumProcessors
   let solverCount = fromMaybe cores cmd.numSolvers
-  withSolvers solver solverCount Nothing $ \s -> do
+  withSolvers solver solverCount cmd.smttimeout $ \s -> do
     res <- equivalenceCheck s bytecodeA bytecodeB veriOpts calldata
     case any isCex res of
       False -> liftIO $ do


### PR DESCRIPTION
## Description
We forgot to respect it before. Default is still the same, i.e. no timeout

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
