### PR TITLE
Fix interpretation of buffer model value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Equivalence checking was incorrectly assuming that overapproximated values
   were sequentially equivalent. We now distinguish these symbolic values with
   `A-` and `B-`
+- Buffer of all zeroes was interpreted as an empty buffer during parsing SMT model.
+  The length of the buffer is now properly taken into account.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -1149,9 +1149,7 @@ getBufs getVal bufs = foldM getBuf mempty bufs
                 :| [SortSymbol (IdIndexed "BitVec" (IxNumeral "8" :| []))]
               )
             )) ((TermSpecConstant val :| [])))
-            -> case val of
-                 SCHexadecimal "00" -> Base 0 0
-                 v -> Base (parseW8 v) len
+            -> Base (parseW8 val) len
 
           -- writing a byte over some array
           (TermApplication


### PR DESCRIPTION
Previosuly, we would interpret any buffer whose model is a constant-zero array as an empty buffer, disregarding the value of the length of the buffer in the model.
However, the length must be taken into account.

Fun fact: The special case was only triggered if the zero value used hexadecimal format (which is used by Z3). For example, Bitwuzla prints using binary format, so this special handling was not triggered for Bitwuzla.

## Description

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
