### PR TITLE
Rewrite exponentiation to bitshift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More rewrite rules for MulMod, AddMod, SHL, SHR, SLT, and SignExtend
 - PLEq is now concretized in case it can be computed
 - More SignExtend test cases
+- Rewrite rules to deal with specific exponentiation patterns
 
 ## Fixed
 - We now try to simplify expressions fully before trying to cast them to a concrete value

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1186,17 +1186,11 @@ simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
       where l = sort [a, b, c]
             an = EVM.Expr.and
 
-    -- A pattern used by Solidity's legacy codegen when storing value of size < 32 bytes
-    -- into a storage slot (which has size 32 bytes)
-    -- It uses exponentiation to simulate bit shift.
-    -- This is needed on EVMs that do not support left shift (before Constantinopole), but is still part of legacy codegen in Solidity 0.8.30 (regardless of EVM target)
-    --
-    -- We can rewrite the exponentiation into a bit-shift, but we need to be conservative.
-    -- For `256 ^ offset`, which is equal to `2 ^ (8 * offset)` we can rewrite only if `8 * offset < 256`, so `offset < 32`.
-    -- Solidity uses specific pattern for the exponent, where we can verify that this condition is satisfied.
+    -- A special pattern sometimes generated from Solidity that uses exponentiation to simulate bit shift.
+    -- We can rewrite the exponentiation into a bit-shift under certain conditions.
     go (Exp (Lit 0x100) offset@(Mul (Lit a) (Mod _ (Lit b))))
-      | a * b <= 32 && (maxWord256 `Prelude.div` a) > b = (shl (Lit 1) (mul (Lit 0x8) offset))
-    go (Exp (Lit 0x100) offset@(Mod _ (Lit 32))) = (shl (Lit 1) (mul (Lit 0x8) offset))
+      | a * b <= 32 && (maxWord256 `Prelude.div` a) > b = shl (Lit 1) (mul (Lit 8) offset)
+    go (Exp (Lit 0x100) offset@(Mod _ (Lit 32))) = (shl (Lit 1) (mul (Lit 8) offset))
 
     -- redundant add / sub
     go (Sub (Add a b) c)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1186,6 +1186,18 @@ simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
       where l = sort [a, b, c]
             an = EVM.Expr.and
 
+    -- A pattern used by Solidity's legacy codegen when storing value of size < 32 bytes
+    -- into a storage slot (which has size 32 bytes)
+    -- It uses exponentiation to simulate bit shift.
+    -- This is needed on EVMs that do not support left shift (before Constantinopole), but is still part of legacy codegen in Solidity 0.8.30 (regardless of EVM target)
+    --
+    -- We can rewrite the exponentiation into a bit-shift, but we need to be conservative.
+    -- For `256 ^ offset`, which is equal to `2 ^ (8 * offset)` we can rewrite only if `8 * offset < 256`, so `offset < 32`.
+    -- Solidity uses specific pattern for the exponent, where we can verify that this condition is satisfied.
+    go (Exp (Lit 0x100) offset@(Mul (Lit a) (Mod _ (Lit b))))
+      | a * b <= 32 && (maxWord256 `Prelude.div` a) > b = (shl (Lit 1) (mul (Lit 0x8) offset))
+    go (Exp (Lit 0x100) offset@(Mod _ (Lit 32))) = (shl (Lit 1) (mul (Lit 0x8) offset))
+
     -- redundant add / sub
     go (Sub (Add a b) c)
       | a == c = b

--- a/test/test.hs
+++ b/test/test.hs
@@ -5173,6 +5173,58 @@ tests = testGroup "hevm"
           calldata <- mkCalldata Nothing []
           eq <- equivalenceCheck s aPrgm bPrgm defaultVeriOpts calldata False
           assertEqualM "Must be different" (any (isCex . fst) eq.res) True
+      , test "eq-storage-write-to-static-array-uint128" $ do
+        Just aPrgm <- solcRuntime "C"
+            [i|
+              contract C {
+                uint128[5] arr;
+                function set(uint i, uint64 v) external returns (uint) {
+                  arr[i] = v;
+                  arr[i] = v;
+                  return 0;
+                }
+              }
+            |]
+        Just bPrgm <- solcRuntime "C"
+          [i|
+              contract C {
+                uint128[5] arr;
+                function set(uint i, uint64 v) external returns (uint) {
+                  arr[i] = v;
+                  return 0;
+                }
+              }
+          |]
+        withSolvers Bitwuzla 1 1 Nothing $ \s -> do
+          calldata <- mkCalldata Nothing []
+          eq <- equivalenceCheck s aPrgm bPrgm defaultVeriOpts calldata False
+          assertEqualM "Must have no difference" [Qed] (map fst eq.res)
+      , test "eq-storage-write-to-static-array-uint8" $ do
+        Just aPrgm <- solcRuntime "C"
+            [i|
+              contract C {
+                uint8[10] arr;
+                function set(uint i, uint8 v) external returns (uint) {
+                  arr[i] = v;
+                  arr[i] = v;
+                  return 0;
+                }
+              }
+            |]
+        Just bPrgm <- solcRuntime "C"
+          [i|
+              contract C {
+                uint8[10] arr;
+                function set(uint i, uint8 v) external returns (uint) {
+                  arr[i] = v;
+                  return 0;
+                }
+              }
+          |]
+        withSolvers Bitwuzla 1 1 Nothing $ \s -> do
+          calldata <- mkCalldata Nothing []
+          eq <- equivalenceCheck s aPrgm bPrgm defaultVeriOpts calldata False
+          assertEqualM "Must have no difference" [Qed] (map fst eq.res)
       , test "eq-all-yul-optimization-tests" $ do
         let opts = defaultVeriOpts{ iterConf = defaultIterConf {maxIter = Just 5, askSmtIters = 20, loopHeuristic = Naive }}
             ignoredTests =


### PR DESCRIPTION
The legacy codegen of Solidity uses exponentiation to simulate bitshift. This was needed back when EVM did not have left bitshift instruction. See also https://github.com/ethereum/solidity/issues/16117 This pattern occurs when storing a value smaller that a storage slot size, i.e., when Solidity packs multiple values into one storage slot.

We can detect this pattern and replace it with actual bitshift. This should remove one possible source of exponentiation and allow us to verify more contracts.

## Description

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
