### PR TITLE
Avoid eager translation of buffer models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `--smtoutput` since it was never used
 - We now build with -DCMAKE_POLICY_VERSION_MINIMUM=3.5 libff, as cmake deprecated 3.5
 - CheckSatResult has now been unified with ProofResult via SMTResult
+- Buffers are now handled more lazily when inspecting a model, which avoids some
+  unnecesary internal errors.
 
 ## [0.54.2] - 2024-12-12
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -412,7 +412,7 @@ equivalence eqOpts cOpts = do
         T.putStrLn . T.unlines $
           [ "Not equivalent. The following inputs result in differing behaviours:"
           , "" , "-----", ""
-          ] <> (intersperse (T.unlines [ "", "-----" ]) $ fmap (formatCex (AbstractBuf "txdata") Nothing) cexs)
+          ] <> (intersperse (T.unlines [ "", "-----" ]) $ fmap (showBuffer (AbstractBuf "txdata")) cexs)
         exitFailure
   where
     decipher = maybe Nothing (hexByteString . strip0x)

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -77,10 +77,6 @@ instance Monoid CexVars where
       , txContext = mempty
       }
 
-flattenBufs :: SMTCex -> Maybe SMTCex
-flattenBufs cex = do
-  bs <- mapM collapse cex.buffers
-  pure $ cex{ buffers = bs }
 
 -- | Attempts to collapse a compressed buffer representation down to a flattened one
 collapse :: BufModel -> Maybe BufModel


### PR DESCRIPTION
## Description
The goal here is to keep the buffer representation in the compressed form as long as possible, and only lazily translate to the flat representation.
This helps to avoid raising `internal error` when the buffer length is too large to be converted to concrete `ByteString`.
Instead, as the output of the equivalence check we print the compressed representation. This information might still be helpful, definitely more helpful than crashing.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
