### PR TITLE
Filter out duplicate read assumptions

### DIFF
--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -307,7 +307,7 @@ findBufferAccess = foldl (foldTerm go) mempty
 -- to zero. Looks for buffer reads in the a list of given predicates
 -- and the buffer and storage environments.
 assertReads :: [Prop] -> BufEnv -> StoreEnv -> [Prop]
-assertReads props benv senv = concatMap assertRead allReads
+assertReads props benv senv = nubOrd $ concatMap assertRead allReads
   where
     assertRead :: (Expr EWord, Expr EWord, Expr Buf) -> [Prop]
     assertRead (_, Lit 0, _) = []

--- a/test/test.hs
+++ b/test/test.hs
@@ -4446,6 +4446,14 @@ tests = testGroup "hevm"
       let sexprs = splitSExpr texts
       let noDuplicates = ((length sexprs) == (Set.size (Set.fromList sexprs)))
       assertBoolM "There were duplicate lines in SMT encoding" noDuplicates
+    , test "no-duplicates-with-read-assumptions" $ do
+      let props = [(PGT (ReadWord (Lit 2) (AbstractBuf "test")) (Lit 0)), (PGT (Expr.padByte $ ReadByte (Lit 10) (AbstractBuf "test")) (Expr.padByte $ LitByte 1))]
+      conf <- readConfig
+      let SMT2 builders _ _ = fromRight (internalError "Must succeed") (assertProps conf props)
+      let texts = fmap toLazyText builders
+      let sexprs = splitSExpr texts
+      let noDuplicates = ((length sexprs) == (Set.size (Set.fromList sexprs)))
+      assertBoolM "There were duplicate lines in SMT encoding" noDuplicates
   ]
   , testGroup "equivalence-checking"
     [


### PR DESCRIPTION
## Description

When we collect assumptions about read access, we might collect duplicate assumptions when the same buffer is accessed at overlapping intervals.
We can filter out these duplicates before we send them to the SMT solver.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
