### PR TITLE
Flake: cleanup and expose dynamic output

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,22 +17,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -153,7 +137,6 @@
     "root": {
       "inputs": {
         "ethereum-tests": "ethereum-tests",
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "forge-std": "forge-std",
         "foundry": "foundry",

--- a/readme.md
+++ b/readme.md
@@ -51,10 +51,9 @@ nix profile install github:ethereum/hevm
 We use `nix` to manage project dependencies. To start hacking on hevm you should first [install
 nix](https://nixos.org/download.html).
 
-Once nix is installed you can run `nix-shell` (or `nix develop` if you use flakes) from the repo
-root to enter a development shell containing all required dev dependencies. If you use
-[direnv](https://direnv.net/), then you can run `direnv allow`, and the shell will be automatically
-entered each time you cd in the project repo.
+Once nix is installed you can run `nix develop` from the repo root to enter a development shell
+containing all required dev dependencies. If you use [direnv](https://direnv.net/), then you can run
+`direnv allow`, and the shell will be automatically entered each time you cd in the project repo.
 
 Once in the shell you can use the usual `cabal` commands to build and test hevm:
 


### PR DESCRIPTION
## Description

Cleans up the nix flake as follows:

- conform to modern nixpkgs standards by removing the `with` statements
  and making scoping explicit
- removing `flake-compat` (which was broken on macos due to
  https://github.com/edolstra/flake-compat/issues/53).

Additionally reworks the structure a little and makes the default flake
output dynamically linked, making it easier to consume from other nix
flakes (e.g. act).

## Checklist

- [x] tested locally
- [ ] added automated tests
- [x] updated the docs
- [ ] updated the changelog
