### PR TITLE
ci: fix publish docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: build docs
-        run: nix-shell --pure --command "cd doc && mdbook build"
+        run: nix develop --ignore-environment --command sh -c "cd doc && mdbook build"
 
       - name: publish docs
         uses: JamesIves/github-pages-deploy-action@v4.6.0

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -1,7 +1,7 @@
 # hevm Book
 
 The hevm book is built using `mdbook` and `yarn`. Known good versions of both
-are included in the nix-shell.
+are included in the flake `devShell`.
 
 ## Running the mdBook server
 


### PR DESCRIPTION
## Description

This relied on `nix-shell` (no longer supported since we dropped flake-compat). Reworked to use `nix develop`.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
