### PR TITLE
Replace actions from DeterminateSystems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+      - name: Nix cache
+        id: cache
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-build-${{ matrix.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          purge: true
+          purge-prefixes: nix-build-${{ matrix.os }}-
+          purge-created: 0
+          purge-primary-key: never
+          gc-max-store-size: 1G
       - name: build hevm
         run: nix build .#ci -L
       - name: Upload artifacts
@@ -53,8 +63,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+      - name: Nix cache
+        id: cache
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-tests-${{ matrix.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          purge: true
+          purge-prefixes: nix-tests-${{ matrix.os }}-
+          purge-created: 0
+          purge-primary-key: never
+          gc-max-store-size: 1G
       # cabal complains if we don't do this...
       - name: cabal update
         run: nix develop --command bash -c "cabal update"
@@ -253,7 +273,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
+      - name: Nix cache
+        id: cache
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-cabal-check-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          purge: true
+          purge-prefixes: nix-cabal-check-
+          purge-created: 0
+          purge-primary-key: never
+          gc-max-store-size: 1G
       - name: run cabal check
         run: nix develop -c cabal check --verbose=3

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30
       - name: lookup nix versions
         id: nixpkgs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30      
       - name: build hevm
         run: |
           nix build .#redistributable --out-link hevm
@@ -44,8 +44,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v30      
       - name: download binaries
         uses: actions/download-artifact@v4
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -171,7 +171,7 @@
 
         # --- packages ----
 
-        packages.ci = pkgs.lib.pipe (hevmBase (if pkgs.stdenv.isLinux then pkgs.pkgsStatic else pkgs)) (with hlib.compose; [doBenchmark dontHaddock disableLibraryProfiling]);
+        packages.ci = pkgs.lib.pipe (hevmBase pkgs) (with hlib.compose; [doBenchmark dontHaddock disableLibraryProfiling]);
         packages.unwrapped = hlib.dontCheck (hevmBase pkgs);
         packages.hevm = hevmWrapped;
         packages.redistributable = hevmRedistributable;


### PR DESCRIPTION
## Description

This aims to replace the GitHub actions from DeterminateSystems since their Magic Nix Cache action is discontinued.
I believe we can use `cache-nix-action` which simply wraps the `cache` GitHub action and does not store the cache anywhere outside of GitHub.
The proposed action requires a bit of manual configuration but not too much.

Moreover, I believe we only need the cache for CI build (`ci` package of `hevm`,  our `build.yaml` workflow).
The other workflows, `Check Dependencies` and `Release` do not need to use a cache at all.
Specifically, for releases, I think it is better not to use a cache and build the environment from scratch.

There is one more change prosed here: The static build for Linux takes a long time, because it is building the whole GHC from scratch. I believe we do not need to do this on CI, where we want to have relatively quick feedback.
The release workflow will still build static binary (this is the `redistributable` package, as opposed to the `ci` package in `flake.nix`.




## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
