### PR TITLE
Fixing missing override on EVM DeletegateCall instruction? I think it's missing...

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -952,6 +952,8 @@ exec1 = do
                   case gasTryFrom xGas of
                     Left _ -> vmError IllegalOverflow
                     Right gas ->
+                      -- NOTE: we don't update overrideCaller in this case because
+                      -- forge-std doesn't. see: https://github.com/foundry-rs/foundry/pull/8863
                       delegateCall this gas xTo' self (Lit 0) xInOffset xInSize xOutOffset xOutSize xs $
                         \_ -> touchAccount self
             _ -> underrun


### PR DESCRIPTION
## Description

I think the DelegateCall was missing the override check? @elopez what do you think?

Notice that the override will be reset by the `delegateCall` function:

```
        \xGas -> do
          resetCaller <- use $ #state % #resetCaller
          when resetCaller $ assign (#state % #overrideCaller) Nothing
```

But it does not assign the `from` caller to the value, instead, we do that in e.g.:

```haskell
        OpStaticcall ->
          case stk of
            xGas:xTo:xInOffset:xInSize:xOutOffset:xOutSize:xs ->
[...]
                Just xTo' ->
                  case gasTryFrom xGas of
                    Left _ -> vmError IllegalOverflow
                    Right gas -> do
                      overrideC <- use $ #state % #overrideCaller
                      delegateCall this gas xTo' xTo' (Lit 0) xInOffset xInSize xOutOffset xOutSize xs $
                        \callee -> do
                          zoom #state $ do
                            assign #callvalue (Lit 0)
                            assign #caller $ fromMaybe self overrideC

[...]
```

And similarly in other places. But somehow OpDelegateCall is missing this.


## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
