### PR TITLE
Fixing signed assert symbolic interpretation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - We no longer produce duplicate SMT assertions regarding concrete keccak values.
 - Ord is now correctly implemented for Prop.
 - Signed and unsigned integers have more refined ranges.
+- Symbolic interpretation of assertGe/Gt/Le/Lt over signed integers now works correctly.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1997,13 +1997,13 @@ cheatActions = Map.fromList
   , action "assertNotEq(string,string)"   $ assertNotEq (AbiStringType)
   --
   , action "assertLt(uint256,uint256)" $ assertLt (AbiUIntType 256)
-  , action "assertLt(int256,int256)"   $ assertLt (AbiIntType 256)
+  , action "assertLt(int256,int256)"   $ assertSLt (AbiIntType 256)
   , action "assertLe(uint256,uint256)" $ assertLe (AbiUIntType 256)
-  , action "assertLe(int256,int256)"   $ assertLe (AbiIntType 256)
+  , action "assertLe(int256,int256)"   $ assertSLe (AbiIntType 256)
   , action "assertGt(uint256,uint256)" $ assertGt (AbiUIntType 256)
-  , action "assertGt(int256,int256)"   $ assertGt (AbiIntType 256)
+  , action "assertGt(int256,int256)"   $ assertSGt (AbiIntType 256)
   , action "assertGe(uint256,uint256)" $ assertGe (AbiUIntType 256)
-  , action "assertGe(int256,int256)"   $ assertGe (AbiIntType 256)
+  , action "assertGe(int256,int256)"   $ assertSGe (AbiIntType 256)
   ]
   where
     action s f = (abiKeccak s, f (abiKeccak s))
@@ -2058,12 +2058,16 @@ cheatActions = Map.fromList
             False -> doStop
             True -> revertErr ew1 ew2 invComp
         abivals -> vmError (BadCheatCode (paramDecodeErr abitype name abivals) sig)
-    assertEq = genAssert (==) Expr.eq "!=" "assertEq"
+    assertEq =    genAssert (==) Expr.eq "!=" "assertEq"
     assertNotEq = genAssert (/=) (\a b -> Expr.iszero $ Expr.eq a b) "==" "assertNotEq"
-    assertLt = genAssert (<) Expr.lt ">=" "assertLt"
-    assertGt = genAssert (>) Expr.gt "<=" "assertGt"
-    assertLe = genAssert (<=) Expr.leq ">" "assertLe"
-    assertGe = genAssert (>=) Expr.geq "<" "assertGe"
+    assertLt =    genAssert (<)  Expr.lt ">=" "assertLt"
+    assertSLt =   genAssert (<)  Expr.slt ">=" "assertLt"
+    assertGt =    genAssert (>)  Expr.gt "<=" "assertGt"
+    assertSGt =   genAssert (>)  Expr.sgt "<=" "assertGt"
+    assertLe =    genAssert (<=) Expr.leq ">" "assertLe"
+    assertSLe =   genAssert (<=) (\a b -> Expr.iszero $ Expr.sgt a b) ">" "assertLe"
+    assertGe =    genAssert (>=) Expr.geq "<" "assertGe"
+    assertSGe =   genAssert (>=) (\a b -> Expr.iszero $ Expr.slt a b) "<" "assertGe"
 
 -- * General call implementation ("delegateCall")
 -- note that the continuation is ignored in the precompile case

--- a/test/test.hs
+++ b/test/test.hs
@@ -1147,8 +1147,7 @@ tests = testGroup "hevm"
         assertEqualM "number of counterexamples" 1 numCexes
         assertEqualM "number of errors" 0 numErrs
         assertEqualM "number of qed-s" 0 numQeds
-    -- BUG: currently failing, but test above, with a simple assert works
-    , ignoreTest $ test "negative-numbers-zero-comp" $ do
+    , test "negative-numbers-zero-comp" $ do
         Just c <- solcRuntime "C" [i|
             contract C {
               function fun(int256 x) public {


### PR DESCRIPTION
## Description
We accidentally used LT/GT/LEq/GEq for signed asserts, too, when symbolically interpreting.  Ooops. This has now been fixed. This fixes #767 and allows us to remove an `ignoreTest` from our test.hs, which previously failed due to this bug.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog