### PR TITLE
Early multi-solutions system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and continue running, whenever possible
 - STATICCALL abstraction is now performed in case of symbolic arguments
 - Better error messages for JSON parsing
+- Multiple solutions are allowed for a single symbolic expression
 - Constant propagation for symbolic values
 
 ## Fixed

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -102,6 +102,7 @@ data Command w
       , solverThreads :: w ::: Maybe Natural      <?> "Number of threads for each solver instance. Only respected for Z3 (default: 1)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , noDecompose   :: w ::: Bool               <?> "Don't decompose storage slots into separate arrays"
+      , maxBranch     :: w ::: Int                <!> "10" <?> "Max number of branches to explore when encountering a symbolic value (default: 10)"
       }
   | Equivalence -- prove equivalence between two programs
       { codeA         :: w ::: ByteString       <?> "Bytecode of the first program"
@@ -122,6 +123,7 @@ data Command w
       , solverThreads :: w ::: Maybe Natural    <?> "Number of threads for each solver instance. Only respected for Z3 (default: 1)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , noDecompose   :: w ::: Bool             <?> "Don't decompose storage slots into separate arrays"
+      , maxBranch     :: w ::: Int              <!> "10" <?> "Max number of branches to explore when encountering a symbolic value (default: 10)"
       }
   | Exec -- Execute a given program with specified env & calldata
       { code        :: w ::: Maybe ByteString  <?> "Program bytecode"
@@ -171,6 +173,7 @@ data Command w
       , maxIterations :: w ::: Maybe Integer            <?> "Number of times we may revisit a particular branching point. For no bound, set -1 (default: 5)"
       , loopDetectionHeuristic :: w ::: LoopHeuristic   <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , noDecompose   :: w ::: Bool                     <?> "Don't decompose storage slots into separate arrays"
+      , maxBranch     :: w ::: Int                      <!> "10" <?> "Max number of branches to explore when encountering a symbolic value (default: 10)"
       , numCexFuzz    :: w ::: Integer                  <!> "3" <?> "Number of fuzzing tries to do to generate a counterexample (default: 3)"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       }
@@ -216,6 +219,7 @@ main = withUtf8 $ do
     , numCexFuzz = cmd.numCexFuzz
     , dumpTrace = cmd.trace
     , decomposeStorage = Prelude.not cmd.noDecompose
+    , maxNumBranch = cmd.maxBranch
     } }
   case cmd of
     Version {} ->putStrLn getFullVersion

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -994,15 +994,15 @@ exec1 = do
           case stk of
             xGas:xTo:xInOffset:xInSize:xOutOffset:xOutSize:xs ->
               case wordToAddr xTo of
-                Nothing -> fallback undefined
+                Nothing -> fallback
                 Just xTo' -> do
                   case gasTryFrom xGas of
                     Left _ -> vmError IllegalOverflow
                     Right gas -> canFetchAccount xTo' >>= \case
-                      False -> fallback undefined
+                      False -> fallback
                       True -> do
                         overrideC <- use $ #state % #overrideCaller
-                        delegateCall this gas xTo' xTo' (Lit 0) xInOffset xInSize xOutOffset xOutSize xs fallback $
+                        delegateCall this gas xTo' xTo' (Lit 0) xInOffset xInSize xOutOffset xOutSize xs (const fallback) $
                           \callee -> do
                             zoom #state $ do
                               assign #callvalue (Lit 0)
@@ -1012,8 +1012,8 @@ exec1 = do
                             touchAccount self
                             touchAccount callee
               where
-                fallback :: a -> EVM t s ()
-                fallback _ = do
+                fallback :: EVM t s ()
+                fallback = do
                   -- Reset caller if needed
                   resetCaller <- use $ #state % #resetCaller
                   when resetCaller $ assign (#state % #overrideCaller) Nothing

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -3028,12 +3028,12 @@ instance VMOps Symbolic where
         assign #result Nothing
         continue Nothing
     where
-      runMore vals leftOrRight = do
+      runMore vals firstThread = do
         case length vals of
           -- if 2, we run both, otherwise, we run 1st and run ourselves with the rest
-          2 -> if leftOrRight then runOne $ head vals
+          2 -> if firstThread then runOne $ head vals
                else runOne (head $ tail vals)
-          _ -> if leftOrRight then runOne $ head vals
+          _ -> if firstThread then runOne $ head vals
                else runBoth . PleaseRunBoth ewordExpr $ runMore (tail vals)
       runOne val = do
         assign #result Nothing

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -43,6 +43,7 @@ data Config = Config
    -- Returns Unknown if the Cex cannot be found via fuzzing
   , onlyCexFuzz      :: Bool
   , decomposeStorage :: Bool
+  , maxNumBranch     :: Int
   }
   deriving (Show, Eq)
 
@@ -56,6 +57,7 @@ defaultConfig = Config
   , numCexFuzz = 10
   , onlyCexFuzz  = False
   , decomposeStorage = True
+  , maxNumBranch = 10
   }
 
 -- Write to the console

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -29,6 +29,9 @@ import System.Process
 import Control.Monad.IO.Class
 import Control.Monad (when)
 import EVM.Effects
+import qualified EVM.Expr as Expr
+import Numeric (showHex,readHex)
+import Data.Bits ((.&.))
 
 -- | Abstract representation of an RPC fetch request
 data RpcQuery a where
@@ -213,9 +216,9 @@ oracle solvers info q = do
          -- Is is possible to satisfy the condition?
          continue <$> checkBranch solvers (branchcondition ./= (Lit 0)) pathconds
 
-    PleaseGetSol symAddr pathconditions continue -> do
+    PleaseGetSols symExpr numBytes pathconditions continue -> do
          let pathconds = foldl' PAnd (PBool True) pathconditions
-         continue <$> getSolution solvers symAddr pathconds
+         continue <$> getSolutions solvers symExpr numBytes pathconds
 
     PleaseFetchContract addr base continue -> do
       contract <- case info of
@@ -244,33 +247,41 @@ oracle solvers info q = do
 
 type Fetcher t m s = App m => Query t s -> m (EVM t s ())
 
-getSolution :: forall m . App m => SolverGroup -> Expr EWord -> Prop -> m (Maybe W256)
-getSolution solvers symAddr pathconditions = do
+getSolutions :: forall m . App m => SolverGroup -> Expr EWord -> Int -> Prop -> m (Maybe [W256])
+getSolutions solvers symExprPreSimp numBytes pathconditions = do
   conf <- readConfig
   liftIO $ do
-    ret <- collectSolutions [] 1 pathconditions conf
+    let symExpr = Expr.concKeccakSimpExpr symExprPreSimp
+    when conf.debug $ putStrLn $ "Collecting solutions to symbolic query: " <> show symExpr
+    ret <- collectSolutions [] conf.maxNumBranch symExpr pathconditions conf
     case ret of
       Nothing -> pure Nothing
       Just r -> case length r of
         0 -> pure Nothing
-        -- Temporary, a future improvement can deal with more than one solution
-        1 -> pure $ Just (r !! 0)
-        _ -> pure Nothing
+        _ -> pure $ Just r
     where
-      collectSolutions :: [W256] -> Int -> Prop -> Config -> IO (Maybe [W256])
-      collectSolutions addrs maxSols conds conf = do
-        if (length addrs > maxSols) then pure Nothing
+      createHexValue k =
+          let hexString = concat (replicate k "ff")
+          in fst . head $ readHex hexString
+      collectSolutions :: [W256] -> Int -> Expr EWord -> Prop -> Config -> IO (Maybe [W256])
+      collectSolutions vals maxSols symExpr conds conf = do
+        if (length vals > maxSols) then pure Nothing
         else
-          checkSat solvers (assertProps conf [(PEq (Var "addrQuery") symAddr) .&& conds]) >>= \case
+          checkSat solvers (assertProps conf [(PEq (Var "addrQuery") symExpr) .&& conds]) >>= \case
             Sat (SMTCex vars _ _ _ _ _)  -> case (Map.lookup (Var "addrQuery") vars) of
-              Just addr -> do
-                let newConds = PAnd conds (symAddr ./= (Lit addr))
-                when conf.debug $ putStrLn $ "Got one solution to symbolic query:" <> show addr <> " now have " <> show (length addrs + 1) <> " solution(s), max is: " <> show maxSols
-                collectSolutions (addr:addrs) maxSols newConds conf
+              Just v -> do
+                let hexMask = createHexValue numBytes
+                    maskedVal = v .&. hexMask
+                    cond = (And symExpr (Lit hexMask)) ./= Lit maskedVal
+                    newConds = Expr.simplifyProp $ PAnd conds cond
+                    showedVal = "val: 0x" <> (showHex maskedVal "")
+                when conf.debug $ putStrLn $ "Got one solution to symbolic query," <> showedVal <> " now have " <>
+                  show (length vals + 1) <> " solution(s), max is: " <> show maxSols
+                collectSolutions (maskedVal:vals) maxSols symExpr newConds conf
               _ -> internalError "No solution to symbolic query"
             Unsat -> do
               when conf.debug $ putStrLn "No more solution(s) to symbolic query."
-              pure $ Just addrs
+              pure $ Just vals
             -- Error or timeout, we need to be conservative
             res -> do
               when conf.debug $ putStrLn $ "Symbolic query result is neither SAT nor UNSAT:" <> show res

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -131,7 +131,6 @@ withSolvers solver count threads timeout cont = do
             when (conf.debug) $ putStrLn $ "   Cex found via fuzzing:" <> (show fuzzResult)
             writeChan r (Sat $ fromJust fuzzResult)
           else if not conf.onlyCexFuzz then do
-            when (conf.debug) $ putStrLn "   Fuzzing failed to find a Cex"
             -- reset solver and send all lines of provided script
             out <- sendScript inst (SMT2 ("(reset)" : cmds) mempty ps)
             case out of

--- a/src/EVM/Stepper.hs
+++ b/src/EVM/Stepper.hs
@@ -8,7 +8,7 @@ module EVM.Stepper
   , run
   , runFully
   , wait
-  , ask
+  , fork
   , evm
   , enter
   , interpret
@@ -43,7 +43,7 @@ data Action t s a where
   Wait :: Query t s -> Action t s ()
 
   -- | Multiple things can happen
-  Ask :: Choose s -> Action Symbolic s ()
+  Fork :: RunBoth s -> Action Symbolic s ()
 
   -- | Embed a VM state transformation
   EVM  :: EVM t s a -> Action t s a
@@ -62,8 +62,8 @@ run = exec >> evm get
 wait :: Query t s -> Stepper t s ()
 wait = singleton . Wait
 
-ask :: Choose s -> Stepper Symbolic s ()
-ask = singleton . Ask
+fork :: RunBoth s -> Stepper Symbolic s ()
+fork = singleton . Fork
 
 evm :: EVM t s a -> Stepper t s a
 evm = singleton . EVM
@@ -87,8 +87,8 @@ runFully = do
     Nothing -> internalError "should not occur"
     Just (HandleEffect (Query q)) ->
       wait q >> runFully
-    Just (HandleEffect (Choose q)) ->
-      ask q >> runFully
+    Just (HandleEffect (RunBoth q)) ->
+      fork q >> runFully
     Just _ ->
       pure vm
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -963,7 +963,7 @@ prettyCalldata cex buf sig types = headErr errSig (T.splitOn "(" sig) <> "(" <> 
           ConcreteBuf c -> T.pack (bsToHex c)
           _ -> err
       SAbi _ -> err
-    headErr e l = fromMaybe e $ listToMaybe l 
+    headErr e l = fromMaybe e $ listToMaybe l
     err = internalError $ "unable to produce a concrete model for calldata: " <> show buf
     errSig = internalError $ "unable to split sig: " <> show sig
 

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -306,7 +306,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
       Stepper.Exec -> do
         (r, vm') <- liftIO $ stToIO $ runStateT exec vm
         interpret fetcher maxIter askSmtIters heuristic vm' (k r)
-      Stepper.Ask (PleaseChoosePath cond continue) -> do
+      Stepper.Fork (PleaseRunBoth cond continue) -> do
         frozen <- liftIO $ stToIO $ freezeVM vm
         evalLeft <- toIO $ do
           (ra, vma) <- liftIO $ stToIO $ runStateT (continue True) frozen { result = Nothing }

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -587,7 +587,7 @@ data PartialExec
 -- | Effect types used by the vm implementation for side effects & control flow
 data Effect t s where
   Query :: Query t s -> Effect t s
-  Choose :: Choose s -> Effect Symbolic s
+  RunBoth :: RunBoth s -> Effect Symbolic s
 deriving instance Show (Effect t s)
 
 -- | Queries halt execution until resolved through RPC calls or SMT queries
@@ -600,8 +600,8 @@ data Query t s where
   PleaseReadEnv       :: String -> (String -> EVM t s ()) -> Query t s
 
 -- | Execution could proceed down one of two branches
-data Choose s where
-  PleaseChoosePath    :: Expr EWord -> (Bool -> EVM Symbolic s ()) -> Choose s
+data RunBoth s where
+  PleaseRunBoth    :: Expr EWord -> (Bool -> EVM Symbolic s ()) -> RunBoth s
 
 -- | The possible return values of a SMT query
 data BranchCondition = Case Bool | Unknown
@@ -630,10 +630,10 @@ instance Show (Query t s) where
     PleaseReadEnv variable _ ->
       (("<EVM.Query: read env: " ++ variable) ++)
 
-instance Show (Choose s) where
+instance Show (RunBoth s) where
   showsPrec _ = \case
-    PleaseChoosePath _ _ ->
-      (("<EVM.Choice: system selecting path(s)") ++)
+    PleaseRunBoth _ _ ->
+      (("<EVM.RunBoth: system running both paths") ++)
 
 -- | The possible result states of a VM
 data VMResult (t :: VMType) s where

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -595,7 +595,7 @@ data Query t s where
   PleaseFetchContract :: Addr -> BaseState -> (Contract -> EVM t s ()) -> Query t s
   PleaseFetchSlot     :: Addr -> W256 -> (W256 -> EVM t s ()) -> Query t s
   PleaseAskSMT        :: Expr EWord -> [Prop] -> (BranchCondition -> EVM Symbolic s ()) -> Query Symbolic s
-  PleaseGetSol        :: Expr EWord -> [Prop] -> (Maybe W256 -> EVM Symbolic s ()) -> Query Symbolic s
+  PleaseGetSols       :: Expr EWord -> Int -> [Prop] -> (Maybe [W256] -> EVM Symbolic s ()) -> Query Symbolic s
   PleaseDoFFI         :: [String] -> Map String String -> (ByteString -> EVM t s ()) -> Query t s
   PleaseReadEnv       :: String -> (String -> EVM t s ()) -> Query t s
 
@@ -619,8 +619,10 @@ instance Show (Query t s) where
       (("<EVM.Query: ask SMT about "
         ++ show condition ++ " in context "
         ++ show constraints ++ ">") ++)
-    PleaseGetSol expr constraints _ ->
-      (("<EVM.Query: ask SMT to get W256 for expression "
+    PleaseGetSols expr numBytes constraints _ ->
+      (("<EVM.Query: ask SMT "
+        ++ "for address " ++ show numBytes ++ "bytes "
+        ++ "of W256 for expression "
         ++ show expr ++ " in context "
         ++ show constraints ++ ">") ++)
     PleaseDoFFI cmd env _ ->
@@ -631,7 +633,7 @@ instance Show (Query t s) where
 instance Show (Choose s) where
   showsPrec _ = \case
     PleaseChoosePath _ _ ->
-      (("<EVM.Choice: waiting for user to select path (0,1)") ++)
+      (("<EVM.Choice: system selecting path(s)") ++)
 
 -- | The possible result states of a VM
 data VMResult (t :: VMType) s where
@@ -863,7 +865,7 @@ class VMOps (t :: VMType) where
 
   partial :: PartialExec -> EVM t s ()
   branch :: Expr EWord -> (Bool -> EVM t s ()) -> EVM t s ()
-  oneSolution :: Expr EWord -> (Maybe W256 -> EVM t s ()) -> EVM t s ()
+  manySolutions :: Expr EWord -> Int -> (Maybe W256 -> EVM t s ()) -> EVM t s ()
 
 -- Bytecode Representations ------------------------------------------------------------------------
 

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -621,7 +621,7 @@ instance Show (Query t s) where
         ++ show constraints ++ ">") ++)
     PleaseGetSols expr numBytes constraints _ ->
       (("<EVM.Query: ask SMT "
-        ++ "for address " ++ show numBytes ++ "bytes "
+        ++ "for " ++ show numBytes ++ " bytes "
         ++ "of W256 for expression "
         ++ show expr ++ " in context "
         ++ show constraints ++ ">") ++)

--- a/test/test.hs
+++ b/test/test.hs
@@ -2113,7 +2113,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        let sig =Just (Sig "fun(uint160)" [AbiUIntType 160])
+        let sig = Just (Sig "fun(uint160)" [AbiUIntType 160])
         (e, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
         assertBoolM "The expression is not partial" $ Prelude.not (Expr.containsNode isPartial e)
      ,

--- a/test/test.hs
+++ b/test/test.hs
@@ -53,7 +53,7 @@ import Data.Containers.ListUtils (nubOrd)
 import Optics.Core hiding (pre, re, elements)
 import Optics.State
 
-import EVM hiding (choose)
+import EVM
 import EVM.ABI
 import EVM.Assembler
 import EVM.Exec

--- a/test/test.hs
+++ b/test/test.hs
@@ -2115,7 +2115,7 @@ tests = testGroup "hevm"
             |]
         let sig =Just (Sig "fun(uint160)" [AbiUIntType 160])
         (e, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
-        assertBoolM "The expression is partial" $ Prelude.not (Expr.containsNode isPartial e)
+        assertBoolM "The expression is not partial" $ Prelude.not (Expr.containsNode isPartial e)
      ,
      -- here test
      test "ITE-with-bitwise-AND" $ do


### PR DESCRIPTION
## Description
Making progress towards symbolic jumpdestinations via SMT solving. This PR allows us to branch out to all potential jumpdests.

The system can restrict the returned value's number of relevant bytes to a fixed value. So if we are looking for a JUMP, it ignores high bytes, because it's impossible to have a PC that's more than 2^16 (more than 65K instructions). Similarly for addresses. This matters, because it can happen that there's some junk that's not restricted and we could get thousands of solutions, but they are actually all the same address if we ignore the bits other than the 160b that an address has.

Currently, it launches a new query for each new solution, which is very slow. This needs to be improved in a new PR. That will require a slight re-engineering of Solvers.hs, so we can query the system for more than one solution at a time.

Number of potential concrete is set to 10 by default. This is actually kinda low. However, we need to be a bit cautious, as things can blow up quickly, so I set 10. It can be changed via `--max-branch K`.

Currently, it does NOT use incremental solving to get multiple solutions. This is not optimal. Hence, it's called "early", as a next PR will fix that.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
