### PR TITLE
Update more precise smt address encoding PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and continue running, whenever possible
 - STATICCALL abstraction is now performed in case of symbolic arguments
 - Better error messages for JSON parsing
+- Aliasing works much better for symbolic and concrete addresses
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2160,8 +2160,9 @@ create self this xSize xGas xValue xs newAddr initCode = do
     pushTrace $ ErrorTrace CallDepthLimitReached
     next
   -- are we deploying to an address that already has a contract?
-  -- note: this check is only sound to do statically if symbolic addresses
-  -- cannot have the value of any existing concrete addresses in the state.
+  -- note: the symbolic interpreter generates constraints ensuring that
+  -- symbolic storage keys cannot alias other storage keys, making this check
+  -- safe to perform statically
   else if collision $ Map.lookup newAddr vm0.env.contracts
   then burn' xGas $ do
     assign (#state % #stack) (Lit 0 : xs)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1390,6 +1390,10 @@ isPartial = \case
   Partial {} -> True
   _ -> False
 
+isSymAddr :: Expr EAddr -> Bool
+isSymAddr (SymAddr _) = True
+isSymAddr _ = False
+
 -- | Returns the byte at idx from the given word.
 indexWord :: Expr EWord -> Expr EWord -> Expr Byte
 -- Simplify masked reads:

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -436,7 +436,7 @@ declareVars names = SMT2 (["; variables"] <> fmap declare names) cexvars mempty
 
 -- Given a list of variable names, create an SMT2 object with the variables declared
 declareConstrainAddrs :: [Builder] -> SMT2
-declareConstrainAddrs names = SMT2 (["; concretea and symbolic addresseses"] <> fmap declare names <> fmap assume names) cexvars mempty
+declareConstrainAddrs names = SMT2 (["; concrete and symbolic addresses"] <> fmap declare names <> fmap assume names) cexvars mempty
   where
     declare n = "(declare-fun " <> n <> " () Addr)"
     -- assume that symbolic addresses do not collide with the zero address or precompiles

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -433,9 +433,11 @@ declareVars names = SMT2 (["; variables"] <> fmap declare names) cexvars mempty
 
 -- Given a list of variable names, create an SMT2 object with the variables declared
 declareAddrs :: [Builder] -> SMT2
-declareAddrs names = SMT2 (["; symbolic addresseses"] <> fmap declare names) cexvars mempty
+declareAddrs names = SMT2 (["; symbolic addresseses"] <> fmap declare names <> fmap assume names) mempty cexvars
   where
     declare n = "(declare-fun " <> n <> " () Addr)"
+    -- assume that symbolic addresses do not collide with the zero address or precompiles
+    assume n = "(assert (bvugt " <> n <> " (_ bv9 160)))"
     cexvars = (mempty :: CexVars){ addrs = fmap toLazyText names }
 
 declareFrameContext :: [(Builder, [Prop])] -> Err SMT2

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -499,11 +499,17 @@ runExpr :: Stepper.Stepper Symbolic RealWorld (Expr End)
 runExpr = do
   vm <- Stepper.runFully
   let traces = TraceContext (Zipper.toForest vm.traces) vm.env.contracts vm.labels
+  let constraints = vm.constraints <> consistentStorageKeys vm.env.contracts
   pure $ case vm.result of
-    Just (VMSuccess buf) -> Success vm.constraints traces buf (fmap toEContract vm.env.contracts)
-    Just (VMFailure e) -> Failure vm.constraints traces e
-    Just (Unfinished p) -> Partial vm.constraints traces p
+    Just (VMSuccess buf) -> Success constraints traces buf (fmap toEContract vm.env.contracts)
+    Just (VMFailure e)   -> Failure constraints traces e
+    Just (Unfinished p)  -> Partial constraints traces p
     _ -> internalError "vm in intermediate state after call to runFully"
+
+-- build constraints that ensure that symbolic storage keys cannot alias other storage keys
+  -- let asserts = vm.constraints <> consistentStorageKeys vm.env.contracts
+consistentStorageKeys :: Map (Expr EAddr) Contract -> [Prop]
+consistentStorageKeys (Map.keys -> addrs) = [a ./= b | a <- addrs, b <- filter Expr.isSymAddr addrs]
 
 toEContract :: Contract -> Expr EContract
 toEContract c = C c.code c.storage c.tStorage c.balance c.nonce
@@ -963,7 +969,7 @@ prettyCalldata cex buf sig types = headErr errSig (T.splitOn "(" sig) <> "(" <> 
           ConcreteBuf c -> T.pack (bsToHex c)
           _ -> err
       SAbi _ -> err
-    headErr e l = fromMaybe e $ listToMaybe l 
+    headErr e l = fromMaybe e $ listToMaybe l
     err = internalError $ "unable to produce a concrete model for calldata: " <> show buf
     errSig = internalError $ "unable to split sig: " <> show sig
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -1967,7 +1967,7 @@ tests = testGroup "hevm"
           [i|
             contract A {
               function f() external {
-                assert(msg.sender != address(0x0));
+                assert(msg.sender != address(0x10));
               }
             }
           |]
@@ -1975,7 +1975,7 @@ tests = testGroup "hevm"
           [i|
             contract B {
               function f() external {
-                assert(block.coinbase != address(0x1));
+                assert(block.coinbase != address(0x11));
               }
             }
           |]
@@ -1983,7 +1983,7 @@ tests = testGroup "hevm"
           [i|
             contract C {
               function f() external {
-                assert(tx.origin != address(0x2));
+                assert(tx.origin != address(0x12));
               }
             }
           |]
@@ -1991,7 +1991,7 @@ tests = testGroup "hevm"
           [i|
             contract D {
               function f() external {
-                assert(address(this) != address(0x3));
+                assert(address(this) != address(0x13));
               }
             }
           |]

--- a/test/test.hs
+++ b/test/test.hs
@@ -1759,8 +1759,7 @@ tests = testGroup "hevm"
         Just c <- solcRuntime "C" src
         res <- reachableUserAsserts c Nothing
         assertBoolM "unexpected cex" (isRight res)
-    -- TODO: implement missing aliasing rules
-    , expectFail $ test "deployed-contract-addresses-cannot-alias" $ do
+    , testCase "deployed-contract-addresses-cannot-alias" $ do
         Just c <- solcRuntime "C"
           [i|
             contract A {}
@@ -1962,6 +1961,20 @@ tests = testGroup "hevm"
         Right e <- reachableUserAsserts c Nothing
         -- TODO: this should work one day
         assertBoolM "should be partial" (Expr.containsNode isPartial e)
+    , test "symbolic-addresses-cannot-be-zero-or-precompiles" $ do
+        let addrs = [T.pack . show . Addr $ a | a <- [0x0..0x09]]
+            mkC a = fromJust <$> solcRuntime "A"
+              [i|
+                contract A {
+                  function f() external {
+                    assert(msg.sender != address(${a}));
+                  }
+                }
+              |]
+        codes <- mapM mkC addrs
+        results <- mapM (flip reachableUserAsserts (Just (Sig "f()" []))) codes
+        let ok = and $ fmap (isRight) results
+        assertBool "unexpected cex" ok
     , test "addresses-in-context-are-symbolic" $ do
         Just a <- solcRuntime "A"
           [i|


### PR DESCRIPTION
## Description
This is an update to #376  that makes it work for the test cases added to that PR. As per @d-xo 's description:

`This adds some more assertions during encoding around the values of symbolic addresses. Still needed is a pass that asserts that all symbolic addresses are pairwise distinct with all known concrete addresses.`

I have added the part that they are pairwise distinct. It is also working now because it checks the addresses _before_ they get erased through the revert that `VMFailure` does. So the generation of the constraints is done _before_ the `VMFailure`'s revert. This fixes the underlying issue that I think may have been created since that PR.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
