### PR TITLE
Fix in equivalence checking 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multiple solutions are allowed for a single symbolic expression
 - Aliasing works much better for symbolic and concrete addresses
 - Constant propagation for symbolic values
+- Add deployment code flag to the `equivalenceCheck` function
+- New simplification rule for reading a byte that is lower than destination offset in `copySlice`
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value
@@ -30,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Better exponential simplification
 - Dumping of END states (.prop) files is now default for `--debug`
 - When cheatcode is missing, we produce a partial execution warning
+- The equivalence checker now is able to prove that an empty store is equivalent to a store with all slots initialized to 0.
+
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -243,6 +243,9 @@ readByte i@(Lit x) (WriteWord (Lit idx) val src)
            (Lit _) -> indexWord (Lit $ x - idx) val
            _ -> IndexWord (Lit $ x - idx) val
     else readByte i src
+-- reading a byte that is lower than the dstOffset of a CopySlice, so it's just reading from src
+readByte i@(Lit x) (CopySlice _ (Lit dstOffset) _ _ dst) | dstOffset > x =
+  readByte i dst
 readByte i@(Lit x) (CopySlice (Lit srcOffset) (Lit dstOffset) (Lit size) src dst)
   = if x - dstOffset < size
     then readByte (Lit $ x - (dstOffset - srcOffset)) src

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -243,7 +243,7 @@ readByte i@(Lit x) (WriteWord (Lit idx) val src)
            (Lit _) -> indexWord (Lit $ x - idx) val
            _ -> IndexWord (Lit $ x - idx) val
     else readByte i src
--- reading a byte that is lower than the dstOffset of a CopySlice, so it's just reading from src
+-- reading a byte that is lower than the dstOffset of a CopySlice, so it's just reading from dst
 readByte i@(Lit x) (CopySlice _ (Lit dstOffset) _ _ dst) | dstOffset > x =
   readByte i dst
 readByte i@(Lit x) (CopySlice (Lit srcOffset) (Lit dstOffset) (Lit size) src dst)

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -394,6 +394,7 @@ solcRuntime contract src = do
       Just (Contracts sol, _, _) -> pure $ Map.lookup ("hevm.sol:" <> contract) sol <&> (.runtimeCode)
       Nothing -> internalError $ "unable to parse solidity output:\n" <> (T.unpack json)
 
+
 functionAbi :: Text -> IO Method
 functionAbi f = do
   json <- solc Solidity ("contract ABI { function " <> f <> " public {}}")

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -687,8 +687,9 @@ equivalenceCheck
   -> ByteString
   -> VeriOpts
   -> (Expr Buf, [Prop])
+  -> Bool
   -> m ([EquivResult], [Expr End])
-equivalenceCheck solvers bytecodeA bytecodeB opts calldata = do
+equivalenceCheck solvers bytecodeA bytecodeB opts calldata create = do
   conf <- readConfig
   case bytecodeA == bytecodeB of
     True -> liftIO $ do
@@ -706,7 +707,7 @@ equivalenceCheck solvers bytecodeA bytecodeB opts calldata = do
     getBranches :: ByteString -> m [Expr End]
     getBranches bs = do
       let bytecode = if BS.null bs then BS.pack [0] else bs
-      prestate <- liftIO $ stToIO $ abstractVM calldata bytecode Nothing False
+      prestate <- liftIO $ stToIO $ abstractVM calldata bytecode Nothing create
       expr <- interpret (Fetch.oracle solvers Nothing) opts.maxIter opts.askSmtIters opts.loopHeuristic prestate runExpr
       let simpl = if opts.simp then (Expr.simplify expr) else expr
       pure $ flattenExpr simpl
@@ -844,7 +845,7 @@ equivalenceCheck' solvers branchesA branchesB = do
         -- TODO: is this sound? do we need a more sophisticated nonce representation?
         noncesDiffer = PBool (ac.nonce /= bc.nonce)
         storesDiffer = case (ac.storage, bc.storage) of
-          (ConcreteStore as, ConcreteStore bs) -> PBool $ as /= bs
+          (ConcreteStore as, ConcreteStore bs) | not (as == Map.empty || bs == Map.empty) -> PBool $ as /= bs
           (as, bs) -> if as == bs then PBool False else as ./= bs
       in balsDiffer .|| storesDiffer .|| noncesDiffer
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -3767,8 +3767,8 @@ tests = testGroup "hevm"
             }
           |]
         withSolvers Z3 3 1 Nothing $ \s -> do
-          a <- equivalenceCheck s initA initB defaultVeriOpts (mkCalldata Nothing []) True
-          assertEqualM "Must have no difference" [Qed ()] a
+          (res, _) <- equivalenceCheck s initA initB defaultVeriOpts (mkCalldata Nothing []) True
+          assertEqualM "Must have no difference" [Qed ()] res
       ,
       test "eq-sol-exp-qed" $ do
         Just aPrgm <- solcRuntime "C"


### PR DESCRIPTION
## Description

The equivalence checker was not taking into account that an empty store is equivalent to a store with all slots initialized to zero. This was not allowing us to prove equivalence for certain smart contracts. 

## Summary of Changes

- If two stores are concrete and one of them is empty, the equivalence check is not performed statically (which was the case until now) but using the SMT encoding. This enforces the correct semantics
- The `symExec` function has now a flag that allows deployment code to be checked for equivalence 
- New simplification rule (by @msooseth) 
- New test that covers the problematic scenario 

Closes #647.

## Checklist

- [X] tested locally
- [X] added automated tests
- [ ] updated the docs
- [X] updated the changelog
