### PR TITLE
Fixing prank: no longer override the sender on lower frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Respect --smt-timeout in equivalence checking
 - Fixed the handling of returndata with an abstract size during transaction finalization
 - Error handling for user-facing cli commands is much improved
+- Fixing prank so it doesn't override the sender address on lower call frames
 
 ## [0.53.0] - 2024-02-23
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -878,6 +878,7 @@ exec1 = do
                               assign #caller from'
                               assign #contract callee
                               assign #overrideCaller Nothing
+                              assign #resetCaller False                              
                             touchAccount from'
                             touchAccount callee
                             transfer from' callee xValue

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -898,6 +898,7 @@ exec1 = do
                         assign #callvalue xValue
                         assign #caller $ fromMaybe self overrideC
                         assign #overrideCaller Nothing
+                        assign #resetCaller False
                       touchAccount self
             _ ->
               underrun

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2015,6 +2015,7 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
                     assign #returndata mempty
                     assign #calldata calldata
                     assign #overrideCaller Nothing
+                    assign #resetCaller False
                   continue xTo
 
 -- -- * Contract creation

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -84,7 +84,7 @@ blankState = do
     , returndata   = mempty
     , static       = False
     , overrideCaller = Nothing
-    , resetCaller  = True
+    , resetCaller  = False
     }
 
 -- | An "external" view of a contract's bytecode, appropriate for

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1820,6 +1820,7 @@ cheatActions = Map.fromList
       \_ _ -> do
         doStop
         assign (#state % #overrideCaller) Nothing
+        assign (#state % #resetCaller) False
 
   , action "createFork(string)" $
       \sig input -> case decodeBuf [AbiStringType] input of

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -877,8 +877,6 @@ exec1 = do
                               assign #callvalue xValue
                               assign #caller from'
                               assign #contract callee
-                              assign #overrideCaller Nothing
-                              assign #resetCaller False
                             touchAccount from'
                             touchAccount callee
                             transfer from' callee xValue
@@ -897,8 +895,6 @@ exec1 = do
                       zoom #state $ do
                         assign #callvalue xValue
                         assign #caller $ fromMaybe self overrideC
-                        assign #overrideCaller Nothing
-                        assign #resetCaller False
                       touchAccount self
             _ ->
               underrun
@@ -989,8 +985,6 @@ exec1 = do
                             assign #caller $ fromMaybe self overrideC
                             assign #contract callee
                             assign #static True
-                            assign #overrideCaller Nothing
-                            assign #resetCaller False
                           touchAccount self
                           touchAccount callee
             _ ->

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -148,7 +148,7 @@ makeVm o = do
       , returndata = mempty
       , static = False
       , overrideCaller = Nothing
-      , resetCaller = True
+      , resetCaller = False
       }
     , env = env
     , cache = cache

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1104,8 +1104,6 @@ callChecks this xGas xContext xTo xValue xInOffset xInSize xOutOffset xOutSize x
       availableGas <- use (#state % #gas)
       let recipientExists = accountExists xContext vm
       let from = fromMaybe vm.state.contract vm.state.overrideCaller
-      resetCaller <- use $ #state % #resetCaller
-      when resetCaller $ assign (#state % #overrideCaller) Nothing
       fromBal <- preuse $ #env % #contracts % ix from % #balance
       costOfCall fees recipientExists xValue availableGas xGas xTo $ \cost gas' -> do
         let checkCallDepth =
@@ -1971,6 +1969,8 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
   | otherwise =
       callChecks this gasGiven xContext xTo xValue xInOffset xInSize xOutOffset xOutSize xs $
         \xGas -> do
+          resetCaller <- use $ #state % #resetCaller
+          when resetCaller $ assign (#state % #overrideCaller) Nothing
           vm0 <- get
           fetchAccount xTo $ \target -> case target.code of
               UnknownCode _ -> do

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -990,6 +990,7 @@ exec1 = do
                             assign #contract callee
                             assign #static True
                             assign #overrideCaller Nothing
+                            assign #resetCaller False
                           touchAccount self
                           touchAccount callee
             _ ->

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -878,7 +878,7 @@ exec1 = do
                               assign #caller from'
                               assign #contract callee
                               assign #overrideCaller Nothing
-                              assign #resetCaller False                              
+                              assign #resetCaller False
                             touchAccount from'
                             touchAccount callee
                             transfer from' callee xValue

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -665,8 +665,6 @@ data BaseState
 -- | Configuration options that need to be consulted at runtime
 data RuntimeConfig = RuntimeConfig
   { allowFFI :: Bool
-  , overrideCaller :: Maybe (Expr EAddr)
-  , resetCaller :: Bool
   , baseState :: BaseState
   }
   deriving (Show)
@@ -728,6 +726,8 @@ data FrameState (t :: VMType) s = FrameState
   , gas          :: !(Gas t)
   , returndata   :: Expr Buf
   , static       :: Bool
+  , overrideCaller :: Maybe (Expr EAddr)
+  , resetCaller  :: Bool
   }
   deriving (Generic)
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -1231,7 +1231,7 @@ tests = testGroup "hevm"
         Right e <- reachableUserAsserts c (Just $ Sig "f(address,uint256)" [AbiAddressType, AbiUIntType 256])
         assertBoolM "The expression is not partial" $ Expr.containsNode isPartial e
       ,
-      test "vm.prank underflow" $ do
+      test "vm.prank-underflow" $ do
         Just c <- solcRuntime "C"
             [i|
               interface Vm {


### PR DESCRIPTION
## Description
As per #608 there is an issue with prank. It keeps overriding the sender on lower frames as well. This should not happen.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
