### PR TITLE
Allow signed integers to be in the expected range

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1633,6 +1633,8 @@ containsNode p = getAny . foldExpr go (Any False)
 inRange :: Int -> Expr EWord -> Prop
 inRange sz e = PAnd (PGEq e (Lit 0)) (PLEq e (Lit $ 2 ^ sz - 1))
 
+inRangeSigned :: Int -> Expr EWord -> Prop
+inRangeSigned sz e = PAnd (PLEq e (Lit $ 2 ^ (sz - 1) - 1)) (PLT e (Lit $ 2 ^ (sz - 1)))
 
 -- | images of keccak(bytes32(x)) where 0 <= x < 256
 preImages :: [(W256, Word8)]

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -124,7 +124,7 @@ symAbiArg name = \case
   AbiIntType n ->
     if n `mod` 8 == 0 && n <= 256
     -- TODO: is this correct?
-    then St [Expr.inRange n v] v
+    then St [Expr.inRangeSigned n v] v
     else internalError "bad type"
   AbiBoolType -> St [bool v] v
   AbiAddressType -> St [] (WAddr (SymAddr name))


### PR DESCRIPTION
## Description

The encoding of signed integers from the ABI was incorrect. Added a small function to provide the correct constraints. This PR will need a good number of tests, but you can start taking a look since the code changes is small.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
