### PR TITLE
Adding a note about prank and delegatecall

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -952,6 +952,8 @@ exec1 = do
                   case gasTryFrom xGas of
                     Left _ -> vmError IllegalOverflow
                     Right gas ->
+                      -- NOTE: we don't update overrideCaller in this case because
+                      -- forge-std doesn't. see: https://github.com/foundry-rs/foundry/pull/8863
                       delegateCall this gas xTo' self (Lit 0) xInOffset xInSize xOutOffset xOutSize xs $
                         \_ -> touchAccount self
             _ -> underrun


### PR DESCRIPTION
## Description

Add notes about why override is not exercised for delegateCall. 

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
