### PR TITLE
RFC: Futamura projection proof-of-concept

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -104,6 +104,7 @@ library
     EVM.Format,
     EVM.Fetch,
     EVM.FeeSchedule,
+    EVM.Futamura,
     EVM.Op,
     EVM.Precompiled,
     EVM.RLP,
@@ -141,6 +142,10 @@ library
   install-includes:
     ethjet/tinykeccak.h, ethjet/ethjet.h, ethjet/ethjet-ff.h, ethjet/blake2.h
   build-depends:
+    ghc                               >= 9.6 && < 10,
+    ghc-paths                         >= 0.1,
+    directory                         >= 1.3,
+    temporary                         >= 1.2.0 && < 1.4, 
     system-cxx-std-lib                >= 1.0 && < 2.0,
     QuickCheck                        >= 2.13.2 && < 2.15,
     Decimal                           >= 0.5.1 && < 0.6,

--- a/src/EVM/Futamura.hs
+++ b/src/EVM/Futamura.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE ImplicitParams, FlexibleContexts, GADTs #-}
+
+module EVM.Futamura where
+
+import Control.Monad.State.Strict
+import Control.Monad.ST
+import System.Directory (getTemporaryDirectory)
+import System.IO.Temp (createTempDirectory)
+import System.FilePath
+import Data.Word (Word8)
+import GHC
+import GHC.Paths (libdir)
+import Unsafe.Coerce
+
+-- Adjust imports to your project
+import EVM.Op
+import EVM.Types
+
+--------------------------------------------------------------------------------
+-- | Generate Haskell Code From a List of Opcodes
+--------------------------------------------------------------------------------
+
+generateHaskellCode :: [GenericOp Word8] -> String
+generateHaskellCode ops =
+  unlines $
+    [ "{-# LANGUAGE ImplicitParams, FlexibleContexts #-}"
+    , "module Generated where"
+    , "import Control.Monad.State.Strict"
+    , "import Control.Monad.ST"
+    , "import EVM"
+    , "import EVM.Types"
+    , "import EVM.Op"
+    , "runSpecialized :: (VMOps t, ?op :: Word8) => StateT (VM t s) (ST s) ()"
+    , "runSpecialized = do"
+    ] ++ map genOp ops
+
+genOp :: GenericOp Word8 -> String
+genOp (OpPush n)  = "  runOpcodePush " ++ show n
+genOp (OpAdd)     = "  runOpcodeAdd"
+genOp (OpDup i)   = "  runOpcodeDup " ++ show i
+-- Add more opcodes as needed
+genOp other       = error $ "Opcode not supported in specialization: " ++ show other
+
+--------------------------------------------------------------------------------
+-- | Compile and Run a Specialized EVM Program at Runtime
+--------------------------------------------------------------------------------
+
+compileAndRunSpecialized :: [GenericOp Word8] -> VM t s -> IO (VM t s)
+compileAndRunSpecialized ops vmState = do
+  tmpDir <- getTemporaryDirectory >>= \tmp -> createTempDirectory tmp "evmjit"
+  let hsPath = tmpDir </> "Generated.hs"
+  writeFile hsPath (generateHaskellCode ops)
+  dynCompileAndRun hsPath vmState
+
+--------------------------------------------------------------------------------
+-- | Use GHC API to Compile and Run the Generated Code
+--------------------------------------------------------------------------------
+
+dynCompileAndRun :: forall t s. FilePath -> VM t s -> IO (VM t s)
+dynCompileAndRun filePath vmState = runGhc (Just libdir) $ do
+  dflags <- getSessionDynFlags
+  _ <- setSessionDynFlags dflags
+
+  target <- guessTarget filePath Nothing Nothing
+  setTargets [target]
+  _ <- load LoadAllTargets
+
+  setContext [IIDecl $ simpleImportDecl (mkModuleName "Generated")]
+
+  value <- compileExpr "Generated.runSpecialized"
+
+  -- Move annotation outside of `let` to avoid scoped type var issue
+  let specialized :: forall s1. StateT (VM t s) (ST s1) ()
+      specialized = unsafeCoerce value
+
+  -- Wrap runST inside IO to unify the lifetimes of `s1` and `s`
+  return $ runST (execStateT specialized vmState)


### PR DESCRIPTION
## Description

This PR was created just to receive comments regarding a potential usage of the futamura projection. It is not working as it needs a few important pieces more:
1. Take the bytecodes, splits it in basic blocks (with external calls considered as the end of a basic block as well), and save each futamura projection. This needs to be done for every contract involved.
2. Write a top level function, similar to `run` (EVM/Exec.hs) which fetches the current futamura projection and runs it. It should find the next basic block and repeat until the transaction is over.

However, you can take a look a the current proof of concept to see if you like the approch.

The final implementation will requiere a large refactoring of the opcode implementation (but it should not be too hard, since all the code is there). In the meantime, some limited benchmarking could be done, once steps 1 and 2 are complete, using a small number of opcodes in very simple contracts. The final implementation will also require the user to install ghc (or stack) to use this feature.
