### PR TITLE
RFC: Dump unsolved queries into a particular path

### DIFF
--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -35,6 +35,7 @@ data Config = Config
   { dumpQueries      :: Bool
   , dumpExprs        :: Bool
   , dumpEndStates    :: Bool
+  , dumpUnsolved     :: Maybe FilePath
   , debug            :: Bool
   , dumpTrace        :: Bool
   , numCexFuzz       :: Integer
@@ -56,6 +57,7 @@ defaultConfig = Config
   { dumpQueries = False
   , dumpExprs = False
   , dumpEndStates = False
+  , dumpUnsolved = Nothing
   , debug = False
   , dumpTrace = False
   , numCexFuzz = 10

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -206,6 +206,12 @@ getMultiSol smt2@(SMT2 cmds cexvars _) multiSol r inst availableInstances fileCo
            writeChan r Nothing
         "unknown" -> liftIO $ do
            when conf.debug $ putStrLn "Unknown result by SMT solver."
+           case conf.dumpUnsolved of
+             Just fp -> do
+              let filename = fp <> "unsolved-" <> show fileCounter <> "-sol" <> show (length vals)
+              liftIO $ putStrLn $ "Dumping unsolved SMT query to: " <> filename  
+              liftIO $ writeSMT2File fullSmt filename
+             Nothing -> pure ()
            writeChan r Nothing
         "sat" -> do
           if length vals >= multiSol.maxSols then liftIO $ do


### PR DESCRIPTION
## Description

A small change to dump unsolved queries into a particular directory (#725). The idea is to allow users to keep unsolved so they can use other solvers or longer timeouts. If they solve it and the result is SAT, they won´t be able to easily extract the counter example, but at least, they will be able to know that their invariants do not hold.
If you like the idea, I can change the other options to also dump into a particular folder instead in the current directory. This makes the integration with 3rd-party software much easier.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
