### PR TITLE
More Prop rewrite rules for PLT and PEq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Hence, it is now active even during branch queries.
 - Rewrite rule to deal with some forms of argument packing by Solidity
   via masking
+- More rewrite rules for (PLT (Lit 0) _) and (PEq (Lit 1) _)
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1329,6 +1329,14 @@ simplifyProp prop =
     go (PLT (Max (Lit a) b) (Lit c)) | a < c = PLT b (Lit c)
     go (PLT (Lit 0) (Eq a b)) = peq a b
 
+    -- when it's PLT but comparison on the RHS then it's just (PEq 1 RHS)
+    go (PLT (Lit 0) (a@LT {})) = peq (Lit 1) a
+    go (PLT (Lit 0) (a@LEq {})) = peq (Lit 1) a
+    go (PLT (Lit 0) (a@SLT {})) = peq (Lit 1) a
+    go (PLT (Lit 0) (a@GT {})) = peq (Lit 1) a
+    go (PLT (Lit 0) (a@GEq {})) = peq (Lit 1) a
+    go (PLT (Lit 0) (a@SGT {})) = peq (Lit 1) a
+
     -- negations
     go (PNeg (PBool b)) = PBool (Prelude.not b)
     go (PNeg (PNeg a)) = a
@@ -1385,8 +1393,6 @@ simplifyProp prop =
     go (PImpl (PBool False) _) = PBool True
 
     -- Double negation (no need for GT/GEq, as it's rewritten to LT/LEq)
-    go (PLT (Lit 0) (LT a b)) = PLT a b
-    go (PLT (Lit 0) (LEq a b)) = PLEq a b
 
     -- Eq
     go (PEq (Lit 0) (Eq a b)) = PNeg (peq a b)
@@ -1394,6 +1400,10 @@ simplifyProp prop =
     go (PEq (Lit 0) (Sub a b)) = peq a b
     go (PEq (Lit 0) (LT a b)) = PLEq b a
     go (PEq (Lit 0) (LEq a b)) = PLT b a
+    go (PEq (Lit 1) (LT a b)) = PLT a b
+    go (PEq (Lit 1) (LEq a b)) = PLEq a b
+    go (PEq (Lit 1) (GT a b)) = PGT a b
+    go (PEq (Lit 1) (GEq a b)) = PGEq a b
     go (PEq l r) = peq l r
 
     go p = p


### PR DESCRIPTION
## Description
These rewrite rules allow us to rewrite things like `(PLT (Lit 0) (LT a b))` into `(PLT a b)`, in two steps. It's a lot cleaner and more complete than the previous setup we had.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
