### PR TITLE
Collect keccaks during concrete running and inject them into the Props during query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-## Changed
-- Updated forge to 1.2.3 and forge-std to 60acb7aa (1.9.7+)
+## [Unreleased]
 
 ## Fixed
 - We now extract more Keccak computations than before from the Props to assert
   more Keccak equalities.
 - Faster word256Bytes and word160Bytes functions to help concrete execution
   performance
+
+## Changed
+- Updated forge to 1.2.3 and forge-std to 60acb7aa (1.9.7+)
+- We now gather Keccak axioms during `setUp()` and inject them into the SMT solver.
+  This helps us finding more correct Keccak preimages
 
 ## [0.55.1] - 2025-07-22
 

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -313,6 +313,7 @@ test-suite ethereum-tests
     BlockchainTests.hs
 
 test-suite cli-test
+  import: test-common
   type:
     exitcode-stdio-1.0
   default-language: GHC2021

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -166,6 +166,7 @@ makeVm o = do
     , osEnv = mempty
     , freshVar = 0
     , exploreDepth = 0
+    , keccakPreImgs = fromList []
     }
     where
     env = Env
@@ -437,7 +438,11 @@ exec1 conf = do
                     orig@(ConcreteBuf bs) ->
                       whenSymbolicElse
                         (pure $ Keccak orig)
-                        (pure $ Lit (keccak' bs))
+                        (do
+                          let kc = keccak' bs
+                          modifying #keccakPreImgs (insert (bs, kc))
+                          pure $ Lit kc
+                        )
                     buf -> pure $ Keccak buf
                   next
                   assign' (#state % #stack) (hash : xs)

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -696,7 +696,8 @@ data VM (t :: VMType) s = VM
   , freshVar       :: Int
   -- ^ used to generate fresh symbolic variable names for overapproximations
   --   during symbolic execution. See e.g. OpStaticcall
-  , exploreDepth    :: Int
+  , exploreDepth   :: Int
+  , keccakPreImgs  :: Set (ByteString, W256)
   }
   deriving (Generic)
 

--- a/test/clitest.hs
+++ b/test/clitest.hs
@@ -11,24 +11,52 @@ break the hevm CLI interface.
 -}
 
 import Test.Hspec
-import System.Process (readProcess, readProcessWithExitCode)
-import System.FilePath ((</>))
+import System.Process (readProcessWithExitCode)
 import System.Exit (ExitCode(..))
 import Data.List.Split (splitOn)
 import Data.Text qualified as T
 import Data.String.Here
+import System.IO.Temp
 
 import EVM.Solidity
+import EVM.Types qualified as Types
 import EVM.Effects
-import EVM.Types
+import EVM.Test.Utils
 
+testEnv :: Env
+testEnv = Env { config = defaultConfig {
+  dumpQueries = False
+  , dumpExprs = False
+  , dumpEndStates = False
+  , debug = False
+  , dumpTrace = False
+  , decomposeStorage = True
+  , verb = 1
+  } }
+
+runOneKeccakTest :: FilePath -> IO ()
+runOneKeccakTest testFile = do
+  withSystemTempDirectory "dapp-test" $ \root -> do
+    let projectType = Foundry
+    ret <- runEnv testEnv $ compile projectType root testFile
+    case ret of
+      Left e -> do
+        putStrLn e
+        Types.internalError $ "Error compiling test file " <> show testFile <> " in directory "
+          <> show root <> " using project type " <> show projectType
+      Right _ -> do
+        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "test"
+          , "--root", root, "--debug", "--num-cex-fuzz", "0", "--smtdebug"] ""
+        stderr `shouldNotContain` "CallStack"
+        stdout `shouldContain` "0x0000000000000000000000000000000000001234"
+        exitCode `shouldBe` (ExitFailure 1)
 
 main :: IO ()
 main = do
   hspec $
     describe "CLI" $ do
       it "hevm help works" $ do
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "--help"] ""
+        (_, stdout, _) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "--help"] ""
         stdout `shouldContain` "Usage: hevm"
         stdout `shouldContain` "test"
         stdout `shouldContain` "equivalence"
@@ -46,18 +74,18 @@ main = do
             }
           }
         |])
-        let symbHex = bsToHex symbBin
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "symbolic", "--code", symbHex] ""
+        let symbHex = Types.bsToHex symbBin
+        (exitCode, stdout, _) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "symbolic", "--code", symbHex] ""
         stdout `shouldContain` "Discovered the following"
         exitCode `shouldBe` ExitFailure 1
 
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "symbolic", "--code", symbHex, "--sig", "nonexistent()"] ""
-        stdout `shouldContain` "QED"
-        exitCode `shouldBe` ExitSuccess
+        (exitCode2, stdout2, _) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "symbolic", "--code", symbHex, "--sig", "nonexistent()"] ""
+        stdout2 `shouldContain` "QED"
+        exitCode2 `shouldBe` ExitSuccess
 
       it "hevm equivalence tutorial works -- FAIL" $ do
         let torun = splitOn " " "equivalence --code-a 60003560000260005260016000f3 --code-b 7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff60005260016000f3"
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" (["run", "exe:hevm", "--" ] ++ torun) ""
+        (exitCode, stdout, _) <- readProcessWithExitCode "cabal" (["run", "exe:hevm", "--" ] ++ torun) ""
         stdout `shouldContain` "Not equivalent"
         stdout `shouldContain` "FAIL"
         exitCode `shouldBe` ExitFailure 1
@@ -72,7 +100,7 @@ main = do
             }
           }
         |])
-        let aHex = bsToHex a
+        let aHex = Types.bsToHex a
         Just b <- runApp $ solcRuntime (T.pack "MyContract") (T.pack [i|
           contract MyContract {
             mapping (address => uint) balances;
@@ -84,15 +112,15 @@ main = do
             }
           }
         |])
-        let bHex = bsToHex b
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" (["run", "exe:hevm", "--", "equivalence" , "--code-a", aHex, "--code-b", bHex ]) ""
+        let bHex = Types.bsToHex b
+        (exitCode, stdout, _) <- readProcessWithExitCode "cabal" (["run", "exe:hevm", "--", "equivalence" , "--code-a", aHex, "--code-b", bHex ]) ""
         stdout `shouldContain` "No discrepancies found"
         stdout `shouldContain` "PASS"
         exitCode `shouldBe` ExitSuccess
 
       it "hevm concrete tutorial works" $ do
         let torun = splitOn " " "exec --code 0x647175696e6550383480393834f3 --gas 0xff"
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" (["run", "exe:hevm", "--" ] ++ torun) ""
+        (exitCode, stdout, _) <- readProcessWithExitCode "cabal" (["run", "exe:hevm", "--" ] ++ torun) ""
         stdout `shouldContain` "Return: 0x64"
         exitCode `shouldBe` ExitSuccess
 
@@ -113,8 +141,8 @@ main = do
              }
            }
           |])
-        let hexStr = bsToHex c
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "symbolic", "--code", hexStr] ""
+        let hexStr = Types.bsToHex c
+        (_, stdout, _) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "symbolic", "--code", hexStr] ""
         stdout `shouldContain` "Warning: fetching contract at address 0"
 
       -- file "devcon_example.yul" from "eq-all-yul-optimization-tests" in test.hs
@@ -156,13 +184,17 @@ main = do
            } |]
         Just aPrgm <- yul (T.pack "") $ T.pack a
         Just bPrgm <- yul (T.pack "") $ T.pack b
-        let hexStrA = bsToHex aPrgm
-            hexStrB = bsToHex bPrgm
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "equivalence", "--num-solvers", "1", "--debug", "--code-a", hexStrA, "--code-b", hexStrB] ""
+        let hexStrA = Types.bsToHex aPrgm
+            hexStrB = Types.bsToHex bPrgm
+        (_, stdout, _) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "equivalence", "--num-solvers", "1", "--debug", "--code-a", hexStrA, "--code-b", hexStrB] ""
         stdout `shouldContain` "Qed found via cache"
       it "crash-of-hevm" $ do
         let hexStrA = "608060405234801561001057600080fd5b506004361061002b5760003560e01c8063efa2978514610030575b600080fd5b61004361003e3660046102ad565b610045565b005b60006100508561007a565b9050600061005d866100a8565b905080821461006e5761006e61034c565b50505050505050505050565b600061008761032e6103aa565b8261009457610197610098565b61013e5b6100a291906103e2565b92915050565b60006100b561032e6103aa565b6100be906103aa565b6100c7906103aa565b82806100d1575060005b806100da575060005b61013157605a6100ea60006103aa565b6100f3906103aa565b6100ff6001605a610404565b61010b6001605a610404565b61011891166101976103e2565b6101229190610493565b61012c9190610493565b610149565b604061013f8161013e6103e2565b6101499190610493565b61015391906103e2565b61016061032e60006103e2565b83801561016b575060015b15801590610177575060015b80156101a05750831515801561018b575060015b15158015610197575060015b806101a0575060005b610251576101976101b3605a602d610493565b602d60006101c2600182610493565b6101cd906001610404565b6101d8906001610404565b6101e1906103aa565b6101ea906103aa565b6101f491906103e2565b6101ff90605a610404565b604e61020c8160016103e2565b6102169190610493565b61022490600116605a610404565b1661022e906103aa565b61023891906103e2565b6102429190610493565b61024c9190610493565b610283565b604561025f8161013e6103e2565b6102699190610493565b60456102778161013e6103e2565b6102819190610493565b165b61028d91906103e2565b1692915050565b80358015155b81146100a257600080fd5b80358061029a565b600080600080600080600080610100898b0312156102ca57600080fd5b6102d48a8a610294565b97506102e38a60208b01610294565b96506102f28a60408b016102a5565b95506103018a60608b016102a5565b94506103108a60808b01610294565b935061031f8a60a08b016102a5565b925061032e8a60c08b01610294565b915061033d8a60e08b016102a5565b90509295985092959890939650565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052600160045260246000fd5b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b60007f800000000000000000000000000000000000000000000000000000000000000082036103db576103db61037b565b5060000390565b818103600083128015838313168383129190911617156100a2576100a261037b565b60008261043a577f4e487b7100000000000000000000000000000000000000000000000000000000600052601260045260246000fd5b7f800000000000000000000000000000000000000000000000000000000000000082147fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8414161561048e5761048e61037b565b500590565b80820160008212801584831290811690159190911617156100a2576100a261037b56fea26469706673582212200a37769e5bf4b8b890caac8ab643126d55feb821a0201d2f674203f23fa666ad64736f6c634300081e0033"
 
-        (exitCode, stdout, stderr) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "symbolic", "--code", hexStrA] ""
+        (exitCode, _, stderr) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "symbolic", "--code", hexStrA] ""
         stderr `shouldNotContain` "CallStack"
         exitCode `shouldBe` ExitSuccess
+
+      -- both should fail with address 0x1234 -- a SPECIFIC address, not a ranomly generated one
+      it "keccak-assumptions-setup" $ runOneKeccakTest "test/contracts/fail/keccak-preimage-setup.sol"
+      it "keccak-assumptions-constructor" $ runOneKeccakTest "test/contracts/fail/keccak-preimage-constructor.sol"

--- a/test/contracts/fail/keccak-preimage-constructor.sol
+++ b/test/contracts/fail/keccak-preimage-constructor.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+import {Test} from "forge-std/Test.sol";
+
+contract MyContractTest is Test {
+  mapping (address => uint) balances;
+  constructor() {
+    balances[address(0x1234)] = 50;
+  }
+  function prove_bad_addr(address x) public view {
+    assert(balances[x] != 50);
+  }
+}

--- a/test/contracts/fail/keccak-preimage-setup.sol
+++ b/test/contracts/fail/keccak-preimage-setup.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+import {Test} from "forge-std/Test.sol";
+
+contract MyContractTest is Test {
+  mapping (address => uint) balances;
+  function setUp() public {
+    balances[address(0x1234)] = 50;
+  }
+  function prove_bad_addr(address x) public view {
+    assert(balances[x] != 50);
+  }
+}


### PR DESCRIPTION
## Description
Fixes #804:

```
$ cabal run -f devel exe:hevm -- test --match '.*bad_addr.*' --root tmp --debug --solver bitwuzla --smtdebug  --trace --max-depth 32 --max-iterations 20 --num-solvers 2  --loop-detection-heuristic Naive
-> debug of func: prove_bad_addr Failure at the end of expr: Revert (ConcreteBuf "")
symRun -- (cex,warnings,unexpectedAllRevert): (True,False,False)
   [FAIL] prove_bad_addr
   Counterexample:
     calldata: prove_bad_addr(0x0000000000000000000000000000000000001234)
     result:   Revert: 0x4e487b710000000000000000000000000000000000000000000000000000000000000001
```

The following changes were also made:
- Cleaned up clitest.hs -- no more warnings
- Added test to clitest.hs -- we can now run forge tests in cli mode, too

Can only be merged after https://github.com/ethereum/hevm/pull/809 has been merged.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
