### PR TITLE
Add --arrays-exp to CVC5 options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   determining when (Eq a b) is true when a==b modulo commutativity
 - `hevm test`'s flag ` --verbose` is now `--verb`, which also increases verbosity
   for other elements of the system
-- Add `--arrays-exp` to CVC5 options.
+- Add `--arrays-exp` to cvc5 options.
 
 ## [0.54.2] - 2024-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   determining when (Eq a b) is true when a==b modulo commutativity
 - `hevm test`'s flag ` --verbose` is now `--verb`, which also increases verbosity
   for other elements of the system
+- Add `--arrays-exp` to CVC5 options.
 
 ## [0.54.2] - 2024-12-12
 

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -365,6 +365,7 @@ solverArgs solver threads timeout = case solver of
     , "--interactive"
     , "--incremental"
     , "--tlimit-per=" <> mkTimeout timeout
+    , "--arrays-exp"
     ]
   Custom _ -> []
 


### PR DESCRIPTION
## Description

This PR adds `--arrays-exp` to CVC5 options. 

Without this option, CVC5 returns the following error on some queries generated by the equivalence: 

```
(error "Term of kind `STORE_ALL` not supported in default mode, try **`--arrays-exp`.")**`
```
Adding the option, prevents the failures. 

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [X] updated the changelog
