### PR TITLE
More robust printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The length of the buffer is now properly taken into account.
 - It was possible to enter an infinite recursion when trying to shrink a buffer found by
   the SMT solver. We now properly detect that it is not possible to shrink the buffer.
+- Pretty printing of buffers is now more robust. Instead of throwing an `internal error`,
+  we now try best to print everything we can, and print an appropriate error message
+  instead of crashing.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that


### PR DESCRIPTION
## Description
We no longer `internalError` in case the buffer is too large and cannot be printed. Instead, we handle it as gracefully as possible.


I have now added a test case that exercises this new capability.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
