### PR TITLE
Finish all frames in case there are no solutions to multisol query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output in case of failure
 - Simple test cases for the CLI
 - Allow limiting the branch depth and width limitation via --max-depth and --max-width
+- When there are zero solutions to a multi-solution query it means that the
+  currently executed branch is in fact impossible. In these cases, unwind all
+  frames and return a Revert with empty returndata.
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value


### PR DESCRIPTION
## Description
If there is no solution to a multi-solution query, then we are in an execution path that is in fact impossible. Let's terminate it by unwinding all frames, and returning a revert with empty calldata. It's basically a nonsensical place to be. Currently, we just revert one frame, which will continue execution on lower frames, incorrectly. Of course the dispatched queries would all be UNSAT anyway -- however, in the meanwhile, we might even encounter issues with symbolic execution, and we will generate queries that we already know are UNSAT.

Will close #657 

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
