### PR TITLE
New CopySlice rule that helps to avoid symbolic copyslice in case of overapproximation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Two more simplification rules: `ReadByte` & `ReadWord` when the `CopySlice`
   it is reading from is writing after the position being read, so the
   `CopySlice` can be ignored
-- One more simplification rule that helps avoid symbolic copyslice in case of
+- More simplification rules that help avoid symbolic copyslice in case of
   STATICCALL overapproximation
 - Test to make sure we don't accidentally overapproxmate a working, good STATICCALL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CopySlice` can be ignored
 - More simplification rules that help avoid symbolic copyslice in case of
   STATICCALL overapproximation
-- Test to make sure we don't accidentally overapproxmate a working, good STATICCALL
+- Test to make sure we don't accidentally overapproximate a working, good STATICCALL
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Two more simplification rules: `ReadByte` & `ReadWord` when the `CopySlice`
   it is reading from is writing after the position being read, so the
   `CopySlice` can be ignored
+- One more simplification rule that helps avoid symbolic copyslice in case of
+  STATICCALL overapproximation
+- Test to make sure we don't accidentally overapproxmate a working, good STATICCALL
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -954,9 +954,9 @@ simplify e = if (mapExpr go e == e)
 
     -- redundant CopySlice
     go (CopySlice (Lit 0x0) (Lit 0x0) (Lit 0x0) _ dst) = dst
-    go (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf k1))
-      (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf k2)) (AbstractBuf k3) _)
-      (ConcreteBuf "")) | k1 == k2 && k2 == k3 = (AbstractBuf k1)
+    go (CopySlice (Lit 0) (Lit 0) (BufLength k1)
+      (CopySlice (Lit 0) (Lit 0) (BufLength k2) k3 _)
+      (ConcreteBuf "")) | k1 == k2 && k2 == k3 = k1
 
     -- simplify storage
     go (SLoad slot store) = readStorage' slot store

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -954,6 +954,9 @@ simplify e = if (mapExpr go e == e)
 
     -- redundant CopySlice
     go (CopySlice (Lit 0x0) (Lit 0x0) (Lit 0x0) _ dst) = dst
+    go (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf k1))
+      (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf k2)) (AbstractBuf k3) _)
+      (ConcreteBuf "")) | k1 == k2 && k2 == k3 = (AbstractBuf k1)
 
     -- simplify storage
     go (SLoad slot store) = readStorage' slot store

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -954,12 +954,12 @@ simplify e = if (mapExpr go e == e)
 
     -- redundant CopySlice
     go (CopySlice (Lit 0x0) (Lit 0x0) (Lit 0x0) _ dst) = dst
-    -- overwrite empty buf with a buf, return is the buf
-    go (CopySlice (Lit 0) (Lit 0) (BufLength src1) src2 (ConcreteBuf "")) | src1 == src2 = src1
     -- We write over dst with data from src. As long as we read from where we write, and
     --    it's the same size, we can just skip the 2nd CopySlice
     go (CopySlice readOff dstOff size2 (CopySlice srcOff writeOff size1 src _) dst) |
       size1 == size2 && readOff == writeOff = CopySlice srcOff dstOff size1 src dst
+    -- overwrite empty buf with a buf, return is the buf
+    go (CopySlice (Lit 0) (Lit 0) (BufLength src1) src2 (ConcreteBuf "")) | src1 == src2 = src1
 
     -- simplify storage
     go (SLoad slot store) = readStorage' slot store

--- a/test/test.hs
+++ b/test/test.hs
@@ -2312,10 +2312,8 @@ tests = testGroup "hevm"
       (expr, ret) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig2 [] defaultVeriOpts
       putStrLnM $ "successfully explored: " <> show (Expr.numBranches expr) <> " paths"
       assertBoolM "The expression is NOT error" $ not $ any isError ret
-    -- NOTE: below used to be symbolic copyslice copy error before new copyslice simplification:
-    --       go (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf k1))
-    --         (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf k2)) (AbstractBuf k3) _)
-    --         (ConcreteBuf "")) | k1 == k2 && k2 == k3 = (AbstractBuf k1)
+    -- NOTE: below used to be symbolic copyslice copy error before new copyslice
+    --       simplifications in Expr.simplify
     , test "overapproximates-undeployed-contract" $ do
       Just c <- solcRuntime "C"
         [i|

--- a/test/test.hs
+++ b/test/test.hs
@@ -507,6 +507,16 @@ tests = testGroup "hevm"
         let e = ReadByte (Lit 0x0) (WriteWord (Lit 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd) (Lit 0x0) (ConcreteBuf "\255\255\255\255"))
         b <- checkEquiv e (Expr.simplify e)
         assertBoolM "Simplifier failed" b
+    , test "copyslice-simps" $ do
+        let e a b =  CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf "buff")) (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf "buff")) (AbstractBuf "buff") (ConcreteBuf a)) (ConcreteBuf b)
+            expr1 = e "" ""
+            expr2 = e "" "aasdfasdf"
+            expr3 = e "9832478932" ""
+            expr4 = e "9832478932" "aasdfasdf"
+        assertEqualM "Not full simp" (Expr.simplify expr1) (AbstractBuf "buff")
+        assertEqualM "Not full simp" (Expr.simplify expr2) $ CopySlice (Lit 0x0) (Lit 0x0) (BufLength (AbstractBuf "buff")) (AbstractBuf "buff") (ConcreteBuf "aasdfasdf")
+        assertEqualM "Not full simp" (Expr.simplify expr3) (AbstractBuf "buff")
+        assertEqualM "Not full simp" (Expr.simplify expr4) $ CopySlice (Lit 0x0) (Lit 0x0) (BufLength (AbstractBuf "buff")) (AbstractBuf "buff") (ConcreteBuf "aasdfasdf")
     , test "buffer-length-copy-slice-beyond-source1" $ do
         let e = BufLength (CopySlice (Lit 0x2) (Lit 0x2) (Lit 0x1) (ConcreteBuf "a") (ConcreteBuf ""))
         b <- checkEquiv e (Expr.simplify e)

--- a/test/test.hs
+++ b/test/test.hs
@@ -2337,6 +2337,7 @@ tests = testGroup "hevm"
            function retFor(address addr) public returns (uint256) {
                // NOTE: this is symbolic execution, and no setUp has been ran
                //       hence, this below calls unknown code! So it overapproximates.
+               //       mm is actually 0 here, which we may want to give a warning for
                uint256 ret = mm.get(addr);
                assert(ret == 4);
                return ret;

--- a/test/test.hs
+++ b/test/test.hs
@@ -2312,6 +2312,10 @@ tests = testGroup "hevm"
       (expr, ret) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig2 [] defaultVeriOpts
       putStrLnM $ "successfully explored: " <> show (Expr.numBranches expr) <> " paths"
       assertBoolM "The expression is NOT error" $ not $ any isError ret
+    -- NOTE: below used to be symbolic copyslice copy error before new copyslice simplification:
+    --       go (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf k1))
+    --         (CopySlice (Lit 0) (Lit 0) (BufLength (AbstractBuf k2)) (AbstractBuf k3) _)
+    --         (ConcreteBuf "")) | k1 == k2 && k2 == k3 = (AbstractBuf k1)
     , test "overapproximates-undeployed-contract" $ do
       Just c <- solcRuntime "C"
         [i|


### PR DESCRIPTION
## Description
This allows us to skip the symbolic copyslice. Basically it's copying over a EMPTY concretebuf values that have been copied from an abstractbuf and ONLY those values. So the result is just the abstractbuf! This helps a lot in avoiding sybmolic copyslice.

## Checklist

- [ ] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
