### PR TITLE
Removing IOAct which was not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - We now try to simplify expressions fully before trying to cast them to a concrete value
   This should improve issues when "Unexpected Symbolic Arguments to Opcode" was
   unnecessarily output
+- Removed dead code related to IOAct in the now deprecated and removed debugger
 
 ## [0.54.2] - 2024-12-12
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -306,9 +306,6 @@ interpret fetcher maxIter askSmtIters heuristic vm =
       Stepper.Exec -> do
         (r, vm') <- liftIO $ stToIO $ runStateT exec vm
         interpret fetcher maxIter askSmtIters heuristic vm' (k r)
-      Stepper.IOAct q -> do
-        r <- liftIO q
-        interpret fetcher maxIter askSmtIters heuristic vm (k r)
       Stepper.Ask (PleaseChoosePath cond continue) -> do
         frozen <- liftIO $ stToIO $ freezeVM vm
         evalLeft <- toIO $ do

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -581,8 +581,6 @@ interpretWithTrace fetcher =
           vm' <- liftIO $ stToIO $ State.execStateT m vm
           assign _1 vm'
           interpretWithTrace fetcher (k ())
-        Stepper.IOAct q ->
-          liftIO q >>= interpretWithTrace fetcher . k
         Stepper.EVM m -> do
           vm <- use _1
           (r, vm') <- liftIO $ stToIO $ State.runStateT m vm


### PR DESCRIPTION
## Description

This has been unused for a while. It was meant for the debugging interface, for the user to be able to e.g. choose a path to go towards, but that has been removed for a long while.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
