### PR TITLE
Fix condition in min-distance keccak axiom

### DIFF
--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -48,7 +48,7 @@ minProp _ = internalError "expected keccak expression"
 
 injProp :: (Expr EWord, Expr EWord) -> Prop
 injProp (k1@(Keccak b1), k2@(Keccak b2)) =
-  POr ((b1 .== b2) .&& (bufLength b1 .== bufLength b2)) (PNeg (PEq k1 k2))
+  PImpl (PEq k1 k2) ((b1 .== b2) .&& (bufLength b1 .== bufLength b2))
 injProp _ = internalError "expected keccak expression"
 
 
@@ -70,7 +70,7 @@ keccakAssumptions ps bufs stores = injectivity <> minValue <> minDiffOfPairs
     minDiffOfPairs = map minDistance keccakPairs
      where
       minDistance :: (Expr EWord, Expr EWord) -> Prop
-      minDistance (ka@(Keccak a), kb@(Keccak b)) = PImpl (a ./= b) (PAnd req1 req2)
+      minDistance (ka@(Keccak a), kb@(Keccak b)) = PImpl ((a ./= b) .|| (bufLength a ./= bufLength b)) (PAnd req1 req2)
         where
           req1 = (PGEq (Sub ka kb) (Lit 256))
           req2 = (PGEq (Sub kb ka) (Lit 256))

--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -21,19 +21,16 @@ newtype KeccakStore = KeccakStore
 initState :: KeccakStore
 initState = KeccakStore { keccakEqs = Set.empty }
 
-keccakFinder :: forall a. Expr a -> State KeccakStore (Expr a)
+keccakFinder :: forall a. Expr a -> State KeccakStore ()
 keccakFinder = \case
-  e@(Keccak _) -> do
-    s <- get
-    put $ s{keccakEqs=Set.insert e s.keccakEqs}
-    pure e
-  e -> pure e
+  e@(Keccak _) -> modify (\s -> s{keccakEqs=Set.insert e s.keccakEqs})
+  _ -> pure ()
 
-findKeccakExpr :: forall a. Expr a -> State KeccakStore (Expr a)
-findKeccakExpr e = mapExprM keccakFinder e
+findKeccakExpr :: forall a. Expr a -> State KeccakStore ()
+findKeccakExpr e = mapExprM_ keccakFinder e
 
-findKeccakProp :: Prop -> State KeccakStore Prop
-findKeccakProp p = mapPropM keccakFinder p
+findKeccakProp :: Prop -> State KeccakStore ()
+findKeccakProp p = mapPropM_ keccakFinder p
 
 findKeccakPropsExprs :: [Prop] -> [Expr Buf]  -> [Expr Storage]-> State KeccakStore ()
 findKeccakPropsExprs ps bufs stores = do

--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -65,8 +65,8 @@ keccakAssumptions ps bufs stores = injectivity <> minValue <> minDiffOfPairs
     (_, st) = runState (findKeccakPropsExprs ps bufs stores) initState
 
     keccakPairs = uniquePairs (Set.toList st.keccakExprs)
-    injectivity = fmap injProp keccakPairs
-    minValue = fmap minProp (Set.toList st.keccakExprs)
+    injectivity = map injProp keccakPairs
+    minValue = map minProp (Set.toList st.keccakExprs)
     minDiffOfPairs = map minDistance keccakPairs
      where
       minDistance :: (Expr EWord, Expr EWord) -> Prop

--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -15,15 +15,15 @@ import EVM.Expr
 
 
 newtype KeccakStore = KeccakStore
-  { keccakEqs :: Set (Expr EWord) }
+  { keccakExprs :: Set (Expr EWord) }
   deriving (Show)
 
 initState :: KeccakStore
-initState = KeccakStore { keccakEqs = Set.empty }
+initState = KeccakStore { keccakExprs = Set.empty }
 
 keccakFinder :: forall a. Expr a -> State KeccakStore ()
 keccakFinder = \case
-  e@(Keccak _) -> modify (\s -> s{keccakEqs=Set.insert e s.keccakEqs})
+  e@(Keccak _) -> modify (\s -> s{keccakExprs=Set.insert e s.keccakExprs})
   _ -> pure ()
 
 findKeccakExpr :: forall a. Expr a -> State KeccakStore ()
@@ -64,9 +64,9 @@ keccakAssumptions ps bufs stores = injectivity <> minValue <> minDiffOfPairs
   where
     (_, st) = runState (findKeccakPropsExprs ps bufs stores) initState
 
-    keccakPairs = uniquePairs (Set.toList st.keccakEqs)
+    keccakPairs = uniquePairs (Set.toList st.keccakExprs)
     injectivity = fmap injProp keccakPairs
-    minValue = fmap minProp (Set.toList st.keccakEqs)
+    minValue = fmap minProp (Set.toList st.keccakExprs)
     minDiffOfPairs = map minDistance keccakPairs
      where
       minDistance :: (Expr EWord, Expr EWord) -> Prop

--- a/test/test.hs
+++ b/test/test.hs
@@ -704,8 +704,7 @@ tests = testGroup "hevm"
         let simplified = Expr.simplify x
         y <- checkEquivAndLHS x simplified
         assertBoolM "Must be equal" y
-     -- TODO
-    , expectFail $ test "word-eq-bug" $ do
+    , test "word-eq-bug" $ do
         -- This test is actually OK because the simplified takes into account that it's impossible to find a
         -- near-collision in the keccak hash
         let x =  (SLoad (Keccak (AbstractBuf "es")) (SStore (Add (Keccak (ConcreteBuf "")) (Lit 0x1)) (Lit 0xacab) (ConcreteStore (Map.empty))))


### PR DESCRIPTION
## Description

If keccak arguments are not the same then the values must be at least 256 apart.
However, the condition of "not same" must include both the buffer *and* its size.

While fixing the condition, I made a cleanup pass over the generation of keccak axioms.
Notably, I have removed the axioms regarding the concrete values in `keccakAssumptions`, because there is another function for that `keccakCompute`, which is better because it tries to simplify the buffer before checking if the result is a concrete buffer.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
