### PR TITLE
Forgot to set dumpEndStates for --debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unnecessarily output
 - Not all testcases ran due to incorrect filtering, fixed
 - Removed dead code related to IOAct in the now deprecated and removed debugger
+- Dumping of END states (.prop) files is now default for `--debug`
 
 ## [0.54.2] - 2024-12-12
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -211,6 +211,7 @@ main = withUtf8 $ do
   let env = Env { config = defaultConfig
     { dumpQueries = cmd.smtdebug
     , debug = cmd.debug
+    , dumpEndStates = cmd.debug
     , dumpExprs = cmd.debug
     , numCexFuzz = cmd.numCexFuzz
     , dumpTrace = cmd.trace


### PR DESCRIPTION
## Description
This should be default for `--debug` as it's not noisy at all and is very helpful

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
