### PR TITLE
Fix implementation of Ord for Prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   we now try best to print everything we can, and print an appropriate error message
   instead of crashing.
 - We no longer produce duplicate SMT assertions regarding concrete keccak values.
+- Ord is now correctly implemented for Prop.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -485,37 +485,34 @@ instance Eq Prop where
   PImpl a b == PImpl c d = a == c && b == d
   _ == _ = False
 
--- Note: we cannot compare via `a <= c || b <= d` because then
---       when a==c but b > d, we'd return TRUE, when we should be
---       returning FALSE.
 instance Ord Prop where
-  PBool a <= PBool b = a <= b
-  PEq (a :: Expr x) (b :: Expr x) <= PEq (c :: Expr y) (d :: Expr y)
-    = case eqT @x @y of
-       Just Refl ->        a <= c || ((a == c) && (b <= d))
-       Nothing -> toNum a <= toNum c
-  PNeg a   <= PNeg b     = a <= b
-  PLT a b  <= PLT c d    = a <= c || (a == c && b <= d)
-  PGT a b  <= PGT c d    = a <= c || (a == c && b <= d)
-  PGEq a b <= PGEq c d   = a <= c || (a == c && b <= d)
-  PLEq a b <= PLEq c d   = a <= c || (a == c && b <= d)
-  PAnd a b <= PAnd c d   = a <= c || (a == c && b <= d)
-  POr a b  <= POr c d    = a <= c || (a == c && b <= d)
-  PImpl a b <= PImpl c d = a <= c || (a == c && b <= d)
-  a <= b = asNum a <= asNum b
-    where
-      asNum :: Prop -> Int
-      asNum (PBool {}) = 0
-      asNum (PEq   {}) = 1
-      asNum (PLT   {}) = 2
-      asNum (PGT   {}) = 3
-      asNum (PGEq  {}) = 4
-      asNum (PLEq  {}) = 5
-      asNum (PNeg  {}) = 6
-      asNum (PAnd  {}) = 7
-      asNum (POr   {}) = 8
-      asNum (PImpl {}) = 9
+  compare (PBool a) (PBool b) = compare a b
+  compare (PEq (a :: Expr x) (b :: Expr x)) (PEq (c :: Expr y) (d :: Expr y)) =
+    case eqT @x @y of
+      Just Refl -> compare (a, b) (c, d)
+      Nothing   -> compare (typeRep a) (typeRep c)
+  compare (PNeg a) (PNeg b) = compare a b
+  compare (PLT a1 b1) (PLT a2 b2) = compare (a1, b1) (a2, b2)
+  compare (PGT a1 b1) (PGT a2 b2) = compare (a1, b1) (a2, b2)
+  compare (PGEq a1 b1) (PGEq a2 b2) = compare (a1, b1) (a2, b2)
+  compare (PLEq a1 b1) (PLEq a2 b2) = compare (a1, b1) (a2, b2)
+  compare (PAnd a1 b1) (PAnd a2 b2) = compare (a1, b1) (a2, b2)
+  compare (POr a1 b1) (POr a2 b2) = compare (a1, b1) (a2, b2)
+  compare (PImpl a1 b1) (PImpl a2 b2) = compare (a1, b1) (a2, b2)
+  compare a b = compare (tag a) (tag b)
 
+    where
+      tag :: Prop -> Int
+      tag PBool{} = 0
+      tag PEq{}   = 1
+      tag PLT{}   = 2
+      tag PGT{}   = 3
+      tag PGEq{}  = 4
+      tag PLEq{}  = 5
+      tag PNeg{}  = 6
+      tag PAnd{}  = 7
+      tag POr{}   = 8
+      tag PImpl{} = 9
 
 
 isPBool :: Prop -> Bool

--- a/test/test.hs
+++ b/test/test.hs
@@ -4251,9 +4251,9 @@ tests = testGroup "hevm"
       (_, [Cex (_, ctr1)]) <- withCVC5Solver $ \s -> checkAssert s defaultPanicCodes c (Just sig) [] defaultVeriOpts
       putStrLnM  $ "expected counterexamples found: " <> show ctr1
   ]
-  , testGroup "simplification-working"
+  , testGroup "prop-and-expr-properties"
   [
-    test "nubOrd-Prop-working" $ do
+    test "nubOrd-Prop-PLT" $ do
         let a = [ PLT (Lit 0x0) (ReadWord (ReadWord (Lit 0x0) (AbstractBuf "txdata")) (AbstractBuf "txdata"))
                 , PLT (Lit 0x1) (ReadWord (ReadWord (Lit 0x0) (AbstractBuf "txdata")) (AbstractBuf "txdata"))
                 , PLT (Lit 0x2) (ReadWord (ReadWord (Lit 0x0) (AbstractBuf "txdata")) (AbstractBuf "txdata"))
@@ -4262,7 +4262,19 @@ tests = testGroup "hevm"
             simp2 = List.nub a
         assertEqualM "Must be 3-length" 3 (length simp)
         assertEqualM "Must be 3-length" 3 (length simp2)
-    , test "PEq-and-PNot-PEq-1" $ do
+    , test "nubOrd-Prop-PEq" $ do
+        let a = [ PEq (Lit 0x0) (ReadWord (Lit 0x0) (AbstractBuf "txdata"))
+                , PEq (Lit 0x0) (ReadWord (Lit 0x1) (AbstractBuf "txdata"))
+                , PEq (Lit 0x0) (ReadWord (Lit 0x2) (AbstractBuf "txdata"))
+                , PEq (Lit 0x0) (ReadWord (Lit 0x0) (AbstractBuf "txdata"))]
+        let simp = nubOrd a
+            simp2 = List.nub a
+        assertEqualM "Must be 3-length" 3 (length simp)
+        assertEqualM "Must be 3-length" 3 (length simp2)
+  ]
+  , testGroup "simplification-working"
+  [
+    test "PEq-and-PNot-PEq-1" $ do
       let a = [PEq (Lit 0x539) (Var "arg1"),PNeg (PEq (Lit 0x539) (Var "arg1"))]
       assertEqualM "Must simplify to PBool False" (Expr.simplifyProps a) ([PBool False])
     , test "PEq-and-PNot-PEq-2" $ do


### PR DESCRIPTION
## Description

Previously, the implementation of `<=` for Prop would not obey the antisymmetry law, I believe in the case of `PEq` specifically. This leads to weird behaviour, namely that duplicates are not properly recognized in Set.

The proposed change is to implement `compare` directly, which I think is easier than trying to fix `<=`.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
