### PR TITLE
More complete keccak computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+- We now extract more Keccak computations than before from the Props to assert
+  more Keccak equalities.
+
+## [0.55.1] - 2025-7-22
+
 ## Added
 - When a staticcall is made to a contract that does not exist, we overapproximate
   and return symbolic values

--- a/src/EVM/Keccak.hs
+++ b/src/EVM/Keccak.hs
@@ -82,10 +82,10 @@ concretizeKeccakParam _ = internalError "Cannot happen"
 
 compute :: forall a. Expr a -> Set Prop
 compute = \case
-  e@(Keccak buf) -> do
-    let b = simplify buf
+  Keccak buf -> do
+    let b = concKeccakSimpExpr buf
     case keccak b of
-      lit@(Lit _) -> Set.singleton (PEq lit (concretizeKeccakParam e))
+      lit@(Lit _) -> Set.singleton (PEq lit (Keccak b))
       _ -> Set.empty
   _ -> Set.empty
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -78,6 +78,7 @@ import EVM.Effects
 import EVM.UnitTest (writeTrace, printWarnings)
 import EVM.Expr (maybeLitByteSimp)
 import Data.Text.Internal.Builder (toLazyText)
+import EVM.Keccak (keccakCompute)
 
 testEnv :: Env
 testEnv = Env { config = defaultConfig {
@@ -4721,6 +4722,13 @@ tests = testGroup "hevm"
       let sexprs = splitSExpr texts
       let noDuplicates = ((length sexprs) == (Set.size (Set.fromList sexprs)))
       assertBoolM "There were duplicate lines in SMT encoding" noDuplicates
+     , test "all-keccak-asserted" $ do
+      let buf1 = (Keccak (ConcreteBuf "abc"))
+          eq = (Eq buf1 (Lit 0x12))
+          buf2 = WriteWord eq (Lit 0x0) mempty
+          props = [PEq (Keccak buf2) (Lit 0x123)]
+          computes = keccakCompute props [] []
+      assertEqualM "Must compute two keccaks" 2 (length computes)
   ]
   , testGroup "equivalence-checking"
     [


### PR DESCRIPTION
## Description
This extracts all keccak computations -- previously some were missed. The new test case passes with the new setup, but failed in the old one. Only one of the two keccaks were extracted from:

```haskell
      let buf1 = (Keccak (ConcreteBuf "abc"))
          eq = (Eq buf1 (Lit 0x12))
          buf2 = WriteWord eq (Lit 0x0) mempty
          props = [PEq (Keccak buf2) (Lit 0x123)]
```

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
