### PR TITLE
Allow changing prefix from prove via `--prefix` in `test` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   currently executed branch is in fact impossible. In these cases, unwind all
   frames and return a Revert with empty returndata.
 - More rewrite rules for PEq, PNeg, missing eqByte call, and distributivity for And
+- Allow changing of the prefix from "prove" via --prefix in `test` mode
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value
@@ -105,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   increases which hurt concrete execution performance due to their linear cost.
 - The concrete MCOPY implementation has been optimized to avoid freezing the whole
   EVM memory.
+- We no longer accept `check` as a prefix for test cases by default.
 
 ## [0.54.2] - 2024-12-12
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -178,6 +178,7 @@ data TestOptions = TestOptions
   , number        ::Maybe W256
   , coverage      ::Bool
   , match         ::Maybe String
+  , prefix        ::String
   , ffi           ::Bool
   }
 
@@ -188,6 +189,7 @@ testOptions = TestOptions
   <*> (optional $ option auto $ long "number" <> help "Block: number")
   <*> (switch $ long "coverage" <> help "Coverage analysis")
   <*> (optional $ strOption $ long "match" <> help "Test case filter - only run methods matching regex")
+  <*> (strOption $ long "prefix"  <> showDefault <> value "prove" <> help "Prefix for test cases to prove")
   <*> (switch $ long "ffi" <> help "Allow the usage of the hevm.ffi() cheatcode (WARNING: this allows test authors to execute arbitrary code on your machine)")
 
 
@@ -257,7 +259,7 @@ commandParser :: Parser Command
 commandParser = subparser
   ( command "test"
       (info (Test <$> testOptions <*> commonOptions <**> helper)
-        (progDesc "Prove Foundry unit tests marked with `prove_`"
+        (progDesc "Prove Foundry unit tests prefixed with `prove` by default"
         <> footer "For more help: https://hevm.dev/std-test-tutorial.html" ))
   <> command "equivalence"
       (info (Equal <$> eqOptions <*> commonOptions <**> helper)
@@ -815,6 +817,7 @@ unitTestOptions testOpts cOpts solvers buildOutput = do
     , askSmtIters = cOpts.askSmtIterations
     , smtTimeout = Just cOpts.smttimeout
     , match = T.pack $ fromMaybe ".*" testOpts.match
+    , prefix = T.pack testOpts.prefix
     , testParams = params
     , dapp = srcInfo
     , ffiAllowed = testOpts.ffi

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -51,6 +51,7 @@ data UnitTestOptions s = UnitTestOptions
   , askSmtIters :: Integer
   , smtTimeout  :: Maybe Natural
   , match       :: Text
+  , prefix      :: Text
   , dapp        :: DappInfo
   , testParams  :: TestVMParams
   , ffiAllowed  :: Bool
@@ -112,7 +113,7 @@ makeVeriOpts opts =
 -- | Returns tuple of (No Cex, No warnings)
 unitTest :: App m => UnitTestOptions RealWorld -> Contracts -> m (Bool, Bool)
 unitTest opts (Contracts cs) = do
-  let unitTestContrs = findUnitTests opts.match $ Map.elems cs
+  let unitTestContrs = findUnitTests opts.prefix opts.match $ Map.elems cs
   conf <- readConfig
   when conf.debug $ liftIO $ do
     putStrLn $ "Found " ++ show (length unitTestContrs) ++ " unit test contract(s) to test:"

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -60,6 +60,7 @@ testOpts solvers root buildOutput match maxIter allowFFI rpcinfo = do
     , askSmtIters = 1
     , smtTimeout = Nothing
     , match = match
+    , prefix = "prove"
     , testParams = params
     , dapp = srcInfo
     , ffiAllowed = allowFFI

--- a/test/contracts/fail/check-prefix.sol
+++ b/test/contracts/fail/check-prefix.sol
@@ -5,7 +5,7 @@ contract SolidityTest is Test {
     function setUp() public {
     }
 
-    function check_trivial() public {
+    function prove_trivial() public {
         assertTrue(false);
     }
 }

--- a/test/test.hs
+++ b/test/test.hs
@@ -1790,7 +1790,7 @@ tests = testGroup "hevm"
         runSolidityTest testFile ".*" >>= assertEqualM "test result" (True, True)
     , test "prefix-check-for-dapp" $ do
         let testFile = "test/contracts/fail/check-prefix.sol"
-        runSolidityTest testFile "check_trivial" >>= assertEqualM "test result" (False, False)
+        runSolidityTest testFile "prove_trivial" >>= assertEqualM "test result" (False, False)
     , test "transfer-dapp" $ do
         let testFile = "test/contracts/pass/transfer.sol"
         runSolidityTest testFile "prove_transfer" >>= assertEqualM "should prove transfer" (True, True)


### PR DESCRIPTION
## Description
Currently, default prefix is "prove" as per documentation. Actually, we also accept "check". This PR allows us to change this from "prove" to any other value. We also drop "check" as a prefix that's accepted. The "check" was never advertised, so I think it's valid to remove? It makes the code simpler, and I think it's OK this way, as `--prefix check` can always be used to be backwards-compatible. This change is highlighted in the changelog.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
