### PR TITLE
SignExtend rewrites + Allow turning off simplification from the CLI + fix property-based tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewrite rule to deal with some forms of argument packing by Solidity
   via masking
 - More rewrite rules for (PLT (Lit 0) _) and (PEq (Lit 1) _)
+- Simplification can now be turned off from the cli via --no-simplify
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value
@@ -92,6 +93,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ord is now correctly implemented for Prop.
 - Signed and unsigned integers have more refined ranges.
 - Symbolic interpretation of assertGe/Gt/Le/Lt over signed integers now works correctly.
+- SignExtend is now correctly being constant-folded
+- Some of our property-based testing was ineffective because of inadvertent
+  simplification  happening before calling the SMT solver. This has now been fixed.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -48,6 +48,7 @@ data Config = Config
   , maxWidth         :: Int
   , maxDepth         :: Maybe Int
   , verb             :: Int
+  , simp             :: Bool
   }
   deriving (Show, Eq)
 
@@ -66,6 +67,7 @@ defaultConfig = Config
   , maxWidth = 100
   , maxDepth = Nothing
   , verb = 0
+  , simp = True
   }
 
 -- Write to the console

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1071,6 +1071,8 @@ simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
     go (EVM.Types.LEq a b) = iszero (lt b a)
     go (SLT a@(Lit _) b@(Lit _)) = slt a b
     go (SGT a b) = SLT b a
+    go (SEx a (SEx a2 b)) | a == a2  = sex a b
+    go (SEx a b) = sex a b
 
     -- IsZero
     go (IsZero (IsZero (IsZero a))) = iszero a

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -104,10 +104,10 @@ checkMulti (SolverGroup taskq) smt2 multiSol = do
 checkSatWithProps :: App m => SolverGroup -> [Prop] -> m (SMTResult, Err SMT2)
 checkSatWithProps sg props = do
   conf <- readConfig
-  let psSimp = simplifyProps props
+  let psSimp = if conf.simp then simplifyProps props else props
   if psSimp == [PBool False] then pure (Qed, Right mempty)
   else do
-    let smt2 = assertProps conf psSimp
+    let smt2 = if conf.simp then assertProps conf psSimp else assertPropsNoSimp psSimp
     if isLeft smt2 then
       let err = getError smt2 in pure (Error err, Left err)
     else do

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -91,16 +91,14 @@ defaultIterConf = IterConfig
   }
 
 data VeriOpts = VeriOpts
-  { simp :: Bool
-  , iterConf :: IterConfig
+  { iterConf :: IterConfig
   , rpcInfo :: Fetch.RpcInfo
   }
   deriving (Eq, Show)
 
 defaultVeriOpts :: VeriOpts
 defaultVeriOpts = VeriOpts
-  { simp = True
-  , iterConf = defaultIterConf
+  { iterConf = defaultIterConf
   , rpcInfo = Nothing
   }
 
@@ -468,10 +466,11 @@ getExprEmptyStore
   -> VeriOpts
   -> m (Expr End)
 getExprEmptyStore solvers c signature' concreteArgs opts = do
+  conf <- readConfig
   calldata <- mkCalldata signature' concreteArgs
   preState <- liftIO $ stToIO $ loadEmptySymVM (RuntimeCode (ConcreteRuntimeCode c)) (Lit 0) calldata
   exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.iterConf preState runExpr
-  if opts.simp then (pure $ Expr.simplify exprInter) else pure exprInter
+  if conf.simp then (pure $ Expr.simplify exprInter) else pure exprInter
 
 getExpr
   :: App m
@@ -482,10 +481,11 @@ getExpr
   -> VeriOpts
   -> m (Expr End)
 getExpr solvers c signature' concreteArgs opts = do
-      calldata <- mkCalldata signature' concreteArgs
-      preState <- liftIO $ stToIO $ abstractVM calldata c Nothing False
-      exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.iterConf preState runExpr
-      if opts.simp then (pure $ Expr.simplify exprInter) else pure exprInter
+  conf <- readConfig
+  calldata <- mkCalldata signature' concreteArgs
+  preState <- liftIO $ stToIO $ abstractVM calldata c Nothing False
+  exprInter <- interpret (Fetch.oracle solvers opts.rpcInfo) opts.iterConf preState runExpr
+  if conf.simp then (pure $ Expr.simplify exprInter) else pure exprInter
 
 {- | Checks if an assertion violation has been encountered
 
@@ -697,7 +697,7 @@ verifyInputs solvers opts fetcher preState maybepost = do
 
   exprInter <- interpret fetcher opts.iterConf preState runExpr
   when conf.dumpExprs $ liftIO $ T.writeFile "unsimplified.expr" (formatExpr exprInter)
-  let expr = if opts.simp then (Expr.simplify exprInter) else exprInter
+  let expr = if conf.simp then (Expr.simplify exprInter) else exprInter
       flattened = flattenExpr expr
   when conf.dumpExprs $ liftIO $ do
     T.writeFile "simplified.expr" (formatExpr expr)
@@ -714,7 +714,7 @@ verifyInputs solvers opts fetcher preState maybepost = do
     Just post -> do
       let
         -- Filter out any leaves from `flattened` that can be statically shown to be safe
-        tocheck = flip map flattened $ \leaf -> (toPropsFinal leaf preState.constraints post, leaf)
+        tocheck = flip map flattened $ \leaf -> (toPropsFinal conf leaf preState.constraints post, leaf)
         withQueries = filter canBeSat tocheck
       when conf.debug $ liftIO $ putStrLn $ "   Checking for reachability of " <> show (length withQueries)
         <> " potential property violation(s) in call " <> call
@@ -733,7 +733,7 @@ verifyInputs solvers opts fetcher preState maybepost = do
     getCallPrefix (WriteByte (Lit 0) (LitByte a) (WriteByte (Lit 1) (LitByte b) (WriteByte (Lit 2) (LitByte c) (WriteByte (Lit 3) (LitByte d) _)))) = mconcat $ map (printf "%02x") [a,b,c,d]
     getCallPrefix _ = "unknown"
     toProps leaf constr post = PNeg (post preState leaf) : constr <> extractProps leaf
-    toPropsFinal leaf constr post = if opts.simp then Expr.simplifyProps $ toProps leaf constr post
+    toPropsFinal conf leaf constr post = if conf.simp then Expr.simplifyProps $ toProps leaf constr post
                                                  else toProps leaf constr post
     canBeSat (a, _) = case a of
         [PBool False] -> False
@@ -803,12 +803,13 @@ equivalenceCheck solvers bytecodeA bytecodeB opts calldata create = do
       pure $ oneQedOrNoQed issues <> partialIssues
   where
     -- decompiles the given bytecode into a list of branches
-    getBranches :: ByteString -> m [Expr End]
+    getBranches :: App m => ByteString -> m [Expr End]
     getBranches bs = do
+      conf <- readConfig
       let bytecode = if BS.null bs then BS.pack [0] else bs
       prestate <- liftIO $ stToIO $ abstractVM calldata bytecode Nothing create
       expr <- interpret (Fetch.oracle solvers Nothing) opts.iterConf prestate runExpr
-      let simpl = if opts.simp then (Expr.simplify expr) else expr
+      let simpl = if conf.simp then Expr.simplify expr else expr
       pure $ flattenExpr simpl
     oneQedOrNoQed :: EqIssues -> EqIssues
     oneQedOrNoQed (EqIssues res partials) =


### PR DESCRIPTION
## Description
This is a PR for two changes that are related, because I want to be able to properly check the rewrites. Our property-based testing usually did something like this:

```haskell
 testProperty  "buffer-simplification" $ \(expr :: Expr Buf) -> propNoSimpNoFuzz $ do
        let simplified = Expr.simplify expr
        checkEquivAndLHS expr simplified
```

However:
```haskell
checkEquivAndLHS orig simp = do
  opts <- readConfig
  let lhsConst =  Expr.checkLHSConst simp
  when (opts.debug) $ liftIO $ putStrLn $ "LHS const: " <> show lhsConst
  equiv <- checkEquiv orig simp
  pure $ lhsConst && equiv
```

and:
```haskell
checkEquiv :: (Typeable a, App m) => Expr a -> Expr a -> m Bool
checkEquiv a b = do
  opts <- readConfig
  if a == b then pure True else do
    when (opts.debug) $ liftIO $ putStrLn $ "Checking equivalence of " <> show a <> " and " <> show b
    x <- checkEquivBase (./=) a b True
    when (opts.debug) $ liftIO $ putStrLn $ "UNSAT check, expect True: " <> show x
    y <- checkEquivBase (.==) a b False
    when (opts.debug) $ liftIO $ putStrLn $ "SAT check, expect False: " <> show y
    pure $ (fromMaybe True x) && not (fromMaybe False y)
```

And finally:
```haskell
checkEquivBase :: (Eq a, App m) => (a -> a -> Prop) -> a -> a -> Bool -> m (Maybe Bool)
checkEquivBase mkprop l r expect = do
  withSolvers Z3 1 1 (Just 1) $ \solvers -> do
     (res, _) <- checkSatWithProps solvers [mkprop l r]
     let ret = case res of
           Qed -> Just True
           Cex {} -> Just False
           Error _ -> Just (not expect)
           Unknown _ -> Nothing
     when (ret == Just (not expect)) $ liftIO $ print res
     pure ret
```

And that's a BIG oops, because:
```haskell
checkSatWithProps sg props = do
  conf <- readConfig
  let psSimp = simplifyProps props
  [...]
```

So we checked simplification against simplification. BAD. This has now been fixed. I have also removed the fuzzer from these via:
```haskell
propNoSimpNoFuzz a = let testEnvNoSimp = Env { config = testEnv.config { numCexFuzz = 0, simp = False } }
  in ioProperty $ runEnv testEnvNoSimp a
```
Because fuzzing is essentially calling the constant folding, which is `simplify`, which we do not want.

Hence, most of our property-based testing was broken. I have also moved `simplify` to `Effects.hs` and it is now a global switch that can be switched on/off, and is properly adhered to by `checkSatWithProps`. Also, it's exposed to the cli, via `--no-simplify`. Much better, I think. I have also added some tests for `SignExtend`, one property-based test, and a few regular tests.

Secondly, I added one very obviously correct rewrite that was missing, probably some typo:
```diff
+    go (SEx a b) = sex a b
```
Without this, we didn't constant fold over `SignExtend`. Oooops.

I have also conferred with Kamil, and added the rewrite:
```diff
+    go (SEx a (SEx a2 b)) | a == a2  = sex a b
```

This seems to come up in the real world when working with signed integers.

Fixes https://github.com/ethereum/hevm/issues/770

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
