### PR TITLE
tests: run `evm` on its own directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,8 +228,6 @@ jobs:
           echo HEVM_SOLIDITY_REPO="$PWD/ethereum-solidity" >> "$GITHUB_ENV"
           echo HEVM_ETHEREUM_TESTS_REPO="$PWD/ethereum-tests" >> "$GITHUB_ENV"
           echo HEVM_FORGE_STD_REPO="$PWD/forge-std" >> "$GITHUB_ENV"
-          # environment
-          echo HEVM_SYSTEM_SHELL="$(which bash)" >> "$GITHUB_ENV"
 
       - name: run tests
         run: |

--- a/test/scripts/convert_trace_to_json.sh
+++ b/test/scripts/convert_trace_to_json.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-num=$(wc -l "$1" | cut -d " " -f 1)
+num=$(wc -l "$1" | awk '{print $1}')
 awk -v ll="$num" 'BEGIN {print "{\"trace\": [" } {if (NR!=ll) {print $0; if (NR!=ll-1) {print ","}} else {print "], \"output\":" $0}} END{print "}"}' "$1" > "$1.json"

--- a/test/scripts/convert_trace_to_json.sh
+++ b/test/scripts/convert_trace_to_json.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euxo pipefail
 
-num=$(wc -l "$1" | awk '{print $1}')
+num=$(awk 'END{print NR}' "$1")
 awk -v ll="$num" 'BEGIN {print "{\"trace\": [" } {if (NR!=ll) {print $0; if (NR!=ll-1) {print ","}} else {print "], \"output\":" $0}} END{print "}"}' "$1" > "$1.json"


### PR DESCRIPTION
## Description

This should allow for parallel runs without overlap on the files.

Closes: #662 

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
