### PR TITLE
Use `Storable` vectors for memory

### DIFF
--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -30,7 +30,8 @@ import Data.Text.IO qualified as T
 import Data.Tree.Zipper qualified as Zipper
 import Data.Tuple (swap)
 import Data.Vector qualified as V
-import Data.Vector.Unboxed qualified as VUnboxed
+import Data.Vector.Storable qualified as VS
+import Data.Vector.Storable.ByteString (vectorToByteString)
 import EVM (makeVm, abstractContract, initialContract, getCodeLocation, isValidJumpDest)
 import EVM.Exec
 import EVM.Fetch qualified as Fetch
@@ -313,7 +314,7 @@ freezeVM vm = do
       }
   where
     freeze = \case
-      ConcreteMemory m -> SymbolicMemory . ConcreteBuf . BS.pack . VUnboxed.toList <$> VUnboxed.freeze m
+      ConcreteMemory m -> SymbolicMemory . ConcreteBuf . vectorToByteString <$> VS.freeze m
       m@(SymbolicMemory _) -> pure m
 
 -- | Interpreter which explores all paths at branching points. Returns an

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -48,8 +48,8 @@ import Data.Text.Encoding qualified as T
 import Data.Tree (Forest)
 import Data.Tree.Zipper qualified as Zipper
 import Data.Vector qualified as V
-import Data.Vector.Storable qualified as SV
-import Data.Vector.Unboxed.Mutable (STVector)
+import Data.Vector.Storable qualified as VS
+import Data.Vector.Storable.Mutable (STVector)
 import Numeric (readHex, showHex)
 import Options.Generic
 import Optics.TH
@@ -842,7 +842,7 @@ data Contract = Contract
   , balance     :: Expr EWord
   , nonce       :: Maybe W64
   , codehash    :: Expr EWord
-  , opIxMap     :: SV.Vector Int
+  , opIxMap     :: VS.Vector Int
   , codeOps     :: V.Vector (Int, Op)
   , external    :: Bool
   }


### PR DESCRIPTION
## Description

This removes the `Unboxed` usage and replaces it with `Storable`, which allows for neat tricks such as `vectorToByteString`


## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
