### PR TITLE
Fix simplification of CopySlice when overflowing into too short buffer

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -348,8 +348,9 @@ copySlice a@(Lit srcOffset) b@(Lit dstOffset) c@(Lit size) d@(ConcreteBuf src) e
               if srcOffset + size < srcOffset -- overflow, read will continue from begining of the buffer
                 then
                   let headSize = (maxWord256 - srcOffset) + 1
+                      tailSize = size - headSize
                       sliceHead = BS.replicate (unsafeInto headSize) 0
-                      sliceTail = BS.take (unsafeInto (size - headSize)) src
+                      sliceTail = padRight (unsafeInto tailSize) $ BS.take (unsafeInto tailSize) src
                    in
                     sliceHead <> sliceTail
                 else BS.replicate (unsafeInto size) 0

--- a/test/test.hs
+++ b/test/test.hs
@@ -736,6 +736,12 @@ tests = testGroup "hevm"
           s = Expr.simplify e
         equal <- checkEquiv e s
         assertEqualM "Must be equal" True equal
+    , test "copy-slice-overflowing-into-too-short-buffer" $ do
+        let
+          e = BufLength (CopySlice (Lit 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) (Lit 0x00) (Lit 0x02) (ConcreteBuf "") (ConcreteBuf ""))
+          s = Expr.simplify e
+        equal <- checkEquiv e s
+        assertEqualM "Must be equal" True equal
   ]
   , testGroup "isUnsat-concrete-tests" [
       test "disjunction-left-false" $ do


### PR DESCRIPTION
## Description

The problem was that we did not take into account the need to pad the slice when the source buffer was too short for required size.


## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
