### PR TITLE
Masking rewrite rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opcodes as well
 - UNSAT cache is now in `Solvers.hs` and is therefore shared across all threads.
   Hence, it is now active even during branch queries.
+- Rewrite rule to deal with some forms of argument packing by Solidity
+  via masking
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1094,6 +1094,10 @@ simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
       | x == 0 = b
       | otherwise = a
 
+    -- Masking as as per Solidity bit-packing of e.g. function parameters
+    go (And (Lit mask1) (Or (And (Lit mask2) _) x)) | (mask1 .&. mask2 == 0)
+         = And (Lit mask1) x
+
     -- address masking
     go (And (Lit 0xffffffffffffffffffffffffffffffffffffffff) a@(WAddr _)) = a
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -2471,6 +2471,29 @@ tests = testGroup "hevm"
       putStrLnM $ "successfully explored: " <> show (Expr.numBranches expr) <> " paths"
       assertBoolM "The expression is NOT error" $ not $ any isError ret
       assertBoolM "The expression is NOT partial" $ not $ Expr.containsNode isPartial expr
+    , test "no-overapprox-when-present" $ do
+      Just c <- solcRuntime "C" [i|
+        contract ERC20 {
+          function f() public {
+          }
+        }
+
+        contract C {
+          address token;
+
+          function no_overapp() public {
+            token = address(new ERC20());
+            token.delegatecall(abi.encodeWithSignature("f()"));
+          }
+        } |]
+      let sig2 = Just (Sig "no_overapp()" [])
+      (expr, ret) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig2 [] defaultVeriOpts
+      -- putStrLnM $ "expr: " <> show expr
+      putStrLnM $ "successfully explored: " <> show (Expr.numBranches expr) <> " paths"
+      assertBoolM "The expression is NOT error" $ not $ any isError ret
+      assertBoolM "The expression is NOT partial" $ not $ Expr.containsNode isPartial expr
+      let numCexes = sum $ map (fromEnum . isCex) ret
+      assertEqualM "number of counterexamples" 0 numCexes
     -- NOTE: below used to be symbolic copyslice copy error before new copyslice
     --       simplifications in Expr.simplify
     , test "overapproximates-undeployed-contract-symbolic" $ do
@@ -3953,8 +3976,7 @@ tests = testGroup "hevm"
                           _ -> False
           assertBoolM "Did not find expected storage cex" testCex
           putStrLnM "expected counterexample found"
-        ,
-        expectFail $ test "calling unique contracts (read from storage)" $ do
+        , test "calling-unique-contracts--read-from-storage" $ do
           Just c <- solcRuntime "C"
             [i|
               contract C {


### PR DESCRIPTION
## Description
When either the Array offset is low or 0, Maps and Arrays cannot clash. Furthermore, I added one more rewrite rule that allows us to deal with Solidity argument packing.

I added a test for the masking rewrite rule. It also happens to fix an issue we had in one of our tests, so that has been enabled as well (should have had `ignoreTest`, not `expectFail`, now it's enabled)

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
