### PR TITLE
Take into account possibly overflowing when reading from buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and hence lead to false negatives through trivially UNSAT SMT expressions
 - Respect --smt-timeout in equivalence checking
 - Fixed the handling of returndata with an abstract size during transaction finalization
+- Fixed handling of indices overflowing 2^256 when reading from buffers
 
 ## [0.53.0] - 2024-02-23
 


### PR DESCRIPTION
When reading from a buffer, it is possible to specify offset that would mean reading beyond the buffer's size. That would normally just mean reading 0. However, when reading multiple consecutive indices, there is an edge case when we would start from a very large offset and would overflow the value 2^256 (which is a boundary given by the yellow paper). When the indices overflow, they start again from the beginning of the buffer.

## Description

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
