### PR TITLE
[DRAFT] More rewrites for array/map clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   via masking
 - More rewrite rules for (PLT (Lit 0) _) and (PEq (Lit 1) _)
 - Simplification can now be turned off from the cli via --no-simplify
+- More rewrite rules for array and map lookups.
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value


### PR DESCRIPTION
## Description
More rewrites so we don't give up in case of map vs array in `readStorage`, but know that they cannot clash. Here is how we know they cannot clash:
* Maps and Arrays hash a different SIZE input: 64B vs 32B. Hence, you'd need a collision of Keccak for them to collide
* HOWEVER, when there is an offset, then the offset could  be set by the attacker to be keccak(a)-keccak(b). So when an offset is allowed, it must be limited. We limited the offset to 256 is other places:

```haskell
      -- Finding two Keccaks that are < 256 away from each other should be VERY hard
      -- This simplification allows us to deal with maps of structs
      (Add (Lit a2) (Keccak _), Add (Lit b2) (Keccak _)) | a2 /= b2, abs (a2-b2) < 256 -> go slot prev
      (Add (Lit a2) (Keccak _), (Keccak _)) | a2 > 0, a2 < 256 -> go slot prev
      ((Keccak _), Add (Lit b2) (Keccak _)) | b2 > 0, b2 < 256 -> go slot prev
```

so I'm limiting it here to the same offset. Which means it's impossible to find a collision that are within 256 of each other. This is accepted to be impossible. 

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
