### PR TITLE
Fix encoding of assumptions about reading after buffer size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Size of calldata can be up to 2**64, not 256. This is now reflected in the documentation
 - We now have less noise during test runs, and assert more about symbolic copyslice tests
 - CopySlice rewrite rule is now less strict while still being sound
+- Assumptions about reading from buffer after its size are now the same in all cases.
+  Previously, they were too weak in case of reading 32 bytes.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -378,7 +378,6 @@ assertReads props benv senv = concatMap assertRead allReads
   where
     assertRead :: (Expr EWord, Expr EWord, Expr Buf) -> [Prop]
     assertRead (_, Lit 0, _) = []
-    assertRead (idx, Lit 32, buf) = [PImpl (PGEq idx (bufLength buf)) (PEq (ReadWord idx buf) (Lit 0))]
     assertRead (idx, Lit sz, buf) = [PImpl (PGEq (Expr.add idx $ Lit offset) (bufLength buf)) (PEq (ReadByte (Expr.add idx $ Lit offset) buf) (LitByte 0)) | offset <- [(0::W256).. sz-1]]
     assertRead (_, _, _) = internalError "Cannot generate assertions for accesses of symbolic size"
 


### PR DESCRIPTION
Previously, the case of reading 32 bytes (a word) was treated in a special way when encoding in SMT assumptions about reading after buffer size. However, the assumptions were too weak and allowed wrong SMT models where the buffer length were too small and values read after this length were not zero according to the SMT model.

We fix this by removing the special treatment.

Fixes #679.

## Description

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
