### PR TITLE
Fix windows build

### DIFF
--- a/.github/scripts/install-libff.sh
+++ b/.github/scripts/install-libff.sh
@@ -27,5 +27,5 @@ CXXFLAGS="-fPIC"
 
 mkdir -p build
 cd build
-CXXFLAGS="$CXXFLAGS" cmake "${ARGS[@]}" ..
+CXXFLAGS="$CXXFLAGS" cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 "${ARGS[@]}" ..
 cmake --build . && cmake --install .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--arrays-exp` to cvc5 options.
 - We now use Options.Applicative and a rather different way of parsing CLI options.
   This should give us much better control over the CLI options and their parsing.
+- We now build with -DCMAKE_POLICY_VERSION_MINIMUM=3.5 libff, as cmake deprecated 3.5
 
 ## [0.54.2] - 2024-12-12
 


### PR DESCRIPTION
## Description
This fixes the windows build, as cmake recent deprecated 3.5

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
