### PR TITLE
Speed up running tests mostly by avoiding unnecessary work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,7 +259,7 @@ jobs:
 
       - name: run rpc tests
         run: |
-          export PATH="$FOUNDRY_PATH:$HASKELL_PATHS:$PATH"
+          export PATH="$BITWUZLA_PATH:$FOUNDRY_PATH:$HASKELL_PATHS:$PATH"
           cabal run rpc-tests
 
       - name: run ethereum tests

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -1565,9 +1565,11 @@ paddedShowHex w n = pad ++ str
      pad = replicate (w - length str) '0'
 
 untilFixpoint :: Eq a => (a -> a) -> a -> a
-untilFixpoint f a = if f a == a
-                    then a
-                    else untilFixpoint f (f a)
+untilFixpoint f a =
+  let a' = f a in
+    if a' == a
+    then a
+    else untilFixpoint f a'
 
 bsToHex :: ByteString -> String
 bsToHex bs = concatMap (paddedShowHex 2) (BS.unpack bs)

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -103,9 +103,4 @@ compile _ root src = do
     initLib tld srcFile dstFile = do
       createDirectoryIfMissing True (tld </> "src")
       writeFile (tld </> "src" </> dstFile) =<< readFile =<< Paths.getDataFileName srcFile
-      _ <- readProcessWithExitCode "git" ["init", tld] ""
-      callProcess "git" ["config", "--file", tld </> ".git" </> "config", "user.name", "'hevm'"]
-      callProcess "git" ["config", "--file", tld </> ".git" </> "config", "user.email", "'hevm@hevm.dev'"]
-      callProcessCwd "git" ["add", "."] tld
-      callProcessCwd "git" ["commit", "-m", "", "--allow-empty-message", "--no-gpg-sign"] tld
       pure ()

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -1,6 +1,7 @@
 module EVM.Test.Utils where
 
 import Data.Text (Text)
+import Data.List (isInfixOf)
 import GHC.IO.Exception (IOErrorType(..))
 import GHC.Natural
 import Paths_hevm qualified as Paths
@@ -90,7 +91,7 @@ compile _ root src = do
   (res,out,err) <- liftIO $ readProcessWithExitCode "forge" ["build", "--ast", "--root", root] ""
   case res of
     ExitFailure _ -> pure . Left $ "compilation failed: " <> "exit code: " <> show res <> "\n\nstdout:\n" <> out <> "\n\nstderr:\n" <> err
-    ExitSuccess -> readBuildOutput root Foundry
+    ExitSuccess -> readFilteredBuildOutput root (\path -> "unit-tests.t.sol" `Data.List.isInfixOf` path) Foundry
   where
     initStdForgeDir :: FilePath -> IO ()
     initStdForgeDir tld = do

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -37,7 +37,7 @@ runSolidityTestCustom testFile match timeout maxIter ffiAllowed rpcinfo projectT
         internalError $ "Error compiling test file " <> show testFile <> " in directory "
           <> show root <> " using project type " <> show projectType
       Right bo@(BuildOutput contracts _) -> do
-        withSolvers Z3 3 1 timeout $ \solvers -> do
+        withSolvers Bitwuzla 3 1 timeout $ \solvers -> do
           opts <- liftIO $ testOpts solvers root (Just bo) match maxIter ffiAllowed rpcinfo
           unitTest opts contracts
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -112,6 +112,9 @@ withDefaultSolver = withSolvers Z3 3 1 Nothing
 withCVC5Solver :: App m => (SolverGroup -> m a) -> m a
 withCVC5Solver = withSolvers CVC5 3 1 Nothing
 
+withBitwuzlaSolver :: App m => (SolverGroup -> m a) -> m a
+withBitwuzlaSolver = withSolvers Bitwuzla 3 1 Nothing
+
 main :: IO ()
 main = defaultMain tests
 
@@ -3867,7 +3870,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          (res, [Qed]) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "calldata beyond calldatasize is 0 (concrete dalldata prefix)" $ do
@@ -3884,7 +3887,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "calldata symbolic access" $ do
@@ -3905,7 +3908,7 @@ tests = testGroup "hevm"
               }
             }
             |]
-          (res, [Qed]) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
+          (res, [Qed]) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "f(uint256)" [AbiUIntType 256])) [] defaultVeriOpts
           putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         test "multiple-contracts" $ do


### PR DESCRIPTION
## Description

This PR proposes the following changes (in separate commits):
- When running solidity tests, do not parse all contracts from the foundry project, parse only the contract we actually are going to test.
- When running solidity tests, use Bitwuzla as the backend instead of Z3
- Remove unnecessary (and expensive) call to simplification in a commonly used helper
- Ensure we do not unnecessarily applied the same operation twice in one iteration of fixpoint computation (this has probably been optimized by the compiler anyway, but better to be sure).
- Remove unnecessary calls to `git` process

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
