### PR TITLE
Update description of calldata in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better exponential simplification
 - Dumping of END states (.prop) files is now default for `--debug`
 - When cheatcode is missing, we produce a partial execution warning
+- Size of calldata can be up to 2**64, not 256. This is now reflected in the documentation
 
 ## [0.54.2] - 2024-12-12
 

--- a/doc/src/equivalence.md
+++ b/doc/src/equivalence.md
@@ -48,6 +48,6 @@ hevm equivalence \
 ```
 If `--sig` is given, calldata is assumed to take the form of the function
 given. If `--calldata` is provided, a specific, concrete calldata is used. If
-neither is provided, calldata of at most `2**64` byte is assumed. Note that a
-`2**64` byte calldata would go over the gas limit, and hence should cover all
-meaningful cases.
+neither is provided, a fully abstract calldata of at most `2**64` byte is
+assumed. Note that a `2**64` byte calldata would go over the gas limit, and
+hence should cover all meaningful cases.

--- a/doc/src/equivalence.md
+++ b/doc/src/equivalence.md
@@ -46,8 +46,8 @@ hevm equivalence \
     --code-a $(solc --bin-runtime "contract1.sol" | tail -n1) \
     --code-b $(solc --bin-runtime "contract2.sol" | tail -n1)
 ```
-
-If `--sig` is provided, a specific function signature is used. If `--calldata` is provided,
-a specific, concrete calldata is used. If neither is provided, calldata of at most `2**64` byte
-is assumed. Note that a `2**64` byte calldata would go over the gas limit, and hence should
-cover all meaningful cases.
+If `--sig` is given, calldata is assumed to take the form of the function
+given. If `--calldata` is provided, a specific, concrete calldata is used. If
+neither is provided, calldata of at most `2**64` byte is assumed. Note that a
+`2**64` byte calldata would go over the gas limit, and hence should cover all
+meaningful cases.

--- a/doc/src/equivalence.md
+++ b/doc/src/equivalence.md
@@ -47,6 +47,7 @@ hevm equivalence \
     --code-b $(solc --bin-runtime "contract2.sol" | tail -n1)
 ```
 
-If `--sig` is given, calldata is assumed to take the form of the function
-given. If left out, calldata is a fully abstract buffer of at most 256 bytes.
-
+If `--sig` is provided, a specific function signature is used. If `--calldata` is provided,
+a specific, concrete calldata is used. If neither is provided, calldata of at most `2**64` byte
+is assumed. Note that a `2**64` byte calldata would go over the gas limit, and hence should
+cover all meaningful cases.


### PR DESCRIPTION
## Description
This fixes the description of the maximum size of the symbolic calldata in our documentation. Thanks to Charles Cooper for this one!

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [x] updated the docs
- [x] updated the changelog
