### PR TITLE
Do not create duplicate assertions about concrete Keccak values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pretty printing of buffers is now more robust. Instead of throwing an `internal error`,
   we now try best to print everything we can, and print an appropriate error message
   instead of crashing.
+- We no longer produce duplicate SMT assertions regarding concrete keccak values.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that


### PR DESCRIPTION
## Description
Previously we were collecting all equalities of concrete Keccak values into lists. This meant that if an expression (Keccak (ConcreteBuf _)) was present multiple times in the given props, we would add the same assertion multiple times (once per every occurence).

Now we collect the equalities into a set, so no duplicates should occur here anymore.

Fixes #728.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
