### PR TITLE
Use the SMT solver to convert symbolic to concrete value(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JoinBytes simplification rule
 - New simplification rule to help deal with abi.encodeWithSelector
 - More simplification rules for Props
+- Using the SMT solver to get a single concrete value for a symbolic expression
+  and continue running, whenever possible
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2942,7 +2942,7 @@ instance VMOps Symbolic where
   toGas _ = ()
   whenSymbolicElse a _ = a
 
-  partial e = assign #result (Just (Unfinished e))
+  partial e = assign #result $ Just (Unfinished e)
   branch cond continue = do
     loc <- codeloc
     pathconds <- use #constraints

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -265,7 +265,7 @@ getSolution solvers symAddr pathconditions = do
             Sat (SMTCex vars _ _ _ _ _)  -> case (Map.lookup (Var "addrQuery") vars) of
               Just addr -> do
                 let newConds = PAnd conds (symAddr ./= (Lit addr))
-                when conf.debug $ putStrLn $ "Got one solution to symbolic query:" <> show addr
+                when conf.debug $ putStrLn $ "Got one solution to symbolic query:" <> show addr <> " now have " <> show (length addrs + 1) <> " solution(s)."
                 collectSolutions (addr:addrs) maxSols newConds conf
               _ -> internalError "No solution to symbolic query"
             Unsat -> do

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -267,7 +267,7 @@ getSolution solvers symAddr pathconditions = do
                 let newConds = PAnd conds (symAddr ./= (Lit addr))
                 when conf.debug $ putStrLn $ "Got one solution to symbolic query:" <> show addr
                 collectSolutions (addr:addrs) maxSols newConds conf
-              _ -> pure $ Just addrs
+              _ -> internalError "No solution to symbolic query"
             Unsat -> do
               when conf.debug $ putStrLn "No more solution(s) to symbolic query."
               pure $ Just addrs

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -618,9 +618,9 @@ instance Show (Query t s) where
       (("<EVM.Query: ask SMT about "
         ++ show condition ++ " in context "
         ++ show constraints ++ ">") ++)
-    PleaseGetSol addr constraints _ ->
-      (("<EVM.Query: get SMT solution for addr "
-        ++ show addr ++ " in context "
+    PleaseGetSol expr constraints _ ->
+      (("<EVM.Query: ask SMT to get W256 for expression "
+        ++ show expr ++ " in context "
         ++ show constraints ++ ">") ++)
     PleaseDoFFI cmd env _ ->
       (("<EVM.Query: do ffi: " ++ (show cmd) ++ " env: " ++ (show env)) ++)

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -594,6 +594,7 @@ data Query t s where
   PleaseFetchContract :: Addr -> BaseState -> (Contract -> EVM t s ()) -> Query t s
   PleaseFetchSlot     :: Addr -> W256 -> (W256 -> EVM t s ()) -> Query t s
   PleaseAskSMT        :: Expr EWord -> [Prop] -> (BranchCondition -> EVM Symbolic s ()) -> Query Symbolic s
+  PleaseGetSol        :: Expr EWord -> [Prop] -> (Maybe W256 -> EVM Symbolic s ()) -> Query Symbolic s
   PleaseDoFFI         :: [String] -> Map String String -> (ByteString -> EVM t s ()) -> Query t s
   PleaseReadEnv       :: String -> (String -> EVM t s ()) -> Query t s
 
@@ -616,6 +617,10 @@ instance Show (Query t s) where
     PleaseAskSMT condition constraints _ ->
       (("<EVM.Query: ask SMT about "
         ++ show condition ++ " in context "
+        ++ show constraints ++ ">") ++)
+    PleaseGetSol addr constraints _ ->
+      (("<EVM.Query: get SMT solution for addr "
+        ++ show addr ++ " in context "
         ++ show constraints ++ ">") ++)
     PleaseDoFFI cmd env _ ->
       (("<EVM.Query: do ffi: " ++ (show cmd) ++ " env: " ++ (show env)) ++)
@@ -854,6 +859,7 @@ class VMOps (t :: VMType) where
 
   partial :: PartialExec -> EVM t s ()
   branch :: Expr EWord -> (Bool -> EVM t s ()) -> EVM t s ()
+  oneSolution :: Expr EWord -> (Maybe W256 -> EVM t s ()) -> EVM t s ()
 
 -- Bytecode Representations ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description
This uses an SMT solver to solve a symbolic value. If it can ONLY be solved into a single value, then it gives that back and we can continue running. This should get rid of a number of cases where we run in to symbolic expression(s) for JUMP (but also other cases, see [1]). Note that the architecture is such that it should be possible to eventually move to a version where more than one solution is possible and so we branch out to explore all. That should fix the issue with #581 . In fact, this code can compute one of the potential addresses (or all addresses), and jump to the first (or any), but with probably small changes, it can support everything needed for #581 That would be really cool, and may make @charles-cooper happy :smile: 

Currently, if more than one value is possible, the result is still as before -- we output a warning and don't continue at all. Obviously, this is suboptimal, and will change with an upcoming PR. If no value at all is possible, that means we are already in an UNSAT branch, and the execution should stop. That should also be an upcoming PR. Currently, we also handle that with the warning, as before.

In other words, I think this PR is basically the beginning of something a bit more serious :) I hope you like it!

[1] I have bumped into a case where we got a symbolic expression for the cheatcode ABI. This PR fixes that too -- if the ABI can only be a single value, it will now simply work.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog