### PR TITLE
Move unsat cache to `Solvers.hs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More complete simplification during interpretation
 - SMT-based resolving of addresses now works for delegatecall and staticcall
   opcodes as well
+- UNSAT cache is now in `Solvers.hs` and is therefore shared across all threads.
+  Hence, it is now active even during branch queries.
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value


### PR DESCRIPTION
## Description
This moves the UNSAT cache to a central location, in `Solvers.hs`. This means that UNSAT cache is filled and used even during interpretation. Also, one can simply use `checkSatWithProps` and the UNSAT cache will be there and working.

This also means that the unsat cache is now available to every place that calls `checkSatWithProps`, which also includes `PleaseAskSMT`, i.e. it will now work also when deciding on branches.

We now have a queue for the cache, and it is taken as priority before picking up any new task.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
