### PR TITLE
Unifying result type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - block.number can now be symbolic. This only affects library use of hevm
 - Removed `--smtoutput` since it was never used
 - We now build with -DCMAKE_POLICY_VERSION_MINIMUM=3.5 libff, as cmake deprecated 3.5
-- CheckSatResult has now been unified with ProofResult via SMT2Result
+- CheckSatResult has now been unified with ProofResult via SMTResult
 
 ## [0.54.2] - 2024-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - block.number can now be symbolic. This only affects library use of hevm
 - Removed `--smtoutput` since it was never used
 - We now build with -DCMAKE_POLICY_VERSION_MINIMUM=3.5 libff, as cmake deprecated 3.5
+- CheckSatResult has now been unified with ProofResult via SMT2Result
 
 ## [0.54.2] - 2024-12-12
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -495,12 +495,12 @@ assert cFileOpts sOpts cExecOpts cOpts = do
     }
     (expr, res) <- verify solvers veriOpts preState (Just $ checkAssertions errCodes)
     case res of
-      [Qed _] -> do
+      [Qed] -> do
         liftIO $ putStrLn "\nQED: No reachable property violations discovered\n"
         showExtras solvers sOpts calldata expr
       _ -> do
         let cexs = snd <$> mapMaybe getCex res
-            smtUnknowns = mapMaybe getUnknown res
+            smtUnknowns = snd <$> mapMaybe getUnknown res
             counterexamples
               | null cexs = []
               | otherwise =
@@ -528,7 +528,7 @@ showExtras solvers sOpts calldata expr = do
   when sOpts.showReachableTree $ do
     reached <- reachable solvers expr
     liftIO $ do
-      putStrLn "=== Reachable Expression ===\n"
+      putStrLn "=== Potentially Reachable Expression ===\n"
       T.putStrLn (formatExpr . snd $ reached)
       putStrLn ""
   when sOpts.getModels $ do

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -3009,7 +3009,7 @@ instance VMOps Symbolic where
         assign (#iterations % at loc) (Just (iteration + 1, stack))
         continue v
       -- Both paths are possible; we ask for more input
-      runBothPaths loc exploreDepth Unknown =
+      runBothPaths loc exploreDepth UnknownBranch =
         (runBoth depthLimit exploreDepth ) . PleaseRunBoth condSimp $ (runBothPaths loc exploreDepth) . Case
 
   -- numBytes allows us to specify how many bytes of the returned value is relevant

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -275,17 +275,17 @@ checkBranch solvers branchcondition pathconditions = do
   let props = [pathconditions .&& branchcondition]
   checkSatWithProps solvers props >>= \case
     -- the condition is unsatisfiable
-    (Unsat, _) -> -- if pathconditions are consistent then the condition must be false
+    (Qed, _) -> -- if pathconditions are consistent then the condition must be false
       pure $ Case False
     -- Sat means its possible for condition to hold
-    (Sat {}, _) -> do -- is its negation also possible?
+    (Cex {}, _) -> do -- is its negation also possible?
       let propsNeg = [pathconditions .&& (PNeg branchcondition)]
       checkSatWithProps solvers propsNeg >>= \case
         -- No. The condition must hold
-        (Unsat, _) -> pure $ Case True
+        (Qed, _) -> pure $ Case True
         -- Yes. Both branches possible
-        (Sat {}, _) -> pure EVM.Types.Unknown
+        (Cex {}, _) -> pure UnknownBranch
         -- If the query times out, or can't be executed (e.g. symbolic copyslice) we simply explore both paths
-        _ -> pure EVM.Types.Unknown
+        _ -> pure UnknownBranch
     -- If the query times out, or can't be executed (e.g. symbolic copyslice) we simply explore both paths
-    _ -> pure EVM.Types.Unknown
+    _ -> pure UnknownBranch

--- a/src/EVM/Fuzz.hs
+++ b/src/EVM/Fuzz.hs
@@ -15,7 +15,7 @@ import Data.Word (Word8)
 
 import EVM.Expr qualified as Expr
 import EVM.Expr (bytesToW256)
-import EVM.SMT qualified as SMT (BufModel(..), SMTCex(..))
+import EVM.Types qualified as SMT
 import EVM.Traversals
 import EVM.Types (Prop(..), W256, Expr(..), EType(..), internalError, keccak')
 

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -77,24 +77,8 @@ data MultiData = MultiData
 
 data SingleData = SingleData
   { smt2 :: SMT2
-  , resultChan :: Chan CheckSatResult
+  , resultChan :: Chan SMT2Result
   }
-
--- | The result of a call to (check-sat)
-data CheckSatResult
-  = Sat SMTCex
-  | Unsat
-  | Unknown String
-  | Error String
-  deriving (Show, Eq)
-
-isSat :: CheckSatResult -> Bool
-isSat (Sat _) = True
-isSat _ = False
-
-isUnsat :: CheckSatResult -> Bool
-isUnsat Unsat = True
-isUnsat _ = False
 
 checkMulti :: SolverGroup -> Err SMT2 -> MultiSol -> IO (Maybe [W256])
 checkMulti (SolverGroup taskQueue) smt2 multiSol = do
@@ -107,20 +91,20 @@ checkMulti (SolverGroup taskQueue) smt2 multiSol = do
     -- collect result
     readChan resChan
 
-checkSatWithProps :: App m => SolverGroup -> [Prop] -> m (CheckSatResult, Err SMT2)
+checkSatWithProps :: App m => SolverGroup -> [Prop] -> m (SMT2Result, Err SMT2)
 checkSatWithProps (SolverGroup taskQueue) props = do
   conf <- readConfig
   let psSimp = simplifyProps props
-  if psSimp == [PBool False] then pure (Unsat, Right mempty)
+  if psSimp == [PBool False] then pure (Qed, Right mempty)
   else do
     let smt2 = assertProps conf psSimp
     if isLeft smt2 then
-      let err = getError smt2 in pure (EVM.Solvers.Unknown err, Left err)
+      let err = getError smt2 in pure (Error err, Left err)
     else do
       res <- liftIO $ checkSat (SolverGroup taskQueue) smt2
       pure (res, Right (getNonError smt2))
 
-checkSat :: SolverGroup -> Err SMT2 -> IO CheckSatResult
+checkSat :: SolverGroup -> Err SMT2 -> IO SMT2Result
 checkSat (SolverGroup taskQueue) smt2 = do
   if isLeft smt2 then pure $ Error $ getError smt2
   else do
@@ -227,7 +211,7 @@ getMultiSol smt2@(SMT2 cmds cexvars _) multiSol r inst availableInstances fileCo
           when conf.debug $ putStrLn $ "Unable to write SMT to solver: " <> (T.unpack err)
           writeChan r Nothing
 
-getOneSol :: (MonadIO m, ReadConfig m) => SMT2 -> (Chan CheckSatResult) -> SolverInstance -> Chan SolverInstance -> Int -> m ()
+getOneSol :: (MonadIO m, ReadConfig m) => SMT2 -> (Chan SMT2Result) -> SolverInstance -> Chan SolverInstance -> Int -> m ()
 getOneSol smt2@(SMT2 cmds cexvars ps) r inst availableInstances fileCounter = do
   conf <- readConfig
   let fuzzResult = tryCexFuzz ps conf.numCexFuzz
@@ -236,7 +220,7 @@ getOneSol smt2@(SMT2 cmds cexvars ps) r inst availableInstances fileCounter = do
     if (isJust fuzzResult)
       then do
         when (conf.debug) $ putStrLn $ "   Cex found via fuzzing:" <> (show fuzzResult)
-        writeChan r (Sat $ fromJust fuzzResult)
+        writeChan r (Cex $ fromJust fuzzResult)
       else if Prelude.not conf.onlyCexFuzz then do
         -- reset solver and send all lines of provided script
         out <- sendScript inst ("(reset)" : cmds)
@@ -248,10 +232,10 @@ getOneSol smt2@(SMT2 cmds cexvars ps) r inst availableInstances fileCounter = do
             sat <- sendLine inst "(check-sat)"
             res <- do
                 case sat of
-                  "unsat" -> pure Unsat
-                  "timeout" -> pure $ EVM.Solvers.Unknown "Result timeout by SMT solver"
-                  "unknown" -> pure $ EVM.Solvers.Unknown "Result unknown by SMT solver"
-                  "sat" -> Sat <$> getModel inst cexvars
+                  "unsat" -> pure Qed
+                  "timeout" -> pure $ Unknown "Result timeout by SMT solver"
+                  "unknown" -> pure $ Unknown "Result unknown by SMT solver"
+                  "sat" -> Cex <$> getModel inst cexvars
                   _ -> pure . Error $ "Unable to parse SMT solver output: " <> T.unpack sat
             writeChan r res
       else do

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -77,7 +77,7 @@ data MultiData = MultiData
 
 data SingleData = SingleData
   { smt2 :: SMT2
-  , resultChan :: Chan SMT2Result
+  , resultChan :: Chan SMTResult
   }
 
 checkMulti :: SolverGroup -> Err SMT2 -> MultiSol -> IO (Maybe [W256])
@@ -91,7 +91,7 @@ checkMulti (SolverGroup taskQueue) smt2 multiSol = do
     -- collect result
     readChan resChan
 
-checkSatWithProps :: App m => SolverGroup -> [Prop] -> m (SMT2Result, Err SMT2)
+checkSatWithProps :: App m => SolverGroup -> [Prop] -> m (SMTResult, Err SMT2)
 checkSatWithProps (SolverGroup taskQueue) props = do
   conf <- readConfig
   let psSimp = simplifyProps props
@@ -104,7 +104,7 @@ checkSatWithProps (SolverGroup taskQueue) props = do
       res <- liftIO $ checkSat (SolverGroup taskQueue) smt2
       pure (res, Right (getNonError smt2))
 
-checkSat :: SolverGroup -> Err SMT2 -> IO SMT2Result
+checkSat :: SolverGroup -> Err SMT2 -> IO SMTResult
 checkSat (SolverGroup taskQueue) smt2 = do
   if isLeft smt2 then pure $ Error $ getError smt2
   else do
@@ -211,7 +211,7 @@ getMultiSol smt2@(SMT2 cmds cexvars _) multiSol r inst availableInstances fileCo
           when conf.debug $ putStrLn $ "Unable to write SMT to solver: " <> (T.unpack err)
           writeChan r Nothing
 
-getOneSol :: (MonadIO m, ReadConfig m) => SMT2 -> (Chan SMT2Result) -> SolverInstance -> Chan SolverInstance -> Int -> m ()
+getOneSol :: (MonadIO m, ReadConfig m) => SMT2 -> (Chan SMTResult) -> SolverInstance -> Chan SolverInstance -> Int -> m ()
 getOneSol smt2@(SMT2 cmds cexvars ps) r inst availableInstances fileCounter = do
   conf <- readConfig
   let fuzzResult = tryCexFuzz ps conf.numCexFuzz

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
 
 module EVM.SymExec where
 
@@ -38,13 +39,13 @@ import EVM.Effects
 import EVM.Expr qualified as Expr
 import EVM.FeeSchedule (feeSchedule)
 import EVM.Format (formatExpr, formatPartial, formatPartialShort, showVal, indent, formatBinary, formatProp)
-import EVM.SMT (SMTCex(..), SMT2(..), assertProps)
 import EVM.SMT qualified as SMT
 import EVM.Solvers
 import EVM.Stepper (Stepper)
 import EVM.Stepper qualified as Stepper
 import EVM.Traversals
-import EVM.Types
+import EVM.Types hiding (Comp)
+import EVM.Types qualified
 import EVM.Expr (maybeConcStoreSimp)
 import GHC.Conc (getNumProcessors)
 import GHC.Generics (Generic)
@@ -58,49 +59,22 @@ data LoopHeuristic
   | StackBased
   deriving (Eq, Show, Read, ParseField, ParseFields, ParseRecord, Generic)
 
-data ProofResult a b c d = Qed a | Cex b | Unknown c | Error d
-  deriving (Show, Eq)
-type VerifyResult = ProofResult () (Expr End, SMTCex) (Expr End) String
-type EquivResult = ProofResult () (SMTCex) () String
-
-isUnknown :: ProofResult a b c d -> Bool
-isUnknown (EVM.SymExec.Unknown _) = True
-isUnknown _ = False
-
-isError :: ProofResult a b c d -> Bool
-isError (EVM.SymExec.Error _) = True
-isError _ = False
-
-getError :: ProofResult a b c String -> Maybe String
-getError (EVM.SymExec.Error e) = Just e
-getError _ = Nothing
-
-isCex :: ProofResult a b c d -> Bool
-isCex (Cex _) = True
-isCex _ = False
-
-isQed :: ProofResult a b c d -> Bool
-isQed (Qed _) = True
-isQed _ = False
-
-groupIssues :: [ProofResult a b c String] -> [(Integer, String)]
+groupIssues :: forall a b . GetUnknownStr b => [ProofResult a b] -> [(Integer, String)]
 groupIssues results = map (\g -> (into (length g), NE.head g)) grouped
   where
-    getErr :: ProofResult a b c String -> String
-    getErr (EVM.SymExec.Error k) = k
-    getErr (EVM.SymExec.Unknown _) = "SMT result timeout/unknown"
-    getErr _ = internalError "shouldn't happen"
-    sorted = sort $ map getErr results
-    grouped = NE.group sorted
+    getIssue :: ProofResult a b -> Maybe String
+    getIssue (Error k) = Just k
+    getIssue (Unknown reason) = Just $ "SMT solver says: " <> getUnknownStr reason
+    getIssue _ = Nothing
+    grouped = NE.group $ sort $ mapMaybe getIssue results
 
 groupPartials :: [Expr End] -> [(Integer, String)]
 groupPartials e = map (\g -> (into (length g), NE.head g)) grouped
   where
-    getErr :: Expr End -> String
-    getErr (Partial _ _ reason) = T.unpack $ formatPartialShort reason
-    getErr _ = internalError "shouldn't happen"
-    sorted = sort $ map getErr (filter isPartial e)
-    grouped = NE.group sorted
+    getPartial :: Expr End -> Maybe String
+    getPartial (Partial _ _ reason) = Just $ T.unpack $ formatPartialShort reason
+    getPartial _ = Nothing
+    grouped = NE.group $ sort $ mapMaybe getPartial e
 
 data VeriOpts = VeriOpts
   { simp :: Bool
@@ -391,7 +365,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
                       -- if we can statically determine unsatisfiability then we skip exploring the jump
                       [PBool False] -> liftIO $ stToIO $ runStateT (continue (Case False)) vm
                       -- otherwise we explore both branches
-                      _ -> liftIO $ stToIO $ runStateT (continue EVM.Types.Unknown) vm
+                      _ -> liftIO $ stToIO $ runStateT (continue UnknownBranch) vm
                     interpret fetcher maxIter askSmtIters heuristic vm' (k r)
           _ -> performQuery
 
@@ -564,7 +538,7 @@ flattenExpr = go []
 -- the incremental nature of the task at hand. Introducing support for
 -- incremental queries might let us go even faster here.
 -- TODO: handle errors properly
-reachable :: App m => SolverGroup -> Expr End -> m ([SMT2], Expr End)
+reachable :: App m => SolverGroup -> Expr End -> m ([SMT.SMT2], Expr End)
 reachable solvers e = do
   res <- go [] e
   pure $ second (fromMaybe (internalError "no reachable paths found")) res
@@ -575,7 +549,7 @@ reachable solvers e = do
        If reachable return the expr wrapped in a Just. If not return Nothing.
        When walking back up the tree drop unreachable subbranches.
     -}
-    go :: (App m, MonadUnliftIO m) => [Prop] -> Expr End -> m ([SMT2], Maybe (Expr End))
+    go :: (App m, MonadUnliftIO m) => [Prop] -> Expr End -> m ([SMT.SMT2], Maybe (Expr End))
     go pcs = \case
       ITE c t f -> do
         (tres, fres) <- withRunInIO $ \env -> concurrently
@@ -590,9 +564,11 @@ reachable solvers e = do
       leaf -> do
         (res, smt2) <- checkSatWithProps solvers pcs
         case res of
-          Sat _ -> pure ([getNonError smt2], Just leaf)
-          Unsat -> pure ([getNonError smt2], Nothing)
-          r -> internalError $ "Invalid solver result: " <> show r
+          Qed -> pure ([getNonError smt2], Nothing)
+          Cex _ -> pure ([getNonError smt2], Just leaf)
+          -- if we get an error, we don't know if the leaf is reachable or not, so
+          -- we assume it could be reachable
+          _ -> pure ([], Just leaf)
 
 -- | Extract constraints stored in Expr End nodes
 extractProps :: Expr End -> [Prop]
@@ -656,12 +632,12 @@ verify solvers opts preState maybepost = do
       putStrLn $ "   Exploration finished, " <> show (Expr.numBranches expr) <> " branch(es) to check in call " <> call
 
     case maybepost of
-      Nothing -> pure (expr, [Qed ()])
+      Nothing -> pure (expr, [Qed])
       Just post -> liftIO $ do
         let
           -- Filter out any leaves from `flattened` that can be statically shown to be safe
           tocheck = flip map flattened $ \leaf -> (toPropsFinal leaf preState.constraints post, leaf)
-          withQueries = filter canBeSat tocheck <&> first (assertProps conf)
+          withQueries = filter canBeSat tocheck <&> first (SMT.assertProps conf)
         when conf.debug $
           putStrLn $ "   Checking for reachability of " <> show (length withQueries)
                      <> " potential property violation(s) in call " <> call
@@ -671,9 +647,9 @@ verify solvers opts preState maybepost = do
           res <- checkSat solvers query
           when conf.debug $ putStrLn $ "   SMT result: " <> show res
           pure (res, leaf)
-        let cexs = filter (\(res, _) -> not . isUnsat $ res) results
+        let cexs = filter (\(res, _) -> not . isQed $ res) results
         when conf.debug $ putStrLn $ "   Found " <> show (length cexs) <> " potential counterexample(s) in call " <> call
-        pure $ if Prelude.null cexs then (expr, [Qed ()]) else (expr, fmap toVRes cexs)
+        pure $ if Prelude.null cexs then (expr, [Qed]) else (expr, fmap toVRes cexs)
   where
     getCallPrefix :: Expr Buf -> String
     getCallPrefix (WriteByte (Lit 0) (LitByte a) (WriteByte (Lit 1) (LitByte b) (WriteByte (Lit 2) (LitByte c) (WriteByte (Lit 3) (LitByte d) _)))) = mconcat $ map (printf "%02x") [a,b,c,d]
@@ -684,12 +660,12 @@ verify solvers opts preState maybepost = do
     canBeSat (a, _) = case a of
         [PBool False] -> False
         _ -> True
-    toVRes :: (CheckSatResult, Expr End) -> VerifyResult
+    toVRes :: (SMT2Result, Expr End) -> VerifyResult
     toVRes (res, leaf) = case res of
-      Sat model -> Cex (leaf, expandCex preState model)
-      EVM.Solvers.Unknown _ -> EVM.SymExec.Unknown leaf
-      EVM.Solvers.Error e -> EVM.SymExec.Error e
-      Unsat -> Qed ()
+      Cex model -> Cex (leaf, expandCex preState model)
+      Unknown reason -> Unknown (reason, leaf)
+      Error e -> Error e
+      Qed -> Qed
 
 expandCex :: VM Symbolic s -> SMTCex -> SMTCex
 expandCex prestate c = c { store = Map.union c.store concretePreStore }
@@ -725,7 +701,7 @@ equivalenceCheck solvers bytecodeA bytecodeB opts calldata create = do
   case bytecodeA == bytecodeB of
     True -> liftIO $ do
       putStrLn "bytecodeA and bytecodeB are identical"
-      pure ([Qed ()], mempty)
+      pure ([Qed], mempty)
     False -> do
       when conf.debug $ liftIO $ do
         putStrLn "bytecodeA and bytecodeB are different, checking for equivalence"
@@ -790,7 +766,7 @@ equivalenceCheck' solvers branchesA branchesB create = do
       procs <- liftIO getNumProcessors
       cexes <- checkAll differingEndStates knownUnsat procs
       let allCexes = cexes <> deployedCexes
-      if all isQed allCexes then pure ([Qed ()], ends)
+      if all isQed allCexes then pure ([Qed], ends)
                             else pure (filter (Prelude.not . isQed) allCexes, ends)
   where
     -- we order the sets by size because this gives us more cache hits when
@@ -809,15 +785,10 @@ equivalenceCheck' solvers branchesA branchesB create = do
     check :: App m => UnsatCache -> Set Prop -> m EquivResult
     check knownUnsat props = do
       ku <- liftIO $ readTVarIO knownUnsat
-      res <- if subsetAny props ku then pure Unsat
+      if subsetAny props ku then pure $ Qed
              else do
                (res, _) <- checkSatWithProps solvers (Set.toList props)
                pure res
-      case res of
-        Sat x -> pure $ Cex x
-        Unsat -> pure $ Qed ()
-        EVM.Solvers.Unknown _ -> pure $ EVM.SymExec.Unknown ()
-        EVM.Solvers.Error txt -> pure $ EVM.SymExec.Error txt
 
     -- Allows us to run it in parallel. Note that this (seems to) run it
     -- from left-to-right, and with a max of K threads. This is in contrast to
@@ -921,31 +892,31 @@ equivalenceCheck' solvers branchesA branchesB create = do
 both' :: (a -> b) -> (a, a) -> (b, b)
 both' f (x, y) = (f x, f y)
 
-produceModels :: App m => SolverGroup -> Expr End -> m [(Expr End, CheckSatResult)]
+produceModels :: App m => SolverGroup -> Expr End -> m [(Expr End, SMT2Result)]
 produceModels solvers expr = do
   let flattened = flattenExpr expr
-      withQueries conf = fmap (\e -> ((assertProps conf) . extractProps $ e, e)) flattened
+      withQueries conf = fmap (\e -> ((SMT.assertProps conf) . extractProps $ e, e)) flattened
   conf <- readConfig
   results <- liftIO $ (flip mapConcurrently) (withQueries conf) $ \(query, leaf) -> do
     res <- checkSat solvers query
     pure (res, leaf)
-  pure $ fmap swap $ filter (\(res, _) -> not . isUnsat $ res) results
+  pure $ fmap swap $ filter (\(res, _) -> not . isQed $ res) results
 
-showModel :: Expr Buf -> (Expr End, CheckSatResult) -> IO ()
+showModel :: Expr Buf -> (Expr End, SMT2Result) -> IO ()
 showModel cd (expr, res) = do
   case res of
-    EVM.Solvers.Unsat -> pure () -- ignore unreachable branches
-    EVM.Solvers.Error e -> do
+    Qed -> pure () -- ignore unreachable branches
+    Error e -> do
       putStrLn ""
       putStrLn "--- Branch ---"
       putStrLn $ "Error during SMT solving, cannot check branch " <> e
-    EVM.Solvers.Unknown reason -> do
+    Unknown reason -> do
       putStrLn ""
       putStrLn "--- Branch ---"
       putStrLn $ "Unable to produce a model for the following end state due to '" <> reason <> "' :"
       T.putStrLn $ indent 2 $ formatExpr expr
       putStrLn ""
-    Sat cex -> do
+    Cex cex -> do
       putStrLn ""
       putStrLn "--- Branch ---"
       putStrLn "Inputs:"
@@ -1093,8 +1064,8 @@ subModel c
   . subVars c.txContext
   . subAddrs c.addrs
   where
-    forceFlattened (SMT.Flat bs) = bs
-    forceFlattened b@(SMT.Comp _) = forceFlattened $
+    forceFlattened (Flat bs) = bs
+    forceFlattened b@(EVM.Types.Comp _) = forceFlattened $
       fromMaybe (internalError $ "cannot flatten buffer: " <> show b)
                 (SMT.collapse b)
 
@@ -1151,10 +1122,6 @@ subStores model b = Map.foldlWithKey subStore b model
                else v
           e -> e
 
-getCex :: ProofResult a b c d -> Maybe b
+getCex :: ProofResult a b -> Maybe a
 getCex (Cex c) = Just c
 getCex _ = Nothing
-
-getUnknown :: ProofResult a b c d-> Maybe c
-getUnknown (EVM.SymExec.Unknown c) = Just c
-getUnknown _ = Nothing

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -660,7 +660,7 @@ verify solvers opts preState maybepost = do
     canBeSat (a, _) = case a of
         [PBool False] -> False
         _ -> True
-    toVRes :: (SMT2Result, Expr End) -> VerifyResult
+    toVRes :: (SMTResult, Expr End) -> VerifyResult
     toVRes (res, leaf) = case res of
       Cex model -> Cex (leaf, expandCex preState model)
       Unknown reason -> Unknown (reason, leaf)
@@ -892,7 +892,7 @@ equivalenceCheck' solvers branchesA branchesB create = do
 both' :: (a -> b) -> (a, a) -> (b, b)
 both' f (x, y) = (f x, f y)
 
-produceModels :: App m => SolverGroup -> Expr End -> m [(Expr End, SMT2Result)]
+produceModels :: App m => SolverGroup -> Expr End -> m [(Expr End, SMTResult)]
 produceModels solvers expr = do
   let flattened = flattenExpr expr
       withQueries conf = fmap (\e -> ((SMT.assertProps conf) . extractProps $ e, e)) flattened
@@ -902,7 +902,7 @@ produceModels solvers expr = do
     pure (res, leaf)
   pure $ fmap swap $ filter (\(res, _) -> not . isQed $ res) results
 
-showModel :: Expr Buf -> (Expr End, SMT2Result) -> IO ()
+showModel :: Expr Buf -> (Expr End, SMTResult) -> IO ()
 showModel cd (expr, res) = do
   case res of
     Qed -> pure () -- ignore unreachable branches

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -1200,7 +1200,7 @@ instance (Eq a, Eq b) => Eq (ProofResult a b) where
 
 type VerifyResult = ProofResult (Expr End, SMTCex) (String, Expr End)
 type EquivResult = ProofResult (SMTCex) String
-type SMT2Result = ProofResult (SMTCex) String
+type SMTResult = ProofResult (SMTCex) String
 
 getUnknown :: ProofResult a b -> Maybe b
 getUnknown (Unknown a) = Just a

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -4,7 +4,6 @@ module EVM.UnitTest where
 
 import EVM
 import EVM.ABI
-import EVM.SMT
 import EVM.Solvers
 import EVM.Dapp
 import EVM.Effects
@@ -14,7 +13,7 @@ import EVM.FeeSchedule (feeSchedule)
 import EVM.Fetch qualified as Fetch
 import EVM.Format
 import EVM.Solidity
-import EVM.SymExec (defaultVeriOpts, symCalldata, verify, isCex, extractCex, prettyCalldata, panicMsg, VeriOpts(..), flattenExpr, isUnknown, isError, groupIssues, groupPartials, ProofResult(..))
+import EVM.SymExec (defaultVeriOpts, symCalldata, verify, extractCex, prettyCalldata, panicMsg, VeriOpts(..), flattenExpr, groupIssues, groupPartials)
 import EVM.Types
 import EVM.Transaction (initTx)
 import EVM.Stepper (Stepper)
@@ -259,7 +258,7 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
     liftIO $ printWarnings ends results t
     pure (not (any isCex results), not (warnings || unexpectedAllRevert))
 
-printWarnings :: [Expr 'End] -> [ProofResult a b c String] -> String -> IO ()
+printWarnings :: GetUnknownStr b => [Expr 'End] -> [ProofResult a b] -> String -> IO ()
 printWarnings e results testName = do
   when (any isUnknown results || any isError results || any Expr.isPartial e) $ do
     putStrLn $ "   \x1b[33m[WARNING]\x1b[0m hevm was only able to partially explore " <> testName <> " due to: ";

--- a/test/test.hs
+++ b/test/test.hs
@@ -215,7 +215,7 @@ tests = testGroup "hevm"
         |]
        expr <- withDefaultSolver $ \s -> getExpr s c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
        assertEqualM "Expression is not clean." (badStoresInExpr expr) False
-       (_, [(Qed _)]) <- withDefaultSolver $ \s -> checkAssert s [0x11] c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+       (_, [(Qed)]) <- withDefaultSolver $ \s -> checkAssert s [0x11] c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
        liftIO $ putStrLn "OK"
     , ignoreTest $ test "simplify-storage-map-todo" $ do
        Just c <- solcRuntime "MyContract"
@@ -1241,7 +1241,7 @@ tests = testGroup "hevm"
              }
             |]
         let sig = (Just (Sig "fun(uint8)" [AbiUIntType 8]))
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
         putStrLnM "expected Qed found"
      , test "enum-conversion-fail" $ do
         Just c <- solcRuntime "MyContract"
@@ -1400,7 +1400,7 @@ tests = testGroup "hevm"
             }
             |]
         let sig = Just (Sig "fun(uint256)" [AbiUIntType 256])
-        (e, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+        (e, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
         assertBoolM "The expression must contain Partial." $ Expr.containsNode isPartial e
       , test "cheatcode-with-selector" $ do
         Just c <- solcRuntime "C"
@@ -1518,7 +1518,7 @@ tests = testGroup "hevm"
         (_, k) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
         let numErrs = sum $ map (fromEnum . isError) k
         assertEqualM "number of errors (i.e. copySlice issues) is 1" 1 numErrs
-        let errStrings = mapMaybe EVM.SymExec.getError k
+        let errStrings = mapMaybe getResError k
         assertEqualM "All errors are from copyslice" True $ all ("CopySlice" `List.isInfixOf`) errStrings
       -- below we hit the limit of the depth of the symbolic execution tree
       , testCase "limit-num-explore-hit-limit" $ do
@@ -1598,7 +1598,7 @@ tests = testGroup "hevm"
         (_, k) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
         let numErrs = sum $ map (fromEnum . isError) k
         assertEqualM "number of errors (i.e. copySlice issues) is 1" 1 numErrs
-        let errStrings = mapMaybe EVM.SymExec.getError k
+        let errStrings = mapMaybe getResError k
         assertEqualM "All errors are from copyslice" True $ all ("CopySlice" `List.isInfixOf`) errStrings
   ]
   , testGroup "Symbolic-Constructor-Args"
@@ -1669,7 +1669,7 @@ tests = testGroup "hevm"
         (e, res) <- withDefaultSolver $
           \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
         liftIO $ printWarnings [e] res "the contracts under test"
-        assertEqualM "Must be QED" res [Qed ()]
+        assertEqualM "Must be QED" res [Qed]
     , test "extcodesize-symbolic2" $ do
         Just c <- solcRuntime "C"
           [i|
@@ -1799,7 +1799,7 @@ tests = testGroup "hevm"
             |]
         let sig = Just $ Sig "fun()" []
             opts = defaultVeriOpts{ maxIter = Just 3 }
-        (e, [Qed _]) <- withDefaultSolver $
+        (e, [Qed]) <- withDefaultSolver $
           \s -> checkAssert s defaultPanicCodes c sig [] opts
         assertBoolM "The expression is not partial" $ isPartial e
     , test "concrete-loops-not-reached" $ do
@@ -1816,7 +1816,7 @@ tests = testGroup "hevm"
 
         let sig = Just $ Sig "fun()" []
             opts = defaultVeriOpts{ maxIter = Just 6 }
-        (e, [Qed _]) <- withDefaultSolver $
+        (e, [Qed]) <- withDefaultSolver $
           \s -> checkAssert s defaultPanicCodes c sig [] opts
         assertBoolM "The expression is partial" $ not $ isPartial e
     , test "symbolic-loops-reached" $ do
@@ -1830,7 +1830,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (e, [Qed _]) <- withDefaultSolver $
+        (e, [Qed]) <- withDefaultSolver $
           \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] (defaultVeriOpts{ maxIter = Just 5 })
         assertBoolM "The expression MUST be partial" $ Expr.containsNode isPartial e
     , test "inconsistent-paths" $ do
@@ -1850,7 +1850,7 @@ tests = testGroup "hevm"
             -- already in an inconsistent path (i == 5, j <= 3, i < j), so we
             -- will continue looping here until we hit max iterations
             opts = defaultVeriOpts{ maxIter = Just 10, askSmtIters = 5 }
-        (e, [Qed _]) <- withDefaultSolver $
+        (e, [Qed]) <- withDefaultSolver $
           \s -> checkAssert s defaultPanicCodes c sig [] opts
         assertBoolM "The expression is not partial" $ Expr.containsNode isPartial e
     , test "mem-tuple" $ do
@@ -1873,7 +1873,7 @@ tests = testGroup "hevm"
           |]
         let opts = defaultVeriOpts
         let sig = Just $ Sig "prove_tuple_pass((uint256,uint256))" [AbiTupleType (V.fromList [AbiUIntType 256, AbiUIntType 256])]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] opts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] opts
         putStrLnM "Qed, memory tuple is good"
     , test "symbolic-loops-not-reached" $ do
         Just c <- solcRuntime "C"
@@ -1891,7 +1891,7 @@ tests = testGroup "hevm"
             -- askSmtIters is low enough here to avoid the inconsistent path
             -- conditions, so we never hit maxIters
             opts = defaultVeriOpts{ maxIter = Just 5, askSmtIters = 1 }
-        (e, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] opts
+        (e, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] opts
         assertBoolM "The expression MUST NOT be partial" $ not (Expr.containsNode isPartial e)
     ]
   , testGroup "Symbolic Addresses"
@@ -1910,7 +1910,7 @@ tests = testGroup "hevm"
         Just a <- solcRuntime "A" src
         Just c <- solcRuntime "C" src
         let sig = Sig "fun(uint256)" [AbiUIntType 256]
-        (expr, [Qed _]) <- withDefaultSolver $ \s ->
+        (expr, [Qed]) <- withDefaultSolver $ \s ->
           verifyContract s c (Just sig) [] defaultVeriOpts Nothing Nothing
         let isSuc (Success {}) = True
             isSuc _ = False
@@ -2230,7 +2230,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256)" [AbiIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256)" [AbiIntType 256])) [] defaultVeriOpts
         putStrLnM "Require works as expected"
      , test "symbolic-block-number" $ do
        Just c <- solcRuntime "C" [i|
@@ -2262,7 +2262,7 @@ tests = testGroup "hevm"
              }
             |]
         let sig = Just (Sig "fun(uint160)" [AbiUIntType 160])
-        (e, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+        (e, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
         assertBoolM "The expression is not partial" $ Prelude.not (Expr.containsNode isPartial e)
      ,
      -- here test
@@ -2301,7 +2301,7 @@ tests = testGroup "hevm"
            }
          }
          |]
-       (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+       (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
        putStrLnM "this should always be true, due to bitwise OR with positive value"
      ,
      test "abstract-returndata-size" $ do
@@ -2342,7 +2342,7 @@ tests = testGroup "hevm"
         }
         |]
       let sig = Just (Sig "checkval(uint8)" [AbiUIntType 8])
-      (res, [Qed _]) <- withDefaultSolver $ \s ->
+      (res, [Qed]) <- withDefaultSolver $ \s ->
         checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
       putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
     , test "staticcall-check-orig" $ do
@@ -2961,7 +2961,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256,int256)" [AbiIntType 256, AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256,int256)" [AbiIntType 256, AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLnM "MUL is associative"
      ,
      -- TODO look at tests here for SAR: https://github.com/dapphub/dapptools/blob/01ef8ea418c3fe49089a44d56013d8fcc34a1ec2/src/dapp-tests/pass/constantinople.sol#L250
@@ -2979,7 +2979,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256)" [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256)" [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLnM "SAR works as expected"
      ,
      test "opcode-sar-pos" $ do
@@ -2996,7 +2996,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256)" [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256)" [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLnM "SAR works as expected"
      ,
      test "opcode-sar-fixedval-pos" $ do
@@ -3013,7 +3013,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256)" [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256)" [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLnM "SAR works as expected"
      ,
      test "opcode-sar-fixedval-neg" $ do
@@ -3030,7 +3030,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256)" [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(int256,int256)" [AbiIntType 256, AbiIntType 256])) [] defaultVeriOpts
         putStrLnM "SAR works as expected"
      ,
      test "opcode-div-zero-1" $ do
@@ -3047,7 +3047,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _])  <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+        (_, [Qed])  <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
         putStrLnM "sdiv works as expected"
       ,
      test "opcode-sdiv-zero-1" $ do
@@ -3064,7 +3064,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _])  <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+        (_, [Qed])  <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
         putStrLnM "sdiv works as expected"
       ,
      test "opcode-sdiv-zero-2" $ do
@@ -3081,7 +3081,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _])  <- withCVC5Solver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+        (_, [Qed])  <- withCVC5Solver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
         putStrLnM "sdiv works as expected"
       ,
      test "signed-overflow-checks" $ do
@@ -3115,7 +3115,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _])  <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+        (_, [Qed])  <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
         putStrLnM "signextend works as expected"
       ,
      test "opcode-signextend-pos-nochop" $ do
@@ -3133,7 +3133,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint8)" [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint8)" [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
         putStrLnM "signextend works as expected"
       ,
       test "opcode-signextend-pos-chopped" $ do
@@ -3151,7 +3151,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint8)" [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint8)" [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
         putStrLnM "signextend works as expected"
       ,
       -- when b is too large, value is unchanged
@@ -3169,7 +3169,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint8)" [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint8)" [AbiUIntType 256, AbiUIntType 8])) [] defaultVeriOpts
         putStrLnM "signextend works as expected"
      ,
      test "opcode-shl" $ do
@@ -3187,7 +3187,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         putStrLnM "SAR works as expected"
      ,
      test "opcode-xor-cancel" $ do
@@ -3204,7 +3204,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         putStrLnM "XOR works as expected"
       ,
       test "opcode-xor-reimplement" $ do
@@ -3220,7 +3220,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
         putStrLnM "XOR works as expected"
       ,
       test "opcode-add-commutative" $ do
@@ -3246,7 +3246,7 @@ tests = testGroup "hevm"
             putStrLnM $ "y:" <> show y
             putStrLnM $ "x:" <> show x
             assertEqualM "Addition is not commutative... that's wrong" False True
-          (_, [Qed _]) -> do
+          (_, [Qed]) -> do
             putStrLnM "adding is commutative"
           _ -> internalError "Unexpected"
       ,
@@ -3264,7 +3264,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-        (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint16)" [AbiUIntType 16])) [] defaultVeriOpts
+        (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "fun(uint16)" [AbiUIntType 16])) [] defaultVeriOpts
         putStrLnM "DIV by zero is zero"
       ,
       -- Somewhat tautological since we are asserting the precondition
@@ -3292,7 +3292,7 @@ tests = testGroup "hevm"
                    Success _ _ b _ -> (ReadWord (Lit 0) b) .== (Add x y)
                    _ -> PBool True
             sig = Just (Sig "add(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])
-        (res, [Qed _]) <- withDefaultSolver $ \s ->
+        (res, [Qed]) <- withDefaultSolver $ \s ->
           verifyContract s safeAdd sig [] defaultVeriOpts (Just pre) (Just post)
         putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
      ,
@@ -3319,7 +3319,7 @@ tests = testGroup "hevm"
               in case leaf of
                    Success _ _ b _ -> (ReadWord (Lit 0) b) .== (Mul (Lit 2) y)
                    _ -> PBool True
-        (res, [Qed _]) <- withDefaultSolver $ \s ->
+        (res, [Qed]) <- withDefaultSolver $ \s ->
           verifyContract s safeAdd (Just (Sig "add(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts (Just pre) (Just post)
         putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
       ,
@@ -3350,7 +3350,7 @@ tests = testGroup "hevm"
                   in Expr.add prex (Expr.mul (Lit 2) y) .== (Expr.readStorage' (Lit 0) poststore)
                 _ -> PBool True
             sig = Just (Sig "f(uint256)" [AbiUIntType 256])
-        (res, [Qed _]) <- withDefaultSolver $ \s ->
+        (res, [Qed]) <- withDefaultSolver $ \s ->
           verifyContract s c sig [] defaultVeriOpts (Just pre) (Just post)
         putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
@@ -3376,7 +3376,7 @@ tests = testGroup "hevm"
                     }
                     |]
             Just c <- liftIO $ yulRuntime "Neg" src
-            (res, [Qed _]) <- withSolvers Z3 4 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "hello(address)" [AbiAddressType])) [] defaultVeriOpts
+            (res, [Qed]) <- withSolvers Z3 4 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "hello(address)" [AbiAddressType])) [] defaultVeriOpts
             putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "catch-storage-collisions-noproblem" $ do
@@ -3412,7 +3412,7 @@ tests = testGroup "hevm"
                        in Expr.add prex prey .== Expr.add postx posty
                      _ -> PBool True
               sig = Just (Sig "f(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])
-          (_, [Qed _]) <- withDefaultSolver $ \s ->
+          (_, [Qed]) <- withDefaultSolver $ \s ->
             verifyContract s c sig [] defaultVeriOpts (Just pre) (Just post)
           putStrLnM "Correct, this can never fail"
         ,
@@ -3553,7 +3553,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         -- We zero out everything but the LSB byte. However, byte(31,x) takes the LSB byte
@@ -3607,7 +3607,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         -- Bitwise OR operation test
@@ -3623,7 +3623,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM "When OR-ing with full 1's we should get back full 1's"
         ,
         -- Bitwise OR operation test
@@ -3640,7 +3640,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM "When OR-ing with a byte of 1's, we should get 1's back there"
         ,
         test "Deposit contract loop (z3)" $ do
@@ -3662,7 +3662,7 @@ tests = testGroup "hevm"
               }
              }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "deposit(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "deposit(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "Deposit-contract-loop-error-version" $ do
@@ -3697,7 +3697,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "check-asm-byte-in-bounds" $ do
@@ -3716,7 +3716,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLnM "in bounds byte reads return the expected value"
         ,
         test "check-div-mod-sdiv-smod-by-zero-constant-prop" $ do
@@ -3746,7 +3746,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "foo(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM "div/mod/sdiv/smod by zero works as expected during constant propagation"
         ,
         test "check-asm-byte-oob" $ do
@@ -3761,7 +3761,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLnM "oob byte reads always return 0"
         ,
         test "injectivity of keccak (diff sizes)" $ do
@@ -3788,7 +3788,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "injectivity of keccak contrapositive (32 bytes)" $ do
@@ -3801,7 +3801,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "injectivity of keccak (64 bytes)" $ do
@@ -3836,7 +3836,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "calldata beyond calldatasize is 0 (concrete dalldata prefix)" $ do
@@ -3853,7 +3853,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "calldata symbolic access" $ do
@@ -3874,7 +3874,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "multiple-contracts" $ do
@@ -3946,7 +3946,7 @@ tests = testGroup "hevm"
                 }
               }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "kecc(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "kecc(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "keccak-concrete-and-sym-agree-nonzero" $ do
@@ -3961,7 +3961,7 @@ tests = testGroup "hevm"
                 }
               }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "kecc(uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "kecc(uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "keccak concrete and sym injectivity" $ do
@@ -3973,14 +3973,14 @@ tests = testGroup "hevm"
                 }
               }
             |]
-          (res, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "safemath-distributivity-yul" $ do
           let yulsafeDistributivity = hex "6355a79a6260003560e01c14156016576015601f565b5b60006000fd60a1565b603d602d604435600435607c565b6039602435600435607c565b605d565b6052604b604435602435605d565b600435607c565b141515605a57fe5b5b565b6000828201821115151560705760006000fd5b82820190505b92915050565b6000818384048302146000841417151560955760006000fd5b82820290505b92915050565b"
           calldata <- mkCalldata (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) []
           vm <- liftIO $ stToIO $ abstractVM calldata yulsafeDistributivity Nothing False
-          (_, [Qed _]) <-  withDefaultSolver $ \s -> verify s defaultVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
+          (_, [Qed]) <-  withDefaultSolver $ \s -> verify s defaultVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
           putStrLnM "Proven"
         ,
         test "safemath-distributivity-sol" $ do
@@ -4005,7 +4005,7 @@ tests = testGroup "hevm"
               }
             |]
 
-          (_, [Qed _]) <- withSolvers Bitwuzla 1 1 (Just 99999999) $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
+          (_, [Qed]) <- withSolvers Bitwuzla 1 1 (Just 99999999) $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM "Proven"
         ,
         test "storage-cex-1" $ do
@@ -4104,7 +4104,7 @@ tests = testGroup "hevm"
             }
             |]
           let sig = (Just (Sig "stuff(address)" [AbiAddressType]))
-          (_, [Qed _]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+          (_, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
           putStrLnM $ "Basic tstore check passed"
   ]
   , testGroup "concr-fuzz"
@@ -4586,7 +4586,7 @@ tests = testGroup "hevm"
         withSolvers Z3 3 1 Nothing $ \s -> do
           calldata <- mkCalldata Nothing []
           (res, _) <- equivalenceCheck s initA initB defaultVeriOpts calldata True
-          assertEqualM "Must have no difference" [Qed ()] res
+          assertEqualM "Must have no difference" [Qed] res
       -- We set x to be 3 vs 0 (default) on deployment. Then, the returned value will be different
       , test "constructor-differing" $ do
         Just initA <- solidity "C"
@@ -4639,7 +4639,7 @@ tests = testGroup "hevm"
         withSolvers Z3 3 1 Nothing $ \s -> do
           calldata <- mkCalldata Nothing []
           (res, _) <- equivalenceCheck s aPrgm bPrgm defaultVeriOpts calldata False
-          assertEqualM "Must have no difference" [Qed ()] res
+          assertEqualM "Must have no difference" [Qed] res
       ,
       test "eq-balance-differs" $ do
         Just aPrgm <- solcRuntime "C"
@@ -5047,12 +5047,11 @@ checkEquivBase :: (Eq a, App m) => (a -> a -> Prop) -> a -> a -> Bool -> m (Mayb
 checkEquivBase mkprop l r expect = do
   withSolvers Z3 1 1 (Just 1) $ \solvers -> do
      (res, _) <- checkSatWithProps solvers [mkprop l r]
-     let
-       ret = case res of
-         Unsat -> Just True
-         Sat _ -> Just False
-         EVM.Solvers.Error _ -> Just (not expect)
-         EVM.Solvers.Unknown _ -> Nothing
+     let ret = case res of
+           Qed -> Just True
+           Cex {} -> Just False
+           Error _ -> Just (not expect)
+           Unknown _ -> Nothing
      when (ret == Just (not expect)) $ liftIO $ print res
      pure ret
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -4296,7 +4296,7 @@ tests = testGroup "hevm"
         let props = [(PEq (BufLength (AbstractBuf "b")) (Lit 0x0))]
         (res, _) <- checkSatWithProps s props
         cex :: SMTCex <- case res of
-          Sat c -> pure c
+          Cex c -> pure c
           _ -> liftIO $ assertFailure "Must be satisfiable!"
         let value = subModel cex (AbstractBuf "b")
         assertEqualM "Buffer must be empty" (ConcreteBuf "") value
@@ -4305,7 +4305,7 @@ tests = testGroup "hevm"
         let props = [(PAnd (PEq (ReadByte (Lit 0x0) (AbstractBuf "b")) (LitByte 0x0)) (PEq (BufLength (AbstractBuf "b")) (Lit 0x1)))]
         (res, _) <- checkSatWithProps s props
         cex :: SMTCex <- case res of
-          Sat c -> pure c
+          Cex c -> pure c
           _ -> liftIO $ assertFailure "Must be satisfiable!"
         let value = subModel cex (AbstractBuf "b")
         assertEqualM "Buffer must have size 1 and contain zero byte" (ConcreteBuf "\0") value
@@ -4315,7 +4315,7 @@ tests = testGroup "hevm"
         (res, _) <- checkSatWithProps s props
         let
           sat = case res of
-            Sat _ -> True
+            Cex _ -> True
             _ -> False
         assertBoolM "Must be satisfiable!" sat
   ]


### PR DESCRIPTION
## Description
`CheckSatResult` vs `ProofResult` has led to a bit of a mess, I think. With this rewrite, it should lead to a cleaner, and easier-to-read code, that is more obviously correct. This also means that in case we have a CopySlice issue, it doesn't get pushed into two different types, which could lead to this kind of thing:

```
      2x -> CopySlice with a symbolically sized region not currently implemented, cannot execute SMT solver on this query
      1x -> SMT result timeout/unknown: CopySlice with a symbolically sized region not currently implemented, cannot execute SMT solver on this query
```

Other changes:
* Another issue fixed is that `reachable` would throw an `internalError` when `reachable` would die due to timeout/symbolic copyslice issue. Now we just say that the leaf may be reachable. We also adjusted the printing so it says "Potentially Reachable" rather than "Reachable".
* Also, `Unknown` has been renamed `UnknownBranch`, since `Unknown` collided with other names. I think `UnknownBranch` is a clean, short-ish name. It actually makes it easier to read some functions, in my opinion.
* Aeson is no longer imported without a qualifier, as it's actually a large namespace and collides with some things. So it's now qualified as `JSON.`, which I think is reasonable.
* I had to use a typeclass to make `Show` work for `Unknown`, but it's actually not that crazy.
* `Qed` for probably historical reason had a `()` parameter at all times -- this was unneeded. I removed it, it's so a lot cleaner now.
* I also had to move some definitions to `Types`. However, I consider this a win, as the cyclical definition issue is now reduced -- `Types` can be imported from anywhere, without cyclical import issues.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
