### PR TITLE
Use `forceAddr` in staticcall and delegatecall instead of `wordToAddr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More rewrite rules for PEq, PNeg, missing eqByte call, and distributivity for And
 - Allow changing of the prefix from "prove" via --prefix in `test` mode
 - More complete simplification during interpretation
+- SMT-based resolving of addresses now works for delegatecall and staticcall
+  opcodes as well
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/test/contracts/pass/no-overapprox-delegatecall.sol
+++ b/test/contracts/pass/no-overapprox-delegatecall.sol
@@ -1,0 +1,26 @@
+
+// This test overapproximates the delegatecall
+// if an SMT solver is not called to check that there is only one solution to the address masking
+import {Test} from "forge-std/Test.sol";
+
+contract ERC20 {
+  address any;
+  function f() public {
+    any = msg.sender;
+  }
+}
+
+contract TEST is Test{
+  address[] tokens;
+  address any = address(0x1234);
+  mapping(address => uint256) balances;
+
+  constructor() {
+    tokens.push(address(new ERC20()));
+  }
+
+  function prove_no_overapprox(address target) public {
+    balances[target] = any.balance;
+    address(tokens[0]).delegatecall(abi.encodeWithSignature("f()"));
+  }
+}

--- a/test/contracts/pass/no-overapprox-staticcall.sol
+++ b/test/contracts/pass/no-overapprox-staticcall.sol
@@ -1,0 +1,23 @@
+
+// This test overapproximates the staticcall (it's a "view" function, so it's a staticcall)
+// if an SMT solver is not called to check that there is only one solution to the address masking
+import {Test} from "forge-std/Test.sol";
+
+contract ERC20 {
+  function f() public view { }
+}
+
+contract TEST is Test{
+  address[] tokens;
+  address any = address(0x1234);
+  mapping(address => uint256) balances;
+
+  function setUp() public {
+    tokens.push(address(new ERC20()));
+  }
+
+  function prove_no_overapprox(address target) public {
+    balances[target] = any.balance;
+    ERC20(address(tokens[0])).f();
+  }
+}

--- a/test/test.hs
+++ b/test/test.hs
@@ -1765,6 +1765,8 @@ tests = testGroup "hevm"
         -- quick smokecheck to make sure that we can parse ForgeStdLib style build outputs
         let cases =
               [ ("test/contracts/pass/trivial.sol", ".*", (True, True))
+              , ("test/contracts/pass/no-overapprox-staticcall.sol", ".*", (True, True))
+              , ("test/contracts/pass/no-overapprox-delegatecall.sol", ".*", (True, True))
               , ("test/contracts/pass/dsProvePass.sol", "proveEasy", (True, True))
               , ("test/contracts/fail/trivial.sol", ".*", (False, False))
               , ("test/contracts/fail/dsProveFail.sol", "prove_add", (False, True))


### PR DESCRIPTION
## Description
Fixes #742 by using the symbolic address resolver to resolve the address to the right address, thereby avoiding overapproximation and hence a spurious counterexample.

I have now added specific tests for both changes. They each fail without the respective changes to OpDelegatecall/OpStaticcall.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
