### PR TITLE
Faster test running by default

### DIFF
--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -35,7 +35,7 @@ runSolidityTestCustom testFile match timeout maxIter ffiAllowed rpcinfo projectT
         internalError $ "Error compiling test file " <> show testFile <> " in directory "
           <> show root <> " using project type " <> show projectType
       Right bo@(BuildOutput contracts _) -> do
-        withSolvers Z3 1 1 timeout $ \solvers -> do
+        withSolvers Z3 3 1 timeout $ \solvers -> do
           opts <- liftIO $ testOpts solvers root (Just bo) match maxIter ffiAllowed rpcinfo
           unitTest opts contracts
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -104,10 +104,10 @@ prop :: Testable prop => ReaderT Env IO prop -> Property
 prop a = ioProperty $ runEnv testEnv a
 
 withDefaultSolver :: App m => (SolverGroup -> m a) -> m a
-withDefaultSolver = withSolvers Z3 1 1 Nothing
+withDefaultSolver = withSolvers Z3 3 1 Nothing
 
 withCVC5Solver :: App m => (SolverGroup -> m a) -> m a
-withCVC5Solver = withSolvers CVC5 1 1 Nothing
+withCVC5Solver = withSolvers CVC5 3 1 Nothing
 
 main :: IO ()
 main = defaultMain tests


### PR DESCRIPTION
## Description
Let's run 3 solver processes by default. Should make testing a lot faster.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
