### PR TITLE
Print warnings using printWarnings in "symbolic" mode as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The concrete MCOPY implementation has been optimized to avoid freezing the whole
   EVM memory.
 - We no longer accept `check` as a prefix for test cases by default.
+- The way we print warnings for `symbolic` mode now matches that of `test` mode.
 
 ## [0.54.2] - 2024-12-12
 


### PR DESCRIPTION
## Description
This fixes https://github.com/ethereum/hevm/issues/785 and now prints warnings the same way for `symbolic` as we do for `test`.

New output:

```
cabal run exe:hevm -- symbolic --code "608060405234801561000f575f80fd5b5060043610610055575f3560e01c806341dd3ccc1461005957806360fe47b1146100895780636d4ce63c146100a55780637784b4f8146100c3578063bd1ead96146100df575b5f80fd5b610073600480360381019061006e9190610335565b6100fb565b604051610080919061038d565b60405180910390f35b6100a3600480360381019061009e91906103a6565b6101ff565b005b6100ad610208565b6040516100ba91906103e0565b60405180910390f35b6100dd60048036038101906100d891906103f9565b610210565b005b6100f960048036038101906100f49190610573565b610230565b005b5f808260405160240161010e91906103e0565b6040516020818303038152906040527f80972a7d000000000000000000000000000000000000000000000000000000007bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19166020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff838183161783525050505090505f8473ffffffffffffffffffffffffffffffffffffffff16826040516101b3919061060c565b5f60405180830381855af49150503d805f81146101eb576040519150601f19603f3d011682016040523d82523d5f602084013e6101f0565b606091505b50509050809250505092915050565b805f8190555050565b5f8054905090565b6014818361021e919061064f565b0361022c5761022b610682565b5b5050565b5f81511161024157610240610682565b5b606160f81b815f81518110610259576102586106af565b5b602001015160f81c60f81b7effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff19161461029457610293610682565b5b50565b5f604051905090565b5f80fd5b5f80fd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6102d1826102a8565b9050919050565b6102e1816102c7565b81146102eb575f80fd5b50565b5f813590506102fc816102d8565b92915050565b5f819050919050565b61031481610302565b811461031e575f80fd5b50565b5f8135905061032f8161030b565b92915050565b5f806040838503121561034b5761034a6102a0565b5b5f610358858286016102ee565b925050602061036985828601610321565b9150509250929050565b5f8115159050919050565b61038781610373565b82525050565b5f6020820190506103a05f83018461037e565b92915050565b5f602082840312156103bb576103ba6102a0565b5b5f6103c884828501610321565b91505092915050565b6103da81610302565b82525050565b5f6020820190506103f35f8301846103d1565b92915050565b5f806040838503121561040f5761040e6102a0565b5b5f61041c85828601610321565b925050602061042d85828601610321565b9150509250929050565b5f80fd5b5f80fd5b5f601f19601f8301169050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b6104858261043f565b810181811067ffffffffffffffff821117156104a4576104a361044f565b5b80604052505050565b5f6104b6610297565b90506104c2828261047c565b919050565b5f67ffffffffffffffff8211156104e1576104e061044f565b5b6104ea8261043f565b9050602081019050919050565b828183375f83830152505050565b5f610517610512846104c7565b6104ad565b9050828152602081018484840111156105335761053261043b565b5b61053e8482856104f7565b509392505050565b5f82601f83011261055a57610559610437565b5b813561056a848260208601610505565b91505092915050565b5f60208284031215610588576105876102a0565b5b5f82013567ffffffffffffffff8111156105a5576105a46102a4565b5b6105b184828501610546565b91505092915050565b5f81519050919050565b5f81905092915050565b8281835e5f83830152505050565b5f6105e6826105ba565b6105f081856105c4565b93506106008185602086016105ce565b80840191505092915050565b5f61061782846105dc565b915081905092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61065982610302565b915061066483610302565b925082820190508082111561067c5761067b610622565b5b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52600160045260245ffd5b7f4e487b71000000000000000000000000000000000000000000000000000000005f52603260045260245ffdfea26469706673582212202c769a538a97e0abc4a43ebbfa10963f85ead03918ff7d492f9dff0e541a362a64736f6c634300081a0033"
Using assertion code(s): 1

Discovered the following 1 counterexample(s):

Calldata:
  0x7784b4f800000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000010
Storage:
  Addr SymAddr "miner": []
  Addr SymAddr "origin": []
Transaction Context:
  TxValue: 0x0
Addrs:
  SymAddr "entrypoint": 0x500C0421100a4c6Acb9004ecd612051B6011c24A
  SymAddr "miner": 0x7C3688400883a191244780202fc846d0dAeAB97F
  SymAddr "origin": 0x83e37FBeFb78B614822c7b51A0E499240B9401a0


   [WARNING] hevm was only able to partially explore symbolically due to:
      2x -> CopySlice with a symbolically sized region not currently implemented, cannot execute SMT solver on this query
```

Old output:

```
[... same as above ...]
assertion code(s): 1

Discovered the following 1 counterexample(s):

Calldata:
  0x7784b4f800000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000010
Storage:
  Addr SymAddr "miner": []
  Addr SymAddr "origin": []
Transaction Context:
  TxValue: 0x0
Addrs:
  SymAddr "entrypoint": 0x500C0421100a4c6Acb9004ecd612051B6011c24A
  SymAddr "miner": 0x7C3688400883a191244780202fc846d0dAeAB97F
  SymAddr "origin": 0x83e37FBeFb78B614822c7b51A0E499240B9401a0
```

Notice the missing warnings.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
