### PR TITLE
Much better overapproximation, and maxBufSize limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More simplification rules that help avoid symbolic copyslice in case of
   STATICCALL overapproximation
 - Test to make sure we don't accidentally overapproximate a working, good STATICCALL
+- Allow EXTCODESIZE/HASH, BALANCE to be abstracted to a symbolic value.
+- Allow CALL to be extracted in case `--promise-no-reent` is given, promising
+  no reentrancy of contracts. This may skip over reentrancy vulnerabilities
+  but allows much more thorough exploration of the contract
+- Allow controlling the max buffer sizes via --max-buf-size to something smaller than 2**64
+  so we don't get too large buffers as counterexamples
+
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value
@@ -42,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When cheatcode is missing, we produce a partial execution warning
 - Size of calldata can be up to 2**64, not 256. This is now reflected in the documentation
 - We now have less noise during test runs, and assert more about symbolic copyslice tests
+- CopySlice rewrite rule is now less strict while still being sound
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -189,7 +189,7 @@ data Command w
       , numCexFuzz    :: w ::: Integer                  <!> "3" <?> "Number of fuzzing tries to do to generate a counterexample (default: 3)"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
       , maxBufSize    :: w ::: Int                      <!> "64" <?> "Maximum size of buffers such as calldata and returndata in exponents of 2 (default: 64, i.e. 2^64 bytes)"
-      , promiseNoReent:: w ::: Bool                     <!> "Promise no reentrancy is possible into the contrct(s) being examined"
+      , promiseNoReent:: w ::: Bool                     <!> "Promise no reentrancy is possible into the contract(s) being examined"
       }
   | Version
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -228,6 +228,9 @@ main = withUtf8 $ do
   when (cmd.maxBufSize > 64) $ do
     putStrLn "Error: maxBufSize must be less than or equal to 64. That limits buffers to a size of 2^64, which is more than enough for practical purposes"
     exitFailure
+  when (cmd.maxBufSize < 0) $ do
+    putStrLn "Error: maxBufSize must be at least 0. Negative values do not make sense. A value of zero means at most 1 byte long buffers"
+    exitFailure
   let env = Env { config = defaultConfig
     { dumpQueries = cmd.smtdebug
     , debug = cmd.debug

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -108,6 +108,8 @@ data Command w
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , noDecompose   :: w ::: Bool               <?> "Don't decompose storage slots into separate arrays"
       , maxBranch     :: w ::: Int                <!> "100" <?> "Max number of branches to explore when encountering a symbolic value (default: 100)"
+      , promiseNoReent:: w ::: Bool               <!> "Promise no reentrancy is possible into the contrct(s) being examined"
+      , maxBufSize    :: w ::: Int                <!> "64" <?> "Maximum size of buffers such as calldata and returndata in exponents of 2 (default: 64, i.e. 2^64 bytes)"
       }
   | Equivalence -- prove equivalence between two programs
       { codeA         :: w ::: Maybe ByteString   <?> "Bytecode of the first program"
@@ -131,6 +133,8 @@ data Command w
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , noDecompose   :: w ::: Bool             <?> "Don't decompose storage slots into separate arrays"
       , maxBranch     :: w ::: Int              <!> "100" <?> "Max number of branches to explore when encountering a symbolic value (default: 100)"
+      , maxBufSize    :: w ::: Int              <!> "64" <?> "Maximum size of buffers such as calldata and returndata in exponents of 2 (default: 64, i.e. 2^64 bytes)"
+      , promiseNoReent:: w ::: Bool             <!> "Promise no reentrancy is possible into the contrct(s) being examined"
       }
   | Exec -- Execute a given program with specified env & calldata
       { code        :: w ::: Maybe ByteString  <?> "Program bytecode"
@@ -184,6 +188,8 @@ data Command w
       , maxBranch     :: w ::: Int                      <!> "100" <?> "Max number of branches to explore when encountering a symbolic value (default: 100)"
       , numCexFuzz    :: w ::: Integer                  <!> "3" <?> "Number of fuzzing tries to do to generate a counterexample (default: 3)"
       , askSmtIterations :: w ::: Integer               <!> "1" <?> "Number of times we may revisit a particular branching point before we consult the smt solver to check reachability (default: 1)"
+      , maxBufSize    :: w ::: Int                      <!> "64" <?> "Maximum size of buffers such as calldata and returndata in exponents of 2 (default: 64, i.e. 2^64 bytes)"
+      , promiseNoReent:: w ::: Bool                     <!> "Promise no reentrancy is possible into the contrct(s) being examined"
       }
   | Version
 
@@ -228,6 +234,8 @@ main = withUtf8 $ do
     , dumpTrace = cmd.trace
     , decomposeStorage = Prelude.not cmd.noDecompose
     , maxBranch = cmd.maxBranch
+    , promiseNoReent = cmd.promiseNoReent
+    , maxBufSize = cmd.maxBufSize
     } }
   case cmd of
     Version {} ->putStrLn getFullVersion
@@ -287,14 +295,13 @@ equivalence cmd = do
   when (isNothing bytecodeB) $ liftIO $ do
     putStrLn "Error: invalid or no bytecode for program B. Provide a valid one with --code-b or --code-b-file"
     exitFailure
-
   let veriOpts = VeriOpts { simp = True
                           , maxIter = parseMaxIters cmd.maxIterations
                           , askSmtIters = cmd.askSmtIterations
                           , loopHeuristic = cmd.loopDetectionHeuristic
                           , rpcInfo = Nothing
                           }
-  calldata <- liftIO $ buildCalldata cmd
+  calldata <- buildCalldata cmd
   solver <- liftIO $ getSolver cmd
   cores <- liftIO $ unsafeInto <$> getNumProcessors
   let solverCount = fromMaybe cores cmd.numSolvers
@@ -356,23 +363,23 @@ parseMaxIters i = if num < 0 then Nothing else Just num
     num = fromMaybe (5::Integer) i
 
 -- | Builds a buffer representing calldata based on the given cli arguments
-buildCalldata :: Command Options.Unwrapped -> IO (Expr Buf, [Prop])
+buildCalldata :: App m => Command Options.Unwrapped -> m (Expr Buf, [Prop])
 buildCalldata cmd = case (cmd.calldata, cmd.sig) of
   -- fully abstract calldata
-  (Nothing, Nothing) -> pure $ mkCalldata Nothing []
+  (Nothing, Nothing) -> mkCalldata Nothing []
   -- fully concrete calldata
   (Just c, Nothing) -> do
     let val = hexByteString $ strip0x c
-    if (isNothing val) then do
+    if (isNothing val) then liftIO $ do
       putStrLn $ "Error, invalid calldata: " <>  show c
       exitFailure
     else pure (ConcreteBuf (fromJust val), [])
   -- calldata according to given abi with possible specializations from the `arg` list
   (Nothing, Just sig') -> do
-    method' <- functionAbi sig'
-    pure $ mkCalldata (Just (Sig method'.methodSignature (snd <$> method'.inputs))) cmd.arg
+    method' <- liftIO $ functionAbi sig'
+    mkCalldata (Just (Sig method'.methodSignature (snd <$> method'.inputs))) cmd.arg
   -- both args provided
-  (_, _) -> do
+  (_, _) -> liftIO $ do
     putStrLn "incompatible options provided: --calldata and --sig"
     exitFailure
 
@@ -382,7 +389,7 @@ assert :: App m => Command Options.Unwrapped -> m ()
 assert cmd = do
   let block'  = maybe Fetch.Latest Fetch.BlockNumber cmd.block
       rpcinfo = (,) block' <$> cmd.rpc
-  calldata <- liftIO $ buildCalldata cmd
+  calldata <- buildCalldata cmd
   preState <- liftIO $ symvmFromCommand cmd calldata
   let errCodes = fromMaybe defaultPanicCodes cmd.assertions
   cores <- liftIO $ unsafeInto <$> getNumProcessors

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -134,7 +134,7 @@ data Command w
       , noDecompose   :: w ::: Bool             <?> "Don't decompose storage slots into separate arrays"
       , maxBranch     :: w ::: Int              <!> "100" <?> "Max number of branches to explore when encountering a symbolic value (default: 100)"
       , maxBufSize    :: w ::: Int              <!> "64" <?> "Maximum size of buffers such as calldata and returndata in exponents of 2 (default: 64, i.e. 2^64 bytes)"
-      , promiseNoReent:: w ::: Bool             <!> "Promise no reentrancy is possible into the contrct(s) being examined"
+      , promiseNoReent:: w ::: Bool             <!> "Promise no reentrancy is possible into the contract(s) being examined"
       }
   | Exec -- Execute a given program with specified env & calldata
       { code        :: w ::: Maybe ByteString  <?> "Program bytecode"

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -225,6 +225,9 @@ getFullVersion = showVersion Paths.version <> " [" <> gitVersion <> "]"
 main :: IO ()
 main = withUtf8 $ do
   cmd <- Options.unwrapRecord "hevm -- Ethereum evaluator"
+  when (cmd.maxBufSize > 64) $ do
+    putStrLn "Error: maxBufSize must be less than or equal to 64. That limits buffers to a size of 2^64, which is more than enough for practical purposes"
+    exitFailure
   let env = Env { config = defaultConfig
     { dumpQueries = cmd.smtdebug
     , debug = cmd.debug

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -108,7 +108,7 @@ data Command w
       , loopDetectionHeuristic :: w ::: LoopHeuristic <!> "StackBased" <?> "Which heuristic should be used to determine if we are in a loop: StackBased (default) or Naive"
       , noDecompose   :: w ::: Bool               <?> "Don't decompose storage slots into separate arrays"
       , maxBranch     :: w ::: Int                <!> "100" <?> "Max number of branches to explore when encountering a symbolic value (default: 100)"
-      , promiseNoReent:: w ::: Bool               <!> "Promise no reentrancy is possible into the contrct(s) being examined"
+      , promiseNoReent:: w ::: Bool               <!> "Promise no reentrancy is possible into the contract(s) being examined"
       , maxBufSize    :: w ::: Int                <!> "64" <?> "Maximum size of buffers such as calldata and returndata in exponents of 2 (default: 64, i.e. 2^64 bytes)"
       }
   | Equivalence -- prove equivalence between two programs

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -331,7 +331,6 @@ exec1 conf = do
     else do
       let ?conf = conf
       let ?op = getOpW8 vm.state
-      let opName = getOpName vm.state
       case getOp (?op) of
 
         OpPush0 -> do

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1391,7 +1391,7 @@ query q = assign #result $ Just $ HandleEffect (Query q)
 runBoth :: RunBoth s -> EVM Symbolic s ()
 runBoth c = assign #result $ Just $ HandleEffect (RunBoth c)
 
-fetchAccount  :: VMOps t => Expr EAddr -> (Contract -> EVM t s ()) -> EVM t s ()
+fetchAccount :: VMOps t => Expr EAddr -> (Contract -> EVM t s ()) -> EVM t s ()
 fetchAccount addr continue =
   let fallback = defaultFallback "trying to access a symbolic address that isn't already present in storage"
   in fetchAccountWithFallback addr fallback continue

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -44,6 +44,8 @@ data Config = Config
   , onlyCexFuzz      :: Bool
   , decomposeStorage :: Bool
   , maxBranch     :: Int
+  , promiseNoReent   :: Bool
+  , maxBufSize       :: Int
   }
   deriving (Show, Eq)
 
@@ -58,6 +60,8 @@ defaultConfig = Config
   , onlyCexFuzz  = False
   , decomposeStorage = True
   , maxBranch = 100
+  , promiseNoReent = False
+  , maxBufSize = 64
   }
 
 -- Write to the console

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -10,6 +10,7 @@ import Data.ByteString (ByteString)
 import Data.Maybe (isNothing)
 import Optics.Core
 import Control.Monad.ST (ST)
+import EVM.Effects (Config)
 
 ethrunAddress :: Addr
 ethrunAddress = Addr 0x00a329c0648769a73afac7f9381e08fb43dbea72
@@ -46,18 +47,18 @@ vmForEthrunCreation creationCode =
     }) <&> set (#env % #contracts % at (LitAddr ethrunAddress))
              (Just (initialContract (RuntimeCode (ConcreteRuntimeCode ""))))
 
-exec :: VMOps t => EVM t s (VMResult t s)
-exec = do
+exec :: (VMOps t) => Config -> EVM t s (VMResult t s)
+exec conf = do
   vm <- get
   case vm.result of
-    Nothing -> exec1 >> exec
+    Nothing -> exec1 conf >> exec conf
     Just r -> pure r
 
-run :: VMOps t => EVM t s (VM t s)
-run = do
+run :: (VMOps t) => Config -> EVM t s (VM t s)
+run conf = do
   vm <- get
   case vm.result of
-    Nothing -> exec1 >> run
+    Nothing -> exec1 conf >> run conf
     Just _ -> pure vm
 
 execWhile :: (VM t s -> Bool) -> State (VM t s) Int

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -283,7 +283,7 @@ readWord idx b@(WriteWord idx' val buf)
     -- the region we want to read overlaps the WriteWord
     _ -> readWordFromBytes idx b
 -- reading a Word that is lower than the dstOffset-32 of a CopySlice, so it's just reading from dst
-readWord i@(Lit x) (CopySlice _ (Lit dstOffset) _ _ dst) | dstOffset > x+32 =
+readWord i@(Lit x) (CopySlice _ (Lit dstOffset) _ _ dst) | dstOffset >= x+32 =
   readWord i dst
 readWord (Lit idx) b@(CopySlice (Lit srcOff) (Lit dstOff) (Lit size) src dst)
   -- the region we are trying to read is enclosed in the sliced region

--- a/src/EVM/Stepper.hs
+++ b/src/EVM/Stepper.hs
@@ -108,7 +108,8 @@ interpret fetcher vm = eval . view
     eval (action :>>= k) =
       case action of
         Exec -> do
-          (r, vm') <- liftIO $ stToIO $ runStateT EVM.Exec.exec vm
+          conf <- readConfig
+          (r, vm') <- liftIO $ stToIO $ runStateT (EVM.Exec.exec conf) vm
           interpret fetcher vm' (k r)
         Wait q -> do
           m <- fetcher q

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -196,8 +196,8 @@ symRun :: App m => UnitTestOptions RealWorld -> VM Concrete RealWorld -> Sig -> 
 symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
     let callSig = testName <> "(" <> (Text.intercalate "," (map abiTypeSolidity types)) <> ")"
     liftIO $ putStrLn $ "\x1b[96m[RUNNING]\x1b[0m " <> Text.unpack callSig
-    let cd = symCalldata callSig types [] (AbstractBuf "txdata")
-        shouldFail = "proveFail" `isPrefixOf` callSig
+    cd <- symCalldata callSig types [] (AbstractBuf "txdata")
+    let shouldFail = "proveFail" `isPrefixOf` callSig
 
     -- define postcondition depending on `shouldFail`
     let testContract store = fromMaybe (internalError "test contract not found in state") (Map.lookup vm.state.contract store)

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -17,7 +17,7 @@ import Control.Monad.Operational qualified as Operational
 import Control.Monad.ST (RealWorld, ST, stToIO)
 import Control.Monad.State.Strict (StateT(..))
 import Control.Monad.State.Strict qualified as State
-import Control.Monad.Reader (ReaderT)
+import Control.Monad.Reader (ReaderT, lift)
 import Data.Aeson ((.:), (.:?))
 import Data.Aeson qualified as JSON
 import Data.ByteString (ByteString)
@@ -532,11 +532,12 @@ runWithTrace :: App m => StateT (TraceState RealWorld) m (VM Concrete RealWorld)
 runWithTrace = do
   -- This is just like `exec` except for every instruction evaluated,
   -- we also increment a counter indexed by the current code location.
+  conf <- lift readConfig
   vm0 <- use _1
   case vm0.result of
     Nothing -> do
       State.modify' (\(a, b) -> (a, b ++ [vmtrace vm0]))
-      vm' <- liftIO $ stToIO $ State.execStateT exec1 vm0
+      vm' <- liftIO $ stToIO $ State.execStateT (exec1 conf) vm0
       assign _1 vm'
       runWithTrace
     Just (VMFailure _) -> do

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -100,9 +100,9 @@ tests = testGroup "rpc"
     -- symbolically exec "transfer" on WETH9 using remote rpc
     -- https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2#code
     , test "weth-sym" $ do
+        calldata' <- symCalldata "transfer(address,uint256)" [AbiAddressType, AbiUIntType 256] ["0xdead"] (AbstractBuf "txdata")
         let
           blockNum = 16198552
-          calldata' = symCalldata "transfer(address,uint256)" [AbiAddressType, AbiUIntType 256] ["0xdead"] (AbstractBuf "txdata")
           postc _ (Failure _ _ (Revert _)) = PBool False
           postc _ _ = PBool True
         vm <- liftIO $ weth9VM blockNum calldata'


### PR DESCRIPTION
## Description
This overapproximates and so allows us to move forward with the exploration for:
- EXTCODESIZE/HASH and BALANCE always when the contract cannot be found. This is useful, because this is ONLY a check on the size of the contract. So we return a symbolic variable, and continue, potentially going into branches that may be impossible in normal circumstances.
- CALL and CALLCODE, _only_ when `--promise-no-reent` is given. This is a kind of a hack, where we assume that state is not changed of either us or any other contract, when a CALL is made to an unknown code. This is _kinda_ okay when all important state-changing code is guarded by reentrancy locks.

I also refactored the STATICCALL abstraction so it is now much more straightforward, and uses the new generic abstraction system. I think it's a VERY cool now.

I have also added:
* `--max-buf-size` so we can adjust the maximum buffer size. Default is still 2**64 but a lower one can be set, which can still be "good enough" but we won't get internalError-s for too large buffer Cex-es. The proper solution to this is halving the buffer limit and finding a new Cex, until fixedpoint. But that' s a lot of work, and this is good enough for the moment.
* Improved a copyslice so it triggers more often
* A bunch of test cases

# Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
