### PR TITLE
Equivalence fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so we don't get too large buffers as counterexamples
 - More symbolic overapproximation for Balance and ExtCodeHash opcodes, fixing
   CodeHash SMT representation
-
+- Add deployment code flag to the `equivalenceCheck` function
+- New simplification rule for reading a byte that is lower than destination offset in `copySlice`
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value
@@ -56,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CopySlice rewrite rule is now less strict while still being sound
 - Assumptions about reading from buffer after its size are now the same in all cases.
   Previously, they were too weak in case of reading 32 bytes.
+- The equivalence checker now is able to prove that an empty store is equivalent to a store with all slots initialized to 0.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More symbolic overapproximation for Balance and ExtCodeHash opcodes, fixing
   CodeHash SMT representation
 - Add deployment code flag to the `equivalenceCheck` function
-- New simplification rule for reading a byte that is lower than destination offset in `copySlice`
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value
@@ -57,7 +56,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CopySlice rewrite rule is now less strict while still being sound
 - Assumptions about reading from buffer after its size are now the same in all cases.
   Previously, they were too weak in case of reading 32 bytes.
-- The equivalence checker now is able to prove that an empty store is equivalent to a store with all slots initialized to 0.
+- The equivalence checker now is able to prove that an empty store is
+  equivalent to a store with all slots initialized to 0.
+- Equivalence checking was incorrectly assuming that overapproximated values
+  were sequentially equivalent. We now distinguish these symbolic values with
+  `A-` and `B-`
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -134,6 +134,7 @@ data Command w
       , maxBranch     :: w ::: Int              <!> "100" <?> "Max number of branches to explore when encountering a symbolic value (default: 100)"
       , maxBufSize    :: w ::: Int              <!> "64" <?> "Maximum size of buffers such as calldata and returndata in exponents of 2 (default: 64, i.e. 2^64 bytes)"
       , promiseNoReent:: w ::: Bool             <!> "Promise no reentrancy is possible into the contract(s) being examined"
+      , create        :: w ::: Bool             <?> "Tx: creation"
       }
   | Exec -- Execute a given program with specified env & calldata
       { code        :: w ::: Maybe ByteString  <?> "Program bytecode"
@@ -307,7 +308,7 @@ equivalence cmd = do
   cores <- liftIO $ unsafeInto <$> getNumProcessors
   let solverCount = fromMaybe cores cmd.numSolvers
   withSolvers solver solverCount (fromMaybe 1 cmd.solverThreads) cmd.smttimeout $ \s -> do
-    (res, e) <- equivalenceCheck s (fromJust bytecodeA) (fromJust bytecodeB) veriOpts calldata
+    (res, e) <- equivalenceCheck s (fromJust bytecodeA) (fromJust bytecodeB) veriOpts calldata cmd.create
     liftIO $ case (any isCex res, any Expr.isPartial e || any isUnknown res) of
       (False, False) -> putStrLn "   \x1b[32m[PASS]\x1b[0m Contracts behave equivalently"
       (True, _)      -> putStrLn "   \x1b[31m[FAIL]\x1b[0m Contracts do not behave equivalently"

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1601,9 +1601,9 @@ freshBufFallback xs = do
   freshVar <- use #freshVar
   assign #freshVar (freshVar + 1)
   let opName = pack $ show $ getOp ?op
-  let freshVarExpr = Var (opName <> "-result-stack-" <> (pack . show) freshVar)
+  let freshVarExpr = Var (opName <> "-result-stack-fresh-" <> (pack . show) freshVar)
   modifying #constraints ((:) (PLEq freshVarExpr (Lit 1) ))
-  let freshReturndataExpr = AbstractBuf (opName <> "-result-data-" <> (pack . show) freshVar)
+  let freshReturndataExpr = AbstractBuf (opName <> "-result-data-fresh-" <> (pack . show) freshVar)
   modifying #constraints ((:) (PLEq (bufLength freshReturndataExpr) (Lit (2 ^ ?conf.maxBufSize))))
   assign (#state % #returndata) freshReturndataExpr
   next >> assign (#state % #stack) (freshVarExpr:xs)
@@ -1617,7 +1617,7 @@ freshVarFallback xs _ = do
   freshVar <- use #freshVar
   assign #freshVar (freshVar + 1)
   let opName = pack $ show $ getOp ?op
-  let freshVarExpr = Var (opName <> "-result-stack-" <> (pack . show) freshVar)
+  let freshVarExpr = Var (opName <> "-result-stack-fresh-" <> (pack . show) freshVar)
   next >> assign (#state % #stack) (freshVarExpr:xs)
 
 forceConcrete :: VMOps t => Expr EWord -> String -> (W256 -> EVM t s ()) -> EVM t s ()
@@ -2962,7 +2962,7 @@ instance VMOps Symbolic where
   pushGas = do
     modifying (#env % #freshGasVals) (+ 1)
     n <- use (#env % #freshGasVals)
-    pushSym $ Expr.Gas n
+    pushSym $ Expr.Gas "" n
   enoughGas _ _ = True
   subGas _ _ = ()
   toGas _ = ()

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -243,7 +243,7 @@ readByte i@(Lit x) (WriteWord (Lit idx) val src)
            (Lit _) -> indexWord (Lit $ x - idx) val
            _ -> IndexWord (Lit $ x - idx) val
     else readByte i src
--- reading a byte that is lower than the dstOffset of a CopySlice, so it's just reading from dst
+-- reading a byte that is lower than the dstOffset of a CopySlice, so it's just reading from src
 readByte i@(Lit x) (CopySlice _ (Lit dstOffset) _ _ dst) | dstOffset > x =
   readByte i dst
 readByte i@(Lit x) (CopySlice (Lit srcOffset) (Lit dstOffset) (Lit size) src dst)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -243,7 +243,7 @@ readByte i@(Lit x) (WriteWord (Lit idx) val src)
            (Lit _) -> indexWord (Lit $ x - idx) val
            _ -> IndexWord (Lit $ x - idx) val
     else readByte i src
--- reading a byte that is lower than the dstOffset of a CopySlice, so it's just reading from src
+-- reading a byte that is lower than the dstOffset of a CopySlice, so it's just reading from dst
 readByte i@(Lit x) (CopySlice _ (Lit dstOffset) _ _ dst) | dstOffset > x =
   readByte i dst
 readByte i@(Lit x) (CopySlice (Lit srcOffset) (Lit dstOffset) (Lit size) src dst)

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -29,7 +29,6 @@ module EVM.Format
   , strip0x'
   , hexByteString
   , hexText
-  , bsToHex
   , showVal
   ) where
 
@@ -858,9 +857,6 @@ hexText t =
   case BS16.decodeBase16Untyped (T.encodeUtf8 (T.drop 2 t)) of
     Right x -> x
     _ -> internalError $ "invalid hex bytestring " ++ show t
-
-bsToHex :: ByteString -> String
-bsToHex bs = concatMap (paddedShowHex 2) (BS.unpack bs)
 
 showVal :: AbiValue -> Text
 showVal (AbiBytes _ bs) = formatBytes bs

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -82,7 +82,10 @@ instance Monoid CexVars where
 data BufModel
   = Comp CompressedBuf
   | Flat ByteString
-  deriving (Eq, Show)
+  deriving (Eq)
+instance Show BufModel where
+  show (Comp c) = "Comp " <> show c
+  show (Flat b) = "Flat 0x" <> bsToHex b
 
 -- | This representation lets us store buffers of arbitrary length without
 -- exhausting the available memory, it closely matches the format used by
@@ -322,10 +325,10 @@ referencedFrameContext expr = nubOrd $ foldTerm go [] expr
   where
     go :: Expr a -> [(Builder, [Prop])]
     go = \case
-      TxValue -> [(fromString "txvalue", [])]
-      v@(Balance a) -> [(fromString "balance_" <> formatEAddr a, [PLT v (Lit $ 2 ^ (96 :: Int))])]
-      Gas freshVar -> [(fromString ("gas_" <> show freshVar), [])]
-      CodeHash a@(LitAddr _) -> [(fromString "codehash_" <> formatEAddr a, [])]
+      o@TxValue -> [(fromRight' $ exprToSMT o, [])]
+      o@(Balance _) -> [(fromRight' $ exprToSMT o, [PLT o (Lit $ 2 ^ (96 :: Int))])]
+      o@(Gas _ _) -> [(fromRight' $ exprToSMT o, [])]
+      o@(CodeHash (LitAddr _)) -> [(fromRight' $ exprToSMT o, [])]
       _ -> []
 
 referencedBlockContext :: TraversableTerm a => a -> [(Builder, [Prop])]
@@ -443,20 +446,26 @@ declareConstrainAddrs names = SMT2 (["; concrete and symbolic addresses"] <> fma
     assume n = "(assert (bvugt " <> n <> " (_ bv9 160)))"
     cexvars = (mempty :: CexVars){ addrs = fmap toLazyText names }
 
+-- The gas is a tuple of (prefix, index). Within each prefix, the gas is strictly decreasing as the
+-- index increases. This function gets a map of Prefix -> [Int], and for each prefix,
+-- enforces the order
 enforceGasOrder :: [Prop] -> SMT2
-enforceGasOrder ps = SMT2 (["; gas ordering"] <> order indices) mempty mempty
+enforceGasOrder ps = SMT2 (["; gas ordering"] <> (concatMap (uncurry order) indices)) mempty mempty
   where
-    order :: [Int] -> [Builder]
-    order n = consecutivePairs n >>= \(x, y)->
+    order :: TS.Text -> [Int] -> [Builder]
+    order prefix n = consecutivePairs (nubInt n) >>= \(x, y)->
       -- The GAS instruction itself costs gas, so it's strictly decreasing
-      ["(assert (bvugt gas_" <> (fromString . show $ x) <> " gas_" <> (fromString . show $ y) <> "))"]
+      ["(assert (bvugt " <> fromRight' (exprToSMT (Gas prefix x)) <> " " <>
+        fromRight' ((exprToSMT (Gas prefix y))) <> "))"]
     consecutivePairs :: [Int] -> [(Int, Int)]
     consecutivePairs [] = []
     consecutivePairs l = zip l (tail l)
-    indices :: [Int] = nubInt $ concatMap (foldProp go mempty) ps
-    go :: Expr a -> [Int]
+    indices = Map.toList $ toMapOfLists $ concatMap (foldProp go mempty) ps
+    toMapOfLists :: [(TS.Text, Int)] -> Map.Map TS.Text [Int]
+    toMapOfLists = foldr (\(k, v) acc -> Map.insertWith (++) k [v] acc) Map.empty
+    go :: Expr a -> [(TS.Text, Int)]
     go e = case e of
-      Gas freshVar -> [freshVar]
+      Gas prefix v -> [(prefix, v)]
       _ -> []
 
 declareFrameContext :: [(Builder, [Prop])] -> Err SMT2
@@ -872,8 +881,8 @@ exprToSMT = \case
     pure $ "(store" `sp` encPrev `sp` encIdx `sp` encVal <> ")"
   SLoad idx store -> op2 "select" store idx
   LitAddr n -> pure $ fromLazyText $ "(_ bv" <> T.pack (show (into n :: Integer)) <> " 160)"
-  Gas freshVar -> pure $ fromLazyText $ "gas_"  <> (T.pack $ show freshVar)
   CodeHash a@(LitAddr _) -> pure $ fromLazyText "codehash_" <> formatEAddr a
+  Gas prefix var -> pure $ fromLazyText $ "gas-" <> T.pack (TS.unpack prefix) <> T.pack (show var)
 
   a -> internalError $ "TODO: implement: " <> show a
   where
@@ -1060,14 +1069,12 @@ parseBlockCtx "prevrandao" = PrevRandao
 parseBlockCtx "gaslimit" = GasLimit
 parseBlockCtx "chainid" = ChainId
 parseBlockCtx "basefee" = BaseFee
-parseBlockCtx gas | TS.isPrefixOf (TS.pack "gas_") gas = Gas (textToInt $ TS.drop 4 gas)
 parseBlockCtx val = internalError $ "cannot parse '" <> (TS.unpack val) <> "' into an Expr"
 
 parseTxCtx :: TS.Text -> Expr EWord
 parseTxCtx name
   | name == "txvalue" = TxValue
   | Just a <- TS.stripPrefix "balance_" name = Balance (parseEAddr a)
-  | Just a <- TS.stripPrefix "gas_" name = Gas (textToInt a)
   | Just a <- TS.stripPrefix "codehash_" name = CodeHash (parseEAddr a)
   | otherwise = internalError $ "cannot parse " <> (TS.unpack name) <> " into an Expr"
 

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -882,7 +882,7 @@ exprToSMT = \case
   SLoad idx store -> op2 "select" store idx
   LitAddr n -> pure $ fromLazyText $ "(_ bv" <> T.pack (show (into n :: Integer)) <> " 160)"
   CodeHash a@(LitAddr _) -> pure $ fromLazyText "codehash_" <> formatEAddr a
-  Gas prefix var -> pure $ fromLazyText $ "gas-" <> T.pack (TS.unpack prefix) <> T.pack (show var)
+  Gas prefix var -> pure $ fromLazyText $ "gas_" <> T.pack (TS.unpack prefix) <> T.pack (show var)
 
   a -> internalError $ "TODO: implement: " <> show a
   where

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -394,6 +394,7 @@ solcRuntime contract src = do
       Just (Contracts sol, _, _) -> pure $ Map.lookup ("hevm.sol:" <> contract) sol <&> (.runtimeCode)
       Nothing -> internalError $ "unable to parse solidity output:\n" <> (T.unpack json)
 
+
 functionAbi :: Text -> IO Method
 functionAbi f = do
   json <- solc Solidity ("contract ABI { function " <> f <> " public {}}")

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -4,7 +4,7 @@ module EVM.SymExec where
 
 import Control.Concurrent.Async (concurrently, mapConcurrently)
 import Control.Concurrent.Spawn (parMapIO, pool)
-import Control.Concurrent.STM (atomically, TVar, readTVarIO, readTVar, newTVarIO, writeTVar)
+import Control.Concurrent.STM (TVar, readTVarIO, newTVarIO)
 import Control.Monad (when, forM_, forM)
 import Control.Monad.IO.Unlift
 import Control.Monad.Operational qualified as Operational

--- a/src/EVM/Traversals.hs
+++ b/src/EVM/Traversals.hs
@@ -158,7 +158,7 @@ foldExpr f acc expr = acc <> (go expr)
 
       -- frame context
 
-      e@(Gas _) -> f e
+      e@(Gas _ _) -> f e
       e@(Balance {}) -> f e
 
       -- code
@@ -516,7 +516,7 @@ mapExprM f expr = case expr of
 
   -- frame context
 
-  Gas a -> f (Gas a)
+  Gas a b -> f (Gas a b)
   Balance a -> do
     a' <- mapExprM f a
     f (Balance a')

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -490,16 +490,16 @@ instance Ord Prop where
   PBool a <= PBool b = a <= b
   PEq (a :: Expr x) (b :: Expr x) <= PEq (c :: Expr y) (d :: Expr y)
     = case eqT @x @y of
-       Just Refl ->        a < c || b < d || (a == c && b == d)
+       Just Refl ->        a <= c || ((a == c) && (b <= d))
        Nothing -> toNum a <= toNum c
-  PLT a b  <= PLT c d    = a < c || b < d || (a == c && b == d)
-  PGT a b  <= PGT c d    = a < c || b < d || (a == c && b == d)
-  PGEq a b <= PGEq c d   = a < c || b < d || (a == c && b == d)
-  PLEq a b <= PLEq c d   = a < c || b < d || (a == c && b == d)
   PNeg a   <= PNeg b     = a <= b
-  PAnd a b <= PAnd c d   = a < c || b < d || (a == c && b == d)
-  POr a b  <= POr c d    = a < c || b < d || (a == c && b == d)
-  PImpl a b <= PImpl c d = a < c || b < d || (a == c && b == d)
+  PLT a b  <= PLT c d    = a <= c || (a == c && b <= d)
+  PGT a b  <= PGT c d    = a <= c || (a == c && b <= d)
+  PGEq a b <= PGEq c d   = a <= c || (a == c && b <= d)
+  PLEq a b <= PLEq c d   = a <= c || (a == c && b <= d)
+  PAnd a b <= PAnd c d   = a <= c || (a == c && b <= d)
+  POr a b  <= POr c d    = a <= c || (a == c && b <= d)
+  PImpl a b <= PImpl c d = a <= c || (a == c && b <= d)
   a <= b = asNum a <= asNum b
     where
       asNum :: Prop -> Int

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -483,20 +483,23 @@ instance Eq Prop where
   PImpl a b == PImpl c d = a == c && b == d
   _ == _ = False
 
+-- Note: we cannot compare via `a <= c || b <= d` because then
+--       when a==c but b > d, we'd return TRUE, when we should be
+--       returning FALSE.
 instance Ord Prop where
   PBool a <= PBool b = a <= b
   PEq (a :: Expr x) (b :: Expr x) <= PEq (c :: Expr y) (d :: Expr y)
     = case eqT @x @y of
-       Just Refl -> a <= c || b <= d
+       Just Refl ->        a < c || b < d || (a == c && b == d)
        Nothing -> toNum a <= toNum c
-  PLT a b <= PLT c d = a <= c || b <= d
-  PGT a b <= PGT c d = a <= c || b <= d
-  PGEq a b <= PGEq c d = a <= c || b <= d
-  PLEq a b <= PLEq c d = a <= c || b <= d
-  PNeg a <= PNeg b = a <= b
-  PAnd a b <= PAnd c d = a <= c || b <= d
-  POr a b <= POr c d = a <= c || b <= d
-  PImpl a b <= PImpl c d = a <= c || b <= d
+  PLT a b  <= PLT c d    = a < c || b < d || (a == c && b == d)
+  PGT a b  <= PGT c d    = a < c || b < d || (a == c && b == d)
+  PGEq a b <= PGEq c d   = a < c || b < d || (a == c && b == d)
+  PLEq a b <= PLEq c d   = a < c || b < d || (a == c && b == d)
+  PNeg a   <= PNeg b     = a <= b
+  PAnd a b <= PAnd c d   = a < c || b < d || (a == c && b == d)
+  POr a b  <= POr c d    = a < c || b < d || (a == c && b == d)
+  PImpl a b <= PImpl c d = a < c || b < d || (a == c && b == d)
   a <= b = asNum a <= asNum b
     where
       asNum :: Prop -> Int

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -53,7 +53,7 @@ import EVM.Expr qualified as Expr
 import EVM.Concrete qualified as Concrete
 import EVM.Exec (ethrunAddress)
 import EVM.Fetch qualified as Fetch
-import EVM.Format (bsToHex, formatBinary)
+import EVM.Format (formatBinary)
 import EVM.FeeSchedule
 import EVM.Op (intToOpName)
 import EVM.Sign (deriveAddr)

--- a/test/test.hs
+++ b/test/test.hs
@@ -4055,7 +4055,16 @@ tests = testGroup "hevm"
   ]
   , testGroup "simplification-working"
   [
-    test "PEq-and-PNot-PEq-1" $ do
+    test "nubOrd-Prop-working" $ do
+        let a = [ PLT (Lit 0x0) (ReadWord (ReadWord (Lit 0x0) (AbstractBuf "txdata")) (AbstractBuf "txdata"))
+                , PLT (Lit 0x1) (ReadWord (ReadWord (Lit 0x0) (AbstractBuf "txdata")) (AbstractBuf "txdata"))
+                , PLT (Lit 0x2) (ReadWord (ReadWord (Lit 0x0) (AbstractBuf "txdata")) (AbstractBuf "txdata"))
+                , PLT (Lit 0x0) (ReadWord (ReadWord (Lit 0x0) (AbstractBuf "txdata")) (AbstractBuf "txdata"))]
+        let simp = nubOrd a
+            simp2 = List.nub a
+        assertEqualM "Must be 3-length" 3 (length simp)
+        assertEqualM "Must be 3-length" 3 (length simp2)
+    , test "PEq-and-PNot-PEq-1" $ do
       let a = [PEq (Lit 0x539) (Var "arg1"),PNeg (PEq (Lit 0x539) (Var "arg1"))]
       assertEqualM "Must simplify to PBool False" (Expr.simplifyProps a) ([PBool False])
     , test "PEq-and-PNot-PEq-2" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -4131,7 +4131,7 @@ tests = testGroup "hevm"
   , testGroup "equivalence-checking"
     [
       -- diverging gas overapproximations are caught
-      -- previously, they had the same name (gas-...), so they compared equal
+      -- previously, they had the same name (gas_...), so they compared equal
       test "eq-divergent-overapprox-gas" $ do
         Just a <- solcRuntime "C"
           [i|

--- a/test/test.hs
+++ b/test/test.hs
@@ -4177,8 +4177,8 @@ tests = testGroup "hevm"
             }
           |]
         withSolvers Z3 3 1 Nothing $ \s -> do
-          a <- equivalenceCheck s initA initB defaultVeriOpts (mkCalldata Nothing []) True
-          assertEqualM "Must have no difference" [Qed ()] a
+          (res, _) <- equivalenceCheck s initA initB defaultVeriOpts (mkCalldata Nothing []) True
+          assertEqualM "Must have no difference" [Qed ()] res
       ,
       test "eq-sol-exp-qed" $ do
         Just aPrgm <- solcRuntime "C"


### PR DESCRIPTION
## Description
This fixes two underlying issues with equivalence checking.

## Creation now deploys the code and checks the difference of the deployed code

Firstly, it fixes the issue that we didn't check the **deployed** contract, as per Zoe's observation. This is because we never deployed the contract that was created and check **its** difference in behaviour. This is no longer the case, we now distinguish between create/no-create equivalence checking. Some of this code was written by Zoe, and I fixed up the rest.

## Equivalence checking no longer assumes overapproximated calls/etc. return the same value

Secondly, during equivalence checking, we actually didn't distinguish the fresh variables added via overapproximation for code A and code B. So the overapproximations were somehow doing the "same thing" which is wrong, they may very well be called with different arguments, at different points of the run, etc. This false equivalence was because the variables were **named the same**. I now have a function `rewriteFresh` that sticks an `A-` or `B-` in front of these fresh variables, therefore making them symbolically different. This also means that we potentially return false positives. This is just the way things are with overapproximation. We could add constraints, such as `(initial state + calldata) -> symbolic value` and then these false positives will go away. However, for the moment, these are not added. This is future work.

## Small Things

Currently, we cannot deal with symbolic code. Hence, the test `constructor-diff-deploy` is under `ignoreTest`. Maybe we could make it work, actually. The deployed code will NEVER have symbolic opcodes, only symbolic values. Hence, it could be possible to change the interpreter to work on this. Future work.

Both `parseBlockCtx ` and `parseTxCtx` have been modified to remove the now very fragile `gas` context extraction. This context should pretty much be useless -- code really ought not to depend on gas. We could extract it, but I find that keeping code in that is not tested and not used is just a recipe for later headaches. I'd rather it isn't extracted, and if it really is necessary at a later point, we can extract it.

`referencedFrameContext` is now using `exprToSMT`, which makes it a lot more standard and less prone to breaking. It was essentially a bug that it wasn't doing that.

The `Ord` for `Prop` was incorrect. `POr a b <= POr c d` cannot be compared via `a <= c || b <= d` because in the case taht `a == b` and `b >d` it will return True, but it should return False. This has been fixed.

## Git History etc.

Closes https://github.com/ethereum/hevm/issues/647.

This is an updated version of #650 -- in a way that all commits by Zoe are preserved.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
