### PR TITLE
Removing abstraction-refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default max iterations is 5 now. `--max-iters -1` now signals no bound. This change is to match other
   symbolic execution frameworks' default bound and to not go into an infinite loop by default when
   there could be other, interesting and reachable bugs in the code
+- Abstraction-refinement is no longer an option, it was never really useful and not well-tested
 
 ## Added
 - More POr and PAnd rules

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -100,8 +100,6 @@ data Command w
       , numSolvers    :: w ::: Maybe Natural      <?> "Number of solver instances to use (default: number of cpu cores)"
       , solverThreads :: w ::: Maybe Natural      <?> "Number of threads for each solver instance. Only respected for Z3 (default: 1)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
-      , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
-      , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , noDecompose   :: w ::: Bool               <?> "Don't decompose storage slots into separate arrays"
       }
   | Equivalence -- prove equivalence between two programs
@@ -122,8 +120,6 @@ data Command w
       , numSolvers    :: w ::: Maybe Natural    <?> "Number of solver instances to use (default: number of cpu cores)"
       , solverThreads :: w ::: Maybe Natural    <?> "Number of threads for each solver instance. Only respected for Z3 (default: 1)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
-      , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
-      , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , noDecompose   :: w ::: Bool             <?> "Don't decompose storage slots into separate arrays"
       }
   | Exec -- Execute a given program with specified env & calldata
@@ -173,8 +169,6 @@ data Command w
       , smttimeout    :: w ::: Maybe Natural            <?> "Timeout given to SMT solver in seconds (default: 300)"
       , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point. For no bound, set -1 (default: 5)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic   <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
-      , abstractArithmetic    :: w ::: Bool             <?> "Use abstraction-refinement for complicated arithmetic functions such as MulMod. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
-      , abstractMemory    :: w ::: Bool                      <?> "Use abstraction-refinement for Memory. This runs the solver first with abstraction turned on, and if it returns a potential counterexample, the counterexample is refined to make sure it is a counterexample for the actual (not the abstracted) problem"
       , noDecompose   :: w ::: Bool                     <?> "Don't decompose storage slots into separate arrays"
       , numCexFuzz    :: w ::: Integer                  <!> "3" <?> "Number of fuzzing tries to do to generate a counterexample (default: 3)"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
@@ -218,8 +212,6 @@ main = withUtf8 $ do
     , debug = cmd.debug
     , dumpExprs = cmd.debug
     , numCexFuzz = cmd.numCexFuzz
-    , abstRefineMem = cmd.abstractMemory
-    , abstRefineArith = cmd.abstractArithmetic
     , dumpTrace = cmd.trace
     , decomposeStorage = Prelude.not cmd.noDecompose
     } }

--- a/doc/src/equivalence.md
+++ b/doc/src/equivalence.md
@@ -35,18 +35,6 @@ Available options:
                            Which heuristic should be used to determine if we are
                            in a loop: StackBased (default) or Naive
                            (default: StackBased)
-  --abstract-arithmetic    Use abstraction-refinement for complicated arithmetic
-                           functions such as MulMod. This runs the solver first
-                           with abstraction turned on, and if it returns a
-                           potential counterexample, the counterexample is
-                           refined to make sure it is a counterexample for the
-                           actual (not the abstracted) problem
-  --abstract-memory        Use abstraction-refinement for Memory. This runs the
-                           solver first with abstraction turned on, and if it
-                           returns a potential counterexample, the
-                           counterexample is refined to make sure it is a
-                           counterexample for the actual (not the abstracted)
-                           problem
 ```
 
 Symbolically execute both the code given in `--code-a` and `--code-b` and try

--- a/doc/src/test.md
+++ b/doc/src/test.md
@@ -35,18 +35,6 @@ Available options:
                            Which heuristic should be used to determine if we are
                            in a loop: StackBased (default) or Naive
                            (default: StackBased)
-  --abstract-arithmetic    Use abstraction-refinement for complicated arithmetic
-                           functions such as MulMod. This runs the solver first
-                           with abstraction turned on, and if it returns a
-                           potential counterexample, the counterexample is
-                           refined to make sure it is a counterexample for the
-                           actual (not the abstracted) problem
-  --abstract-memory        Use abstraction-refinement for Memory. This runs the
-                           solver first with abstraction turned on, and if it
-                           returns a potential counterexample, the
-                           counterexample is refined to make sure it is a
-                           counterexample for the actual (not the abstracted)
-                           problem
   --num-cex-fuzz INTEGER   Number of fuzzing tries to do to generate a
                            counterexample (default: 3) (default: 3)
   --ask-smt-iterations INTEGER

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -36,8 +36,6 @@ data Config = Config
   , dumpExprs        :: Bool
   , dumpEndStates    :: Bool
   , debug            :: Bool
-  , abstRefineArith  :: Bool
-  , abstRefineMem    :: Bool
   , dumpTrace        :: Bool
   , numCexFuzz       :: Integer
    -- Used to debug fuzzer in test.hs. It disables the SMT solver
@@ -54,8 +52,6 @@ defaultConfig = Config
   , dumpExprs = False
   , dumpEndStates = False
   , debug = False
-  , abstRefineArith = False
-  , abstRefineMem   = False
   , dumpTrace = False
   , numCexFuzz = 10
   , onlyCexFuzz  = False

--- a/test/test.hs
+++ b/test/test.hs
@@ -79,8 +79,6 @@ testEnv = Env { config = defaultConfig {
   , dumpExprs = False
   , dumpEndStates = False
   , debug = False
-  , abstRefineArith = False
-  , abstRefineMem   = False
   , dumpTrace = False
   , decomposeStorage = True
   } }
@@ -3810,9 +3808,8 @@ checkEquivAndLHS orig simp = do
 
 checkEquivBase :: (Eq a, App m) => (a -> a -> Prop) -> a -> a -> Bool -> m (Maybe Bool)
 checkEquivBase mkprop l r expect = do
-  conf <-  readConfig
   withSolvers Z3 1 1 (Just 1) $ \solvers -> liftIO $ do
-     let smt = assertPropsNoSimp conf [mkprop l r]
+     let smt = assertPropsNoSimp [mkprop l r]
      res <- checkSat solvers smt
      let
        ret = case res of


### PR DESCRIPTION
## Description

It was never really turned on, it made things slower. The SMT solver should be doing this, actually. It may be the wrong place to do it, or the wrong approach in doing it. Either way, it seems like it's not useful.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [x] updated the docs
- [x] updated the changelog
