### PR TITLE
Use the pranked address' nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SignExtend is now correctly being constant-folded
 - Some of our property-based testing was ineffective because of inadvertent
   simplification  happening before calling the SMT solver. This has now been fixed.
+- When pranking an address, we used the non-pranked address' nonce
+  to calculate the new address. This was incorrect, and lead to address clash,
+  as the nonce was never incremented.
 
 ## Changed
 - Warnings now lead printing FAIL. This way, users don't accidentally think that

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -864,7 +864,11 @@ exec1 conf = do
                   assign (#state % #overrideCaller) Nothing
                   assign (#state % #resetCaller) False
 
-                newAddr <- createAddress from' this.nonce
+                nonce <- zoom (#env % #contracts) $ do
+                  contr <- use (at from')
+                  pure $ maybe Nothing (\c -> c.nonce) contr
+
+                newAddr <- createAddress from' nonce
                 _ <- accessAccountForGas newAddr
                 burn' cost $ do
                   initCode <- readMemory xOffset xSize

--- a/test/contracts/pass/nonce-issues.sol
+++ b/test/contracts/pass/nonce-issues.sol
@@ -1,0 +1,41 @@
+/// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.26;
+import {Test} from "forge-std/Test.sol";
+
+contract MyVault {
+    mapping(address => uint256) public balance;
+    function deposit() external payable {
+        balance[msg.sender] += msg.value;
+    }
+}
+
+contract Caller {}
+
+contract SymbolicTest is Test {
+    function setUp() public {
+        address caller = address(0xdead);
+        vm.startPrank(caller);
+        new MyVault();
+        new MyVault();
+    }
+
+    function prove_nonce_addr_nonexistent(uint8 amt) public {
+        assert(1 == 1);
+      }
+}
+
+contract SymbolicTest2 is Test {
+    function setUp() public {
+        address caller = address(new Caller());
+        // option 2
+        // address caller = makeAddr("alice");
+        vm.deal(caller, 1 ether); // just in case...
+        vm.startPrank(caller);
+        new MyVault();
+        new MyVault();
+    }
+
+    function prove_prank_addr_exists(uint8 amt) public {
+        assert(1 == 1);
+      }
+}

--- a/test/test.hs
+++ b/test/test.hs
@@ -1961,6 +1961,12 @@ tests = testGroup "hevm"
     , test "transfer-dapp" $ do
         let testFile = "test/contracts/pass/transfer.sol"
         runSolidityTest testFile "prove_transfer" >>= assertEqualM "should prove transfer" (True, True)
+    , test "nonce-issues" $ do
+        let testFile = "test/contracts/pass/nonce-issues.sol"
+        runSolidityTest testFile "prove_prank_addr_exists" >>= assertEqualM "should not bail" (True, True)
+        -- TODO: Currently fails, because we don't know how to increment the
+        -- nonce of a non-existent address.
+        -- runSolidityTest testFile "prove_nonce_addr_nonexistent" >>= assertEqualM "should not bail" (True, True)
     , test "badvault-sym-branch" $ do
         let testFile = "test/contracts/fail/10_BadVault.sol"
         runSolidityTestCustom testFile "prove_BadVault_usingExploitLaunchPad"  Nothing Nothing True Nothing Foundry >>=

--- a/test/test.hs
+++ b/test/test.hs
@@ -1964,9 +1964,7 @@ tests = testGroup "hevm"
     , test "nonce-issues" $ do
         let testFile = "test/contracts/pass/nonce-issues.sol"
         runSolidityTest testFile "prove_prank_addr_exists" >>= assertEqualM "should not bail" (True, True)
-        -- TODO: Currently fails, because we don't know how to increment the
-        -- nonce of a non-existent address.
-        -- runSolidityTest testFile "prove_nonce_addr_nonexistent" >>= assertEqualM "should not bail" (True, True)
+        runSolidityTest testFile "prove_nonce_addr_nonexistent" >>= assertEqualM "should not bail" (True, True)
     , test "badvault-sym-branch" $ do
         let testFile = "test/contracts/fail/10_BadVault.sol"
         runSolidityTestCustom testFile "prove_BadVault_usingExploitLaunchPad"  Nothing Nothing True Nothing Foundry >>=


### PR DESCRIPTION
## Description
We used the non-pranked' address' nonce, instead of the nonce of the pranked address' nonce when doing OpCreate. This lead to clash of addresses being calculated, because the nonce was never updated -- only the pranked address' nonce was updated, correctly. Now we do the address calculation correctly.

This only fixes the case when the address exists. When it doesn't, and we are running in concrete execution mode (such as in `setUp`, then we return a symbolic address, and that's not supported in concrete execution mode, so the system bails out.

Fixes #775

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
