### PR TITLE
Cleanup code, use a struct for loop detection configuration

### DIFF
--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -92,10 +92,7 @@ runBCTest x =
 findPanics :: App m => Solver -> Natural -> Integer -> ByteString -> m ()
 findPanics solver count iters c = do
   _ <- withSolvers solver count 1 Nothing $ \s -> do
-    let opts = defaultVeriOpts
-          { maxIter = Just iters
-          , askSmtIters = iters + 1
-          }
+    let opts = defaultVeriOpts { iterConf = defaultIterConf {maxIter = Just iters, askSmtIters = iters + 1 }}
     checkAssert s allPanicCodes c Nothing [] opts
   liftIO $ putStrLn "done"
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -387,9 +387,11 @@ equivalence eqOpts cOpts = do
     putStrLn "Error: invalid or no bytecode for program B. Provide a valid one with --code-b or --code-b-file"
     exitFailure
   let veriOpts = VeriOpts { simp = True
-                          , maxIter = parseMaxIters cOpts.maxIterations
-                          , askSmtIters = cOpts.askSmtIterations
-                          , loopHeuristic = cOpts.loopDetectionHeuristic
+                          , iterConf = IterConfig {
+                            maxIter = parseMaxIters cOpts.maxIterations
+                            , askSmtIters = cOpts.askSmtIterations
+                            , loopHeuristic = cOpts.loopDetectionHeuristic
+                            }
                           , rpcInfo = Nothing
                           }
   calldata <- buildCalldata cOpts eqOpts.sig eqOpts.arg
@@ -493,9 +495,11 @@ assert cFileOpts sOpts cExecOpts cOpts = do
   solver <- liftIO $ getSolver cOpts.solver
   withSolvers solver solverCount cOpts.solverThreads (Just cOpts.smttimeout) $ \solvers -> do
     let veriOpts = VeriOpts { simp = True
-                        , maxIter = parseMaxIters cOpts.maxIterations
-                        , askSmtIters = cOpts.askSmtIterations
-                        , loopHeuristic = cOpts.loopDetectionHeuristic
+                        , iterConf = IterConfig {
+                          maxIter = parseMaxIters cOpts.maxIterations
+                          , askSmtIters = cOpts.askSmtIterations
+                          , loopHeuristic = cOpts.loopDetectionHeuristic
+                          }
                         , rpcInfo = rpcinfo
     }
     (expr, res) <- verify solvers veriOpts preState (Just $ checkAssertions errCodes)

--- a/src/EVM/Stepper.hs
+++ b/src/EVM/Stepper.hs
@@ -35,21 +35,16 @@ import EVM.Types
 
 -- | The instruction type of the operational monad
 data Action t s a where
-
   -- | Keep executing until an intermediate result is reached
   Exec :: Action t s (VMResult t s)
-
-  -- | Wait for a query to be resolved
-  Wait :: Query t s -> Action t s ()
-
-  -- | Two things can happen
-  Fork :: RunBoth s -> Action Symbolic s ()
-
-  -- | Many (>2) things can happen
-  ForkMany :: RunAll s -> Action Symbolic s ()
-
   -- | Embed a VM state transformation
   EVM  :: EVM t s a -> Action t s a
+  -- | Wait for a query to be resolved
+  Wait :: Query t s -> Action t s ()
+  -- | Two things can happen
+  Fork :: RunBoth s -> Action Symbolic s ()
+  -- | Many (>2) things can happen
+  ForkMany :: RunAll s -> Action Symbolic s ()
 
 -- | Type alias for an operational monad of @Action@
 type Stepper t s a = Program (Action t s) a

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -76,11 +76,23 @@ groupPartials e = map (\g -> (into (length g), NE.head g)) grouped
     getPartial _ = Nothing
     grouped = NE.group $ sort $ mapMaybe getPartial e
 
-data VeriOpts = VeriOpts
-  { simp :: Bool
-  , maxIter :: Maybe Integer
+data IterConfig = IterConfig
+  { maxIter :: Maybe Integer
   , askSmtIters :: Integer
   , loopHeuristic :: LoopHeuristic
+  }
+  deriving (Eq, Show)
+
+defaultIterConf :: IterConfig
+defaultIterConf = IterConfig
+  { maxIter = Nothing
+  , askSmtIters = 1
+  , loopHeuristic = StackBased
+  }
+
+data VeriOpts = VeriOpts
+  { simp :: Bool
+  , iterConf :: IterConfig
   , rpcInfo :: Fetch.RpcInfo
   }
   deriving (Eq, Show)
@@ -88,9 +100,7 @@ data VeriOpts = VeriOpts
 defaultVeriOpts :: VeriOpts
 defaultVeriOpts = VeriOpts
   { simp = True
-  , maxIter = Nothing
-  , askSmtIters = 1
-  , loopHeuristic = StackBased
+  , iterConf = defaultIterConf
   , rpcInfo = Nothing
   }
 
@@ -311,13 +321,11 @@ freezeVM vm = do
 interpret
   :: forall m . App m
   => Fetch.Fetcher Symbolic m RealWorld
-  -> Maybe Integer -- max iterations
-  -> Integer -- ask smt iterations
-  -> LoopHeuristic
+  -> IterConfig
   -> VM Symbolic RealWorld
   -> Stepper Symbolic RealWorld (Expr End)
   -> m (Expr End)
-interpret fetcher maxIter askSmtIters heuristic vm =
+interpret fetcher iterConf vm =
   eval . Operational.view
   where
   eval :: Operational.ProgramView (Stepper.Action Symbolic RealWorld) (Expr End) -> m (Expr End)
@@ -327,10 +335,10 @@ interpret fetcher maxIter askSmtIters heuristic vm =
       Stepper.Exec -> do
         conf <- readConfig
         (r, vm') <- liftIO $ stToIO $ runStateT (exec conf) vm
-        interpret fetcher maxIter askSmtIters heuristic vm' (k r)
+        interpret fetcher iterConf vm' (k r)
       Stepper.EVM m -> do
         (r, vm') <- liftIO $ stToIO $ runStateT m vm
-        interpret fetcher maxIter askSmtIters heuristic vm' (k r)
+        interpret fetcher iterConf vm' (k r)
       Stepper.ForkMany (PleaseRunAll expr vals continue) -> do
         when (length vals < 2) $ internalError "PleaseRunAll requires at least 2 branches"
         frozen <- liftIO $ stToIO $ freezeVM vm
@@ -345,23 +353,23 @@ interpret fetcher maxIter askSmtIters heuristic vm =
           runOne :: App m => VM 'Symbolic RealWorld -> Int -> W256 -> m (Expr 'End)
           runOne frozen newDepth v = do
             (ra, vma) <- liftIO $ stToIO $ runStateT (continue v) frozen { result = Nothing, exploreDepth = newDepth }
-            interpret fetcher maxIter askSmtIters heuristic vma (k ra)
+            interpret fetcher iterConf vma (k ra)
       Stepper.Fork (PleaseRunBoth cond continue) -> do
         frozen <- liftIO $ stToIO $ freezeVM vm
         let newDepth = vm.exploreDepth+1
         evalLeft <- toIO $ do
           (ra, vma) <- liftIO $ stToIO $ runStateT (continue True) frozen { result = Nothing, exploreDepth = newDepth }
-          interpret fetcher maxIter askSmtIters heuristic vma (k ra)
+          interpret fetcher iterConf vma (k ra)
         evalRight <- toIO $ do
           (rb, vmb) <- liftIO $ stToIO $ runStateT (continue False) frozen { result = Nothing, exploreDepth = newDepth }
-          interpret fetcher maxIter askSmtIters heuristic vmb (k rb)
+          interpret fetcher iterConf vmb (k rb)
         (a, b) <- liftIO $ concurrently evalLeft evalRight
         pure $ ITE cond a b
       Stepper.Wait q -> do
         let performQuery = do
               m <- fetcher q
               (r, vm') <- liftIO$ stToIO $ runStateT m vm
-              interpret fetcher maxIter askSmtIters heuristic vm' (k r)
+              interpret fetcher iterConf vm' (k r)
 
         case q of
           PleaseAskSMT cond preconds continue -> do
@@ -372,25 +380,25 @@ interpret fetcher maxIter askSmtIters heuristic vm =
               -- is the condition concrete?
               Lit c ->
                 -- have we reached max iterations, are we inside a loop?
-                case (maxIterationsReached vm maxIter, isLoopHead heuristic vm) of
+                case (maxIterationsReached vm iterConf.maxIter, isLoopHead iterConf.loopHeuristic vm) of
                   -- Yes. return a partial leaf
                   (Just _, Just True) ->
                     pure $ Partial [] (TraceContext (Zipper.toForest vm.traces) vm.env.contracts vm.labels) $ MaxIterationsReached vm.state.pc vm.state.contract
                   -- No. keep executing
                   _ -> do
                     (r, vm') <- liftIO $ stToIO $ runStateT (continue (Case (c > 0))) vm
-                    interpret fetcher maxIter askSmtIters heuristic vm' (k r)
+                    interpret fetcher iterConf vm' (k r)
 
               -- the condition is symbolic
               _ ->
                 -- are in we a loop, have we hit maxIters, have we hit askSmtIters?
-                case (isLoopHead heuristic vm, askSmtItersReached vm askSmtIters, maxIterationsReached vm maxIter) of
+                case (isLoopHead iterConf.loopHeuristic vm, askSmtItersReached vm iterConf.askSmtIters, maxIterationsReached vm iterConf.maxIter) of
                   -- we're in a loop and maxIters has been reached
                   (Just True, _, Just n) -> do
                     -- continue execution down the opposite branch than the one that
                     -- got us to this point and return a partial leaf for the other side
                     (r, vm') <- liftIO $ stToIO $ runStateT (continue (Case $ not n)) vm
-                    a <- interpret fetcher maxIter askSmtIters heuristic vm' (k r)
+                    a <- interpret fetcher iterConf vm' (k r)
                     pure $ ITE cond a (Partial [] (TraceContext (Zipper.toForest vm.traces) vm.env.contracts vm.labels) (MaxIterationsReached vm.state.pc vm.state.contract))
                   -- we're in a loop and askSmtIters has been reached
                   (Just True, True, _) ->
@@ -402,7 +410,7 @@ interpret fetcher maxIter askSmtIters heuristic vm =
                       [PBool False] -> liftIO $ stToIO $ runStateT (continue (Case False)) vm
                       -- otherwise we explore both branches
                       _ -> liftIO $ stToIO $ runStateT (continue UnknownBranch) vm
-                    interpret fetcher maxIter askSmtIters heuristic vm' (k r)
+                    interpret fetcher iterConf vm' (k r)
           _ -> performQuery
 
 maxIterationsReached :: VM Symbolic s -> Maybe Integer -> Maybe Bool
@@ -465,7 +473,7 @@ getExprEmptyStore
 getExprEmptyStore solvers c signature' concreteArgs opts = do
   calldata <- mkCalldata signature' concreteArgs
   preState <- liftIO $ stToIO $ loadEmptySymVM (RuntimeCode (ConcreteRuntimeCode c)) (Lit 0) calldata
-  exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.maxIter opts.askSmtIters opts.loopHeuristic preState runExpr
+  exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.iterConf preState runExpr
   if opts.simp then (pure $ Expr.simplify exprInter) else pure exprInter
 
 getExpr
@@ -479,7 +487,7 @@ getExpr
 getExpr solvers c signature' concreteArgs opts = do
       calldata <- mkCalldata signature' concreteArgs
       preState <- liftIO $ stToIO $ abstractVM calldata c Nothing False
-      exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.maxIter opts.askSmtIters opts.loopHeuristic preState runExpr
+      exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.iterConf preState runExpr
       if opts.simp then (pure $ Expr.simplify exprInter) else pure exprInter
 
 {- | Checks if an assertion violation has been encountered
@@ -666,7 +674,7 @@ verify solvers opts preState maybepost = do
   let call = mconcat ["prefix 0x", getCallPrefix preState.state.calldata]
   when conf.debug $ liftIO $ putStrLn $ "   Exploring call " <> call
 
-  exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.maxIter opts.askSmtIters opts.loopHeuristic preState runExpr
+  exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.iterConf preState runExpr
   when conf.dumpExprs $ liftIO $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
   liftIO $ do
     when conf.debug $ putStrLn "   Simplifying expression"
@@ -784,7 +792,7 @@ equivalenceCheck solvers bytecodeA bytecodeB opts calldata create = do
     getBranches bs = do
       let bytecode = if BS.null bs then BS.pack [0] else bs
       prestate <- liftIO $ stToIO $ abstractVM calldata bytecode Nothing create
-      expr <- interpret (Fetch.oracle solvers Nothing) opts.maxIter opts.askSmtIters opts.loopHeuristic prestate runExpr
+      expr <- interpret (Fetch.oracle solvers Nothing) opts.iterConf prestate runExpr
       let simpl = if opts.simp then (Expr.simplify expr) else expr
       pure $ flattenExpr simpl
     oneQedOrNoQed :: EqIssues -> EqIssues

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -13,7 +13,7 @@ import EVM.FeeSchedule (feeSchedule)
 import EVM.Fetch qualified as Fetch
 import EVM.Format
 import EVM.Solidity
-import EVM.SymExec (defaultVeriOpts, symCalldata, verify, extractCex, prettyCalldata, panicMsg, VeriOpts(..), flattenExpr, groupIssues, groupPartials)
+import EVM.SymExec (defaultVeriOpts, symCalldata, verify, extractCex, prettyCalldata, panicMsg, VeriOpts(..), flattenExpr, groupIssues, groupPartials, IterConfig(..), defaultIterConf)
 import EVM.Types
 import EVM.Transaction (initTx)
 import EVM.Stepper (Stepper)
@@ -104,8 +104,7 @@ writeTrace vm = do
 -- | Generate VeriOpts from UnitTestOptions
 makeVeriOpts :: UnitTestOptions s -> VeriOpts
 makeVeriOpts opts =
-   defaultVeriOpts { maxIter = opts.maxIter
-                   , askSmtIters = opts.askSmtIters
+   defaultVeriOpts { iterConf = defaultIterConf {maxIter = opts.maxIter, askSmtIters = opts.askSmtIters }
                    , rpcInfo = opts.rpcInfo
                    }
 

--- a/test/EVM/Test/Tracing.hs
+++ b/test/EVM/Test/Tracing.hs
@@ -248,7 +248,7 @@ data EVMToolAlloc =
 instance JSON.ToJSON EVMToolAlloc where
   toJSON b = JSON.object [ ("balance" , (JSON.toJSON $ show b.balance))
                          , ("code", (JSON.toJSON $ ByteStringS b.code))
-                         , ("nonce", (JSON.toJSON $ b.nonce))
+                         , ("nonce", (JSON.toJSON b.nonce))
                          ]
 
 emptyEVMToolAlloc :: EVMToolAlloc
@@ -432,7 +432,8 @@ runCodeWithTrace
 runCodeWithTrace rpcinfo evmEnv alloc txn fromAddr toAddress = withSolvers Z3 0 1 Nothing $ \solvers -> do
   let calldata' = ConcreteBuf txn.txdata
       code' = alloc.code
-      buildExpr s vm = interpret (Fetch.oracle s Nothing) Nothing 1 Naive vm runExpr
+      iterConf = IterConfig { maxIter = Nothing, askSmtIters = 1, loopHeuristic = Naive }
+      buildExpr s vm = interpret (Fetch.oracle s Nothing) iterConf vm runExpr
   origVM <- liftIO $ stToIO $ vmForRuntimeCode code' calldata' evmEnv alloc txn fromAddr toAddress
 
   expr <- buildExpr solvers $ symbolify origVM


### PR DESCRIPTION
This likely seems minor but I find it so much easier to order these in the right way and not leave empty lines when not necessary. Also, passing around a struct is so much more safe than passing around `Integer`-s, because the order of the integers can be messed up. I find the code easier to read this way.

## Description

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
