### PR TITLE
More complete simplification of branching during interpretation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   currently executed branch is in fact impossible. In these cases, unwind all
   frames and return a Revert with empty returndata.
 - More rewrite rules for PEq, PNeg, missing eqByte call, and distributivity for And
+- More complete simplification during interpretation
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -373,9 +373,6 @@ interpret fetcher iterConf vm =
 
         case q of
           PleaseAskSMT cond preconds continue -> do
-            let
-              -- no concretiziation here, or we may lose information
-              simpProps = Expr.simplifyProps ((cond ./= Lit 0):preconds)
             case Expr.concKeccakSimpExpr cond of
               -- is the condition concrete?
               Lit c ->
@@ -405,10 +402,10 @@ interpret fetcher iterConf vm =
                     -- ask the smt solver about the loop condition
                     performQuery
                   _ -> do
+                    let simpProps = Expr.simplifyProps $ Expr.concKeccakProps ((cond ./= Lit 0):preconds)
                     (r, vm') <- case simpProps of
-                      -- if we can statically determine unsatisfiability then we skip exploring the jump
                       [PBool False] -> liftIO $ stToIO $ runStateT (continue (Case False)) vm
-                      -- otherwise we explore both branches
+                      [] -> liftIO $ stToIO $ runStateT (continue (Case True)) vm
                       _ -> liftIO $ stToIO $ runStateT (continue UnknownBranch) vm
                     interpret fetcher iterConf vm' (k r)
           _ -> performQuery


### PR DESCRIPTION
## Description
This is a minor change that allows us to do more simplification during interpretation. It also accounts for the case of pure SAT (not only UNSAT) in branching.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
