### PR TITLE
ci: windows: use builtin GHC clang toolchain to build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
           strip result/hevm.exe
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hevm-windows-x64
           path: result/hevm.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         shell: bash
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: CLANG64
+          msystem: MINGW64
           path-type: minimal
           update: true
           install: >-
@@ -111,13 +111,16 @@ jobs:
       - name: Extract GHC & Cabal paths
         run: |
           HASKELL_PATHS="$(cygpath -u "$GHC_PATH"):$(cygpath -u "$CABAL_PATH")"
+          HASKELL_MINGW_PATH="$(cygpath -u "$GHC_PATH/../mingw")"
           echo "HASKELL_PATHS=$HASKELL_PATHS" >> "$GITHUB_ENV"
+          echo "HASKELL_MINGW_PATH=$HASKELL_MINGW_PATH" >> "$GITHUB_ENV"
         env:
           GHC_PATH: ${{ steps.setup.outputs.ghc-path }}
           CABAL_PATH: ${{ steps.setup.outputs.cabal-path }}
 
       - name: build and install c dependencies
         run: |
+          export PATH="$HASKELL_MINGW_PATH/bin:$PATH"
           echo "::group::Installing libsecp256k1"
           ./.github/scripts/install-libsecp256k1.sh
           echo "::endgroup::"
@@ -128,9 +131,11 @@ jobs:
         run: |
           export PATH="$HASKELL_PATHS:$PATH"
           cabal configure --disable-documentation --enable-executable-static --enable-executable-stripping \
+            --extra-include-dirs="$(cygpath -m "$HASKELL_MINGW_PATH/x86_64-w64-mingw32/include")" --extra-lib-dirs="$(cygpath -m "$HASKELL_MINGW_PATH/x86_64-w64-mingw32/lib")" \
+            --extra-include-dirs="$(cygpath -m "$HASKELL_MINGW_PATH/include")" --extra-lib-dirs="$(cygpath -m "$HASKELL_MINGW_PATH/lib")" \
+            --extra-include-dirs="D:/a/_temp/msys64/mingw64/include" --extra-lib-dirs="D:/a/_temp/msys64/mingw64/lib" \
             --extra-include-dirs="$HOME/.local/include" --extra-lib-dirs="$HOME/.local/lib" \
-            --extra-include-dirs="D:/a/_temp/msys64/clang64/include" --extra-lib-dirs="D:/a/_temp/msys64/clang64/lib" \
-            --ghc-options=-pgml=D:/a/_temp/msys64/clang64/bin/clang.exe -fstatic-secp256k1
+            --ghc-options=-pgml="$(cygpath -m "$HASKELL_MINGW_PATH/bin/clang.exe")" -fstatic-secp256k1 --constraint="zlib +bundled-c-zlib"
           cabal build --dry-run
           # The last step generates dist-newstyle/cache/plan.json for the cache key.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         shell: bash
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: CLANG64
           path-type: minimal
           update: true
           install: >-
@@ -133,7 +133,7 @@ jobs:
           cabal configure --disable-documentation --enable-executable-static --enable-executable-stripping \
             --extra-include-dirs="$(cygpath -m "$HASKELL_MINGW_PATH/x86_64-w64-mingw32/include")" --extra-lib-dirs="$(cygpath -m "$HASKELL_MINGW_PATH/x86_64-w64-mingw32/lib")" \
             --extra-include-dirs="$(cygpath -m "$HASKELL_MINGW_PATH/include")" --extra-lib-dirs="$(cygpath -m "$HASKELL_MINGW_PATH/lib")" \
-            --extra-include-dirs="D:/a/_temp/msys64/mingw64/include" --extra-lib-dirs="D:/a/_temp/msys64/mingw64/lib" \
+            --extra-include-dirs="D:/a/_temp/msys64/clang64/include" --extra-lib-dirs="D:/a/_temp/msys64/clang64/lib" \
             --extra-include-dirs="$HOME/.local/include" --extra-lib-dirs="$HOME/.local/lib" \
             --ghc-options=-pgml="$(cygpath -m "$HASKELL_MINGW_PATH/bin/clang.exe")" -fstatic-secp256k1 --constraint="zlib +bundled-c-zlib"
           cabal build --dry-run


### PR DESCRIPTION
## Description

MSYS2 recently got its Clang updated from v18 to v19, and that caused build failures such as the following:

> ghc-9.6.5.exe: loadArchive: GNU-variant filename offset 31 invalid (range [0..964]) while reading filename from `D:\a\_temp\msys64\clang64\lib\libmingw32.a'
> 
> \<no location info\>: error:
>     loadArchive "D:\\a\\_temp\\msys64\\clang64\\lib\\libmingw32.a": failed
> [29 of 29] Compiling Paths_hevm       ( D:\a\hevm\hevm\dist-newstyle\build\x86_64-windows\ghc-9.6.5\hevm-0.53.0\build\autogen\Paths_hevm.hs, D:\a\hevm\hevm\dist-newstyle\build\x86_64-windows\ghc-9.6.5\hevm-0.53.0\build\Paths_hevm.o )

This PR switches the Windows build to use the toolchain shipped together with GHC to avoid the incompatibility issues.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
