### PR TITLE
Add test case for robust printing

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -4357,20 +4357,28 @@ tests = testGroup "hevm"
   ]
   , testGroup "calling-solvers"
   [ test "no-error-on-large-buf" $ do
-      -- This test generates a very large buffer that previously would cause an internalError when
+      -- These two tests generates a very large buffer that previously would cause an internalError when
       -- printed via "formatCex". We should be able to print it now.
-      Just c <- solcRuntime "MyContract"
-          [i|
+      Just c <- solcRuntime "MyContract" [i|
           contract MyContract {
             function fun(bytes calldata a) external pure {
               if (a.length > 0x800000000000) {
                 assert(false);
               }
             }
-           }
-          |]
+           } |]
       (_, [Cex cex]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
       putStrLnM $ "Cex found:" <> T.unpack (formatCex (AbstractBuf "txdata") Nothing (snd cex))
+    , test "no-error-on-large-buf-pure-print" $ do
+      let bufs = Map.singleton (AbstractBuf "txdata")
+                  (EVM.Types.Comp Write {byte = 1, idx = 0x27, next = Base {byte = 0x66, length = 0xffff000000000000000}})
+      let mycex = SMTCex {vars = mempty
+                         , addrs = mempty
+                         , buffers = bufs
+                         , store = mempty
+                         , blockContext = mempty
+                         , txContext = Map.fromList [(TxValue,0x0)]}
+      putStrLnM $ "Cex found:" <> T.unpack (formatCex (AbstractBuf "txdata") Nothing mycex)
     , testCase "correct-model-for-empty-buffer" $ runEnv (testEnv {config = testEnv.config {numCexFuzz = 0}}) $ do
       withDefaultSolver $ \s -> do
         let props = [(PEq (BufLength (AbstractBuf "b")) (Lit 0x0))]


### PR DESCRIPTION
## Description
Sorry, forgot to add this test case to the robust printing PR. It simply checks that we don't `error` out due to a large buffer.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
