### PR TITLE
Reading code plain from a file instead of JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Warnings now lead printing FAIL. This way, users don't accidentally think that
   their contract is correct when there were cases/branches that hevm could not
   fully explore. Printing of issues is also now much more organized
+- We now read file as bytecode rather than JSON, as it's more compatible
+  with different input formats
 
 ## [0.54.2] - 2024-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generated via iterative calls to the SMT solver for quicker solving
 - Aliasing works much better for symbolic and concrete addresses
 - Constant propagation for symbolic values
-- Allow reading deployedBytecode.object from the forge JSON as --code-file or --code-a-file/--code-b-file
+- Allow reading bytecode via --code-file or --code-a-file/--code-b-file. Strips
+  `\n`, spaces, and ignores leading `0x` to make it easier to use via e.g.
+  `jq '.deplayedBytecode.object file.json > file.txt'` to parse Forge JSON output
   This alleviates the issue when the contract is large and does not fit the command line
   limit of 8192 characters
 - Two more simplification rules: `ReadByte` & `ReadWord` when the `CopySlice`
@@ -47,8 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Warnings now lead printing FAIL. This way, users don't accidentally think that
   their contract is correct when there were cases/branches that hevm could not
   fully explore. Printing of issues is also now much more organized
-- We now read file as bytecode rather than JSON, as it's more compatible
-  with different input formats
 
 ## [0.54.2] - 2024-12-12
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -9,8 +9,10 @@ module Main where
 import Control.Monad (when, forM_, unless)
 import Control.Monad.ST (RealWorld, stToIO)
 import Control.Monad.IO.Unlift
+import Control.Exception (try, IOException)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BS
+import qualified Data.ByteString.Char8 as BC
 import Data.DoubleWord (Word256)
 import Data.List (intersperse)
 import Data.Maybe (fromMaybe, mapMaybe, fromJust, isNothing, isJust)
@@ -28,9 +30,6 @@ import System.Directory (withCurrentDirectory, getCurrentDirectory, doesDirector
 import System.FilePath ((</>))
 import System.Exit (exitFailure, exitWith, ExitCode(..))
 import Main.Utf8 (withUtf8)
-import qualified Data.ByteString.Char8 as BC
-import Data.Aeson (decode, (.:))
-import Data.Aeson.Types (parseMaybe)
 
 import EVM (initialContract, abstractContract, makeVm)
 import EVM.ABI (Sig(..))
@@ -61,7 +60,7 @@ data Command w
   = Symbolic -- Symbolically explore an abstract program, or specialized with specified env & calldata
   -- vm opts
       { code          :: w ::: Maybe ByteString <?> "Program bytecode"
-      , codeFile      :: w ::: Maybe String     <?> "Program bytecode from JSON file's deployedBytecode.object field"
+      , codeFile    :: w ::: Maybe String       <?> "Program bytecode in a file"
       , calldata      :: w ::: Maybe ByteString <?> "Tx: calldata"
       , address       :: w ::: Maybe Addr       <?> "Tx: address"
       , caller        :: w ::: Maybe Addr       <?> "Tx: caller"
@@ -112,8 +111,8 @@ data Command w
   | Equivalence -- prove equivalence between two programs
       { codeA         :: w ::: Maybe ByteString   <?> "Bytecode of the first program"
       , codeB         :: w ::: Maybe ByteString   <?> "Bytecode of the second program"
-      , codeAFile     :: w ::: Maybe String     <?> "First program's bytecode from JSON file's deployedBytecode.object field"
-      , codeBFile     :: w ::: Maybe String     <?> "Second program's bytecode from JSON file's deployedBytecode.object field"
+      , codeAFile     :: w ::: Maybe String     <?> "First program's bytecode in a file"
+      , codeBFile     :: w ::: Maybe String     <?> "Second program's bytecode in a file"
       , sig           :: w ::: Maybe Text       <?> "Signature of types to decode / encode"
       , arg           :: w ::: [String]         <?> "Values to encode"
       , calldata      :: w ::: Maybe ByteString <?> "Tx: calldata"
@@ -134,7 +133,7 @@ data Command w
       }
   | Exec -- Execute a given program with specified env & calldata
       { code        :: w ::: Maybe ByteString  <?> "Program bytecode"
-      , codeFile    :: w ::: Maybe String      <?> "Program bytecode from JSON file's deployedBytecode.object field"
+      , codeFile    :: w ::: Maybe String      <?> "Program bytecode in a file"
       , calldata    :: w ::: Maybe ByteString  <?> "Tx: calldata"
       , address     :: w ::: Maybe Addr        <?> "Tx: address"
       , caller      :: w ::: Maybe Addr        <?> "Tx: caller"
@@ -259,21 +258,17 @@ getCode fname code = do
     putStrLn "Error: Cannot provide both a file and code"
     exitFailure
   case fname of
-    Nothing -> pure code
-    Just f -> fmap Just $ readJSONcode f
-
-readJSONcode :: FilePath -> IO ByteString
-readJSONcode fname = do
-  contents <- BS.readFile fname
-  case decode contents of
-    Nothing -> do
-      putStrLn "Error: Failed to parse JSON given as code file"
-      exitFailure
-    Just json -> case parseMaybe (.: "deployedBytecode") json >>= parseMaybe (.: "object") of
-      Nothing -> do
-        putStrLn "Error: Expected a deployedBytecode object in code file"
-        exitFailure
-      Just obj -> pure $ BC.pack obj
+    Nothing -> pure $ fmap strip code
+    Just f -> do
+      result <- try (BS.readFile f) :: IO (Either IOException BS.ByteString)
+      case result of
+        Left e -> do
+          putStrLn $ "Error reading file: " <> (show e)
+          exitFailure
+        Right content -> do
+          pure $ Just $ strip (BS.toStrict content)
+  where
+    strip = BC.filter (\c -> c /= ' ' && c /= '\n' && c /= '\r' && c /= '\t' && c /= '"')
 
 equivalence :: App m => Command Options.Unwrapped -> m ()
 equivalence cmd = do

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -213,7 +213,6 @@ executable hevm
     witch,
     unliftio-core,
     with-utf8,
-    aeson,
 
 --- Test Helpers ---
 


### PR DESCRIPTION
## Description
It's actually better to read plain code rather than JSON. Let's just do that. A simple `jq '.deplayedBytecode.object file.json > file.txt'` will do the trick. In order to do that, I have now stripped: empty space, newline, and '"'. This means that the above `jq` will just work.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
