### PR TITLE
Small update to SMT encoding of MulMod and AddMod

### DIFF
--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -721,18 +721,18 @@ exprToSMT = \case
     aExp <- exprToSMT a
     bExp <- exprToSMT b
     cExp <- exprToSMT c
-    let aLift = "(concat (_ bv0 256) " <> aExp <> ")"
-        bLift = "(concat (_ bv0 256) " <> bExp <> ")"
-        cLift = "(concat (_ bv0 256) " <> cExp <> ")"
-    pure $ "((_ extract 255 0) (ite (= " <> cExp <> " (_ bv0 256)) (_ bv0 512) (bvurem (bvmul " <> aLift `sp` bLift <> ")" <> cLift <> ")))"
+    let aLift = "((_ zero_extend 256) " <> aExp <> ")"
+        bLift = "((_ zero_extend 256) " <> bExp <> ")"
+        cLift = "((_ zero_extend 256) " <> cExp <> ")"
+    pure $ "(ite (= " <> cExp <> " (_ bv0 256)) (_ bv0 256) ((_ extract 255 0) (bvurem (bvmul " <> aLift `sp` bLift <> ")" <> cLift <> ")))"
   AddMod a b c -> do
     aExp <- exprToSMT a
     bExp <- exprToSMT b
     cExp <- exprToSMT c
-    let aLift = "(concat (_ bv0 256) " <> aExp <> ")"
-        bLift = "(concat (_ bv0 256) " <> bExp <> ")"
-        cLift = "(concat (_ bv0 256) " <> cExp <> ")"
-    pure $ "((_ extract 255 0) (ite (= " <> cExp <> " (_ bv0 256)) (_ bv0 512) (bvurem (bvadd " <> aLift `sp` bLift <> ")" <> cLift <> ")))"
+    let aLift = "((_ zero_extend 1) " <> aExp <> ")"
+        bLift = "((_ zero_extend 1) " <> bExp <> ")"
+        cLift = "((_ zero_extend 1) " <> cExp <> ")"
+    pure $ "(ite (= " <> cExp <> " (_ bv0 256)) (_ bv0 256) ((_ extract 255 0) (bvurem (bvadd " <> aLift `sp` bLift <> ")" <> cLift <> ")))"
   EqByte a b -> do
     cond <- op2 "=" a b
     pure $ "(ite " <> cond `sp` one `sp` zero <> ")"


### PR DESCRIPTION
We apply the following changes:
- Instead of concatenating vector of 0 bits,  we can use SMT-LIB build-in `zero_extend`. Maybe the solvers has better native support for that.
- Instead of having `ite` nested under the `extract` operation, we can pull it to the top-level and do the extension and shortening only in one branch.
- For AddMod, we do not need to extend all the way to 512 bits, extending just one bit to 257 bits is sufficient.

## Description

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
