### PR TITLE
Fix argument order of shift operation in rewrite rule

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1189,8 +1189,8 @@ simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
     -- A special pattern sometimes generated from Solidity that uses exponentiation to simulate bit shift.
     -- We can rewrite the exponentiation into a bit-shift under certain conditions.
     go (Exp (Lit 0x100) offset@(Mul (Lit a) (Mod _ (Lit b))))
-      | a * b <= 32 && (maxWord256 `Prelude.div` a) > b = shl (Lit 1) (mul (Lit 8) offset)
-    go (Exp (Lit 0x100) offset@(Mod _ (Lit 32))) = (shl (Lit 1) (mul (Lit 8) offset))
+      | a * b <= 32 && (maxWord256 `Prelude.div` a) > b = shl (mul (Lit 8) offset) (Lit 1)
+    go (Exp (Lit 0x100) offset@(Mod _ (Lit 32))) = (shl (mul (Lit 8) offset)) (Lit 1)
 
     -- redundant add / sub
     go (Sub (Add a b) c)

--- a/test/test.hs
+++ b/test/test.hs
@@ -5189,7 +5189,8 @@ tests = testGroup "hevm"
           calldata <- mkCalldata Nothing []
           eq <- equivalenceCheck s aPrgm bPrgm defaultVeriOpts calldata False
           assertEqualM "Must be different" (any (isCex . fst) eq.res) True
-      , test "eq-storage-write-to-static-array-uint128" $ do
+      ,
+      test "eq-storage-write-to-static-array-uint128" $ do
         Just aPrgm <- solcRuntime "C"
             [i|
               contract C {
@@ -5215,7 +5216,8 @@ tests = testGroup "hevm"
           calldata <- mkCalldata Nothing []
           eq <- equivalenceCheck s aPrgm bPrgm defaultVeriOpts calldata False
           assertEqualM "Must have no difference" [Qed] (map fst eq.res)
-      , test "eq-storage-write-to-static-array-uint8" $ do
+      ,
+      test "eq-storage-write-to-static-array-uint8" $ do
         Just aPrgm <- solcRuntime "C"
             [i|
               contract C {
@@ -5232,6 +5234,33 @@ tests = testGroup "hevm"
               contract C {
                 uint8[10] arr;
                 function set(uint i, uint8 v) external returns (uint) {
+                  arr[i] = v;
+                  return 0;
+                }
+              }
+          |]
+        withSolvers Bitwuzla 1 1 Nothing $ \s -> do
+          calldata <- mkCalldata Nothing []
+          eq <- equivalenceCheck s aPrgm bPrgm defaultVeriOpts calldata False
+          assertEqualM "Must have no difference" [Qed] (map fst eq.res)
+      ,
+      test "eq-storage-write-to-static-array-uint32" $ do
+        Just aPrgm <- solcRuntime "C"
+            [i|
+              contract C {
+                uint32[5] arr;
+                function set(uint i, uint32 v) external returns (uint) {
+                  arr[i] = 1;
+                  arr[i] = v;
+                  return 0;
+                }
+              }
+            |]
+        Just bPrgm <- solcRuntime "C"
+          [i|
+              contract C {
+                uint32[5] arr;
+                function set(uint i, uint32 v) external returns (uint) {
                   arr[i] = v;
                   return 0;
                 }


### PR DESCRIPTION
## Description

Apparently, for the SHL expression, the first argument is the number of bits we are shifting and the second argument is the bit-vector we are shifting.
I messed up the order because for me having the bit-vector first seems more natural.

This is a follow up on #794.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
