### PR TITLE
Avoid fixpoint for literals and concrete storage

### DIFF
--- a/bench/bench-perf.hs
+++ b/bench/bench-perf.hs
@@ -121,6 +121,7 @@ main = do
                    , ("contractCreation", contractCreation, Nothing)
                    , ("contractCreationMem", contractCreationMem, Nothing)
                    , ("arrayCreationMem", arrayCreationMem, Just 9)
+                   , ("mapStorage", mapStorage, Nothing)
                    ]
   defaultMain =<< mapM f benchmarks
   
@@ -296,6 +297,23 @@ arrayCreationMem n = do
             function main() public {
               for (uint i = 0; i < ${n}; i++) {
                 C[] memory ret = work();
+              }
+            }
+          }
+        |]
+  fmap fromJust (runApp $ solcRuntime "A" src)
+
+-- Create large map in storage
+mapStorage :: Int -> IO ByteString
+mapStorage n = do
+  let src =
+        [i|
+          struct C { uint256 a; uint256 b; }
+          contract A {
+            mapping(uint256 => mapping(uint256 => C)) m;
+            function main() public {
+              for (uint i = 0; i < ${n}; i++) {
+                m[i][${n}-i] = C(i, ${n});
               }
             }
           }

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -965,6 +965,8 @@ simplify :: Expr a -> Expr a
 simplify e = untilFixpoint (simplifyNoLitToKeccak . litToKeccak) e
 
 simplifyNoLitToKeccak :: Expr a -> Expr a
+simplifyNoLitToKeccak l@(Lit _) = l
+simplifyNoLitToKeccak s@(ConcreteStore _) = s
 simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
   where
     go :: Expr a -> Expr a


### PR DESCRIPTION
## Description

This PR adds a fast case to `simplifyNoLitToKeccak` for `Lit`s and `ConcreteStorage` which don't need simplification, and was causing a performance regression versus hevm 0.54.2. Additionally, it adds a simple benchmark case to exercise SSTORE, used to show the improvement.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
