### PR TITLE
Gas fixes

### DIFF
--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -9,7 +9,7 @@ module EVM.SMT where
 import Prelude hiding (LT, GT)
 
 import Control.Monad
-import Data.Containers.ListUtils (nubOrd)
+import Data.Containers.ListUtils (nubOrd, nubInt)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.List qualified as List
@@ -451,7 +451,7 @@ enforceGasOrder ps = SMT2 (["; gas ordering"] <> order indices) mempty mempty
     consecutivePairs :: [Int] -> [(Int, Int)]
     consecutivePairs [] = []
     consecutivePairs l = zip l (tail l)
-    indices :: [Int] = nubOrd $ concatMap (foldProp go mempty) ps
+    indices :: [Int] = nubInt $ concatMap (foldProp go mempty) ps
     go :: Expr a -> [Int]
     go e = case e of
       Gas freshVar -> [freshVar]

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -442,16 +442,16 @@ declareAddrs names = SMT2 (["; symbolic addresseses"] <> fmap declare names) cex
     cexvars = (mempty :: CexVars){ addrs = fmap toLazyText names }
 
 enforceGasOrder :: [Prop] -> SMT2
-enforceGasOrder ps = SMT2 (["; gas ordering"] <> order names) mempty mempty
+enforceGasOrder ps = SMT2 (["; gas ordering"] <> order indices) mempty mempty
   where
     order :: [Int] -> [Builder]
-    order n = consecutivePairs n >>= \case
+    order n = consecutivePairs n >>= \(x, y)->
       -- The GAS instruction itself costs gas, so it's strictly decreasing
-      (x, y) -> ["(assert (bvugt gas_" <> (fromString . show $ x) <> " gas_" <> (fromString . show $ y) <> "))"]
+      ["(assert (bvugt gas_" <> (fromString . show $ x) <> " gas_" <> (fromString . show $ y) <> "))"]
     consecutivePairs :: [Int] -> [(Int, Int)]
     consecutivePairs [] = []
     consecutivePairs l = zip l (tail l)
-    names :: [Int] = nubOrd $ concatMap (foldProp go mempty) ps
+    indices :: [Int] = nubOrd $ concatMap (foldProp go mempty) ps
     go :: Expr a -> [Int]
     go e = case e of
       Gas freshVar -> [freshVar]

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -450,8 +450,7 @@ enforceGasOrder ps = SMT2 (["; gas ordering"] <> order names) mempty mempty
       (x, y) -> ["(assert (bvugt gas_" <> (fromString . show $ x) <> " gas_" <> (fromString . show $ y) <> "))"]
     consecutivePairs :: [Int] -> [(Int, Int)]
     consecutivePairs [] = []
-    consecutivePairs [_] = []
-    consecutivePairs (x:y:xs) = (x, y) : consecutivePairs (y:xs)
+    consecutivePairs l = zip l (tail l)
     names :: [Int] = nubOrd $ concatMap (foldProp go mempty) ps
     go :: Expr a -> [Int]
     go e = case e of

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -286,7 +286,7 @@ data Expr (a :: EType) where
 
   Balance        :: Expr EAddr -> Expr EWord
 
-  Gas            :: Int                -- frame idx
+  Gas            :: Int                -- fresh gas variable
                  -> Expr EWord
 
   -- code

--- a/test/test.hs
+++ b/test/test.hs
@@ -1168,8 +1168,21 @@ tests = testGroup "hevm"
              |]
          (_, [Cex _]) <- withSolvers Bitwuzla 1 1 Nothing $ \s -> checkAssert s [0x1] c Nothing [] defaultVeriOpts
          putStrLnM "expected counterexample found"
-      ,
-     test "enum-conversion-fail" $ do
+     , test "gas-decrease-monotone" $ do
+        Just c <- solcRuntime "MyContract"
+            [i|
+            contract MyContract {
+              function fun(uint8 a) external {
+                uint a = gasleft();
+                uint b = gasleft();
+                assert(a > b);
+              }
+             }
+            |]
+        let sig = (Just (Sig "fun(uint8)" [AbiUIntType 8]))
+        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+        putStrLnM "expected Qed found"
+     , test "enum-conversion-fail" $ do
         Just c <- solcRuntime "MyContract"
             [i|
             contract MyContract {


### PR DESCRIPTION
## Description
Gas has been a second-class citizen. We kinda died on it in many cases. This fixes some of the issues related to Gas:
* We use a specific variable, `gas_X` to track it
* We can now emit it in SMT
* We enforce an order on in SMT: gas is monotonically decreasing. This is true because issuing `Gas` decreases the gas so even `Gas, Gas, Gas` is strictly monotonically decreasing.

I added a test-case for gas as well.

## Checklist

- [ ] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
