### PR TITLE
More symbolic overapproximation when the remote contract cannot be fetched, adding CodeHash SMT representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   but allows much more thorough exploration of the contract
 - Allow controlling the max buffer sizes via --max-buf-size to something smaller than 2**64
   so we don't get too large buffers as counterexamples
+- More symbolic overapproximation for Balance and ExtCodeHash opcodes, fixing
+  CodeHash SMT representation
 
 
 ## Fixed

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -450,7 +450,7 @@ exec1 conf = do
           case stk of
             x:xs -> forceAddr x (freshVarFallback xs) $ \a ->
               accessAndBurn a $
-                fetchAccount a $ \c -> do
+                fetchAccountWithFallback a (freshVarFallback xs) $ \c -> do
                   next
                   assign (#state % #stack) xs
                   pushSym c.balance
@@ -568,9 +568,9 @@ exec1 conf = do
           case stk of
             x':xs -> forceAddr x' (freshVarFallback xs) $ \x ->
               accessAndBurn x $ do
-                next
-                assign (#state % #stack) xs
-                fetchAccount x $ \c ->
+                fetchAccountWithFallback x (freshVarFallback xs) $ \c -> do
+                   next
+                   assign (#state % #stack) xs
                    if accountEmpty c
                      then push (W256 0)
                      else case view bytecode c of

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -27,6 +27,7 @@ import Numeric.Natural (Natural)
 import System.Environment (lookupEnv, getEnvironment)
 import System.Process
 import Control.Monad.IO.Class
+import Control.Monad (when)
 import EVM.Effects
 import qualified EVM.Expr as Expr
 
@@ -214,6 +215,8 @@ oracle solvers info q = do
          continue <$> getSolutions solvers symExpr numBytes pathconds
 
     PleaseFetchContract addr base continue -> do
+      conf <- readConfig
+      when (conf.debug) $ liftIO $ putStrLn $ "Fetching contract at " ++ show addr
       contract <- case info of
         Nothing -> let
           c = case base of
@@ -225,7 +228,9 @@ oracle solvers info q = do
         Just x -> pure $ continue x
         Nothing -> internalError $ "oracle error: " ++ show q
 
-    PleaseFetchSlot addr slot continue ->
+    PleaseFetchSlot addr slot continue -> do
+      conf <- readConfig
+      when (conf.debug) $ liftIO $ putStrLn $ "Fetching slot " <> (show slot) <> " at " <> (show addr)
       case info of
         Nothing -> pure (continue 0)
         Just (n, url) ->


### PR DESCRIPTION
## Description
This allows us to overapproximate when the contract is real, but cannot be fetched. Meant to be on top of #658 i.e. `symbolic-extcodesize`. It allows us to overapproximate also when the contract cannot be fetched with RPC for opcodes:
* Balance
* CodeHash

I also added `CodeHash`  SMT representation so concrete addresses that cannot be fetched can be abstracted away and e.g. equivalence-checked. Tests have been added that exercise this very functionality.

See opcodes for reference:
* https://www.evm.codes/?fork=cancun#31
* https://www.evm.codes/?fork=cancun#3f

Debug code has also been added to show when the system is trying to fetch data via RPC. This helps in e.g. debugging. We probably at one point want to collect this data, which would allow us to fully and correctly replay things in tests. But that's a bit far away...

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
