### PR TITLE
[DRAFT] Resolve to only deployed contracts

### DIFF
--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -94,6 +94,7 @@ data CommonOptions = CommonOptions
   , maxWidth      ::Int
   , maxDepth      ::Maybe Int
   , noSimplify    ::Bool
+  , onlyDeployed  ::Bool
   }
 
 commonOptions :: Parser CommonOptions
@@ -121,6 +122,7 @@ commonOptions = CommonOptions
   <*> (option auto $ long "max-width"      <> showDefault <> value 100 <> help "Max number of concrete values to explore when encountering a symbolic value. This is a form of branch width limitation per symbolic value")
   <*> (optional $ option auto $ long "max-depth" <> help "Limit maximum depth of branching during exploration (default: unlimited)")
   <*> (switch $ long "no-simplify" <> help "Don't perform simplification of expressions")
+  <*> (switch $ long "only-deployed" <> help "When trying to resolve unknown addresses, only use addresses of deployed contracts")
 
 data CommonExecOptions = CommonExecOptions
   { address       ::Maybe Addr
@@ -358,6 +360,7 @@ main = do
         , maxDepth = cOpts.maxDepth
         , verb = cOpts.verb
         , simp = Prelude.not cOpts.noSimplify
+        , onlyDeployed = cOpts.onlyDeployed
         } }
 
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2143,7 +2143,7 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
     -- Here, we are sure that the address has been deployed
     multiCall :: VM t s -> Expr 'Buf -> Maybe W256 -> Gas t -> W256 -> EVM t s ()
     multiCall vm0 calldata abi xGas addrW256 = do
-      let addr = LitAddr (fromInteger . toInteger $ addrW256)
+      let addr = LitAddr $ truncateToAddr addrW256
           contract = vm0.env.contracts Map.! addr
       actualCall vm0 addr contract calldata abi xGas
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2140,6 +2140,7 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
     filterConcrete (LitAddr w) = Just (fromInteger $ toInteger w.addressWord160)
     filterConcrete _ = Nothing
 
+    -- Here, we are sure that the address has been deployed
     multiCall :: VM t s -> Expr 'Buf -> Maybe W256 -> Gas t -> W256 -> EVM t s ()
     multiCall vm0 calldata abi xGas addrW256 = do
       let targetAddr :: Expr 'EAddr = litToAddr addrW256

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2120,12 +2120,12 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
           resetCaller <- use $ #state % #resetCaller
           when resetCaller $ assign (#state % #overrideCaller) Nothing
           vm0 <- get
-          fetchAccountWithFallback xTo (actualFallback xGas vm0) $ \target -> case target.code of
+          fetchAccountWithFallback xTo (actualFallback xGas vm0) $ \contract -> case contract.code of
               UnknownCode _  -> actualFallback xGas vm0 xTo
               _ -> do
                 burn' xGas $ do
                   (calldata, abi) <- getCalldataAbi
-                  actualCall vm0 xTo target.codehash target.code calldata abi xGas
+                  actualCall vm0 xTo contract calldata abi xGas
   where
     actualFallback xGas vm0 addr = do
       if not (?conf.onlyDeployed) then fallback addr
@@ -2143,25 +2143,23 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
     -- Here, we are sure that the address has been deployed
     multiCall :: VM t s -> Expr 'Buf -> Maybe W256 -> Gas t -> W256 -> EVM t s ()
     multiCall vm0 calldata abi xGas addrW256 = do
-      let targetAddr :: Expr 'EAddr = LitAddr (fromInteger . toInteger $ addrW256)
-          contract = vm0.env.contracts Map.! targetAddr
-          targetHash = contract.codehash
-          targetCode = contract.code
-      actualCall vm0 targetAddr targetHash targetCode calldata abi xGas
+      let addr = LitAddr (fromInteger . toInteger $ addrW256)
+          contract = vm0.env.contracts Map.! addr
+      actualCall vm0 addr contract calldata abi xGas
 
     getCalldataAbi = do
       calldata <- readMemory xInOffset xInSize
       abi <- maybeLitWordSimp . readBytes 4 (Lit 0) <$> readMemory xInOffset (Lit 4)
       pure (calldata, abi)
 
-    actualCall :: VM t s -> Expr 'EAddr -> Expr 'EWord -> ContractCode -> Expr 'Buf -> Maybe W256 -> Gas t -> EVM t s ()
-    actualCall vm0 targetAddr targetHash targetCode calldata abi xGas = do
+    actualCall :: VM t s -> Expr EAddr -> Contract -> Expr 'Buf -> Maybe W256 -> Gas t -> EVM t s ()
+    actualCall vm0 targetAddr contract calldata abi xGas = do
       let newContext = CallContext
                         { target    = targetAddr
                         , context   = xContext
                         , offset    = xOutOffset
                         , size      = xOutSize
-                        , codehash  = targetHash
+                        , codehash  = contract.codehash
                         , callreversion = vm0.env.contracts
                         , subState  = vm0.tx.subState
                         , abi
@@ -2183,7 +2181,7 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
       zoom #state $ do
         assign #gas xGas
         assign #pc 0
-        assign #code (clearInitCode targetCode)
+        assign #code (clearInitCode contract.code)
         assign #codeContract targetAddr
         assign #stack mempty
         assign #memory newMemory

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2143,7 +2143,7 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
     -- Here, we are sure that the address has been deployed
     multiCall :: VM t s -> Expr 'Buf -> Maybe W256 -> Gas t -> W256 -> EVM t s ()
     multiCall vm0 calldata abi xGas addrW256 = do
-      let targetAddr :: Expr 'EAddr = litToAddr addrW256
+      let targetAddr :: Expr 'EAddr = LitAddr (fromInteger . toInteger $ addrW256)
           contract = vm0.env.contracts Map.! targetAddr
           targetHash = contract.codehash
           targetCode = contract.code
@@ -2153,9 +2153,6 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
       calldata <- readMemory xInOffset xInSize
       abi <- maybeLitWordSimp . readBytes 4 (Lit 0) <$> readMemory xInOffset (Lit 4)
       pure (calldata, abi)
-
-    litToAddr :: W256 -> Expr EAddr
-    litToAddr w = LitAddr (fromInteger . toInteger $ w)
 
     actualCall :: VM t s -> Expr 'EAddr -> Expr 'EWord -> ContractCode -> Expr 'Buf -> Maybe W256 -> Gas t -> EVM t s ()
     actualCall vm0 targetAddr targetHash targetCode calldata abi xGas = do

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -64,7 +64,6 @@ import Data.Vector.Storable.ByteString (vectorToByteString, byteStringToVector)
 import Data.Word (Word8, Word32, Word64)
 import Text.Read (readMaybe)
 import Witch (into, tryFrom, unsafeInto, tryInto)
-import Debug.Trace (traceM, traceShowM, trace)
 
 import Crypto.Hash (Digest, SHA256, RIPEMD160)
 import Crypto.Hash qualified as Crypto
@@ -2129,31 +2128,34 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
                   actualCall vm0 xTo target.codehash target.code calldata abi xGas
   where
     actualFallback xGas vm0 addr = do
-      if not (?conf.onlyDeployed) then trace ("here?") $ fallback addr
-      else trace ("there") $ case eqT @t @Symbolic of
+      if not (?conf.onlyDeployed) then fallback addr
+      else case eqT @t @Symbolic of
         Just Refl -> do
           burn' xGas $ do
             (calldata, abi) <- getCalldataAbi
             let concVals = mapMaybe filterConcrete $ Map.keys vm0.env.contracts
-            runAll (?conf.maxDepth) vm0.exploreDepth $ PleaseRunAll (WAddr xTo) concVals (callHelper vm0 calldata abi xGas)
+            runAll (?conf.maxDepth) vm0.exploreDepth $ PleaseRunAll (WAddr xTo) concVals (multiCall vm0 calldata abi xGas)
         _ -> internalError "delegateCall: UnknownCode in concrete mode"
     filterConcrete :: Expr EAddr -> Maybe W256
     filterConcrete (LitAddr w) = Just (fromInteger $ toInteger w.addressWord160)
     filterConcrete _ = Nothing
-    -- addr is W256
-    callHelper :: VM t s -> Expr 'Buf -> Maybe W256 -> Gas t -> W256 -> EVM t s ()
-    callHelper vm0 calldata abi xGas addrW256 = do
+
+    multiCall :: VM t s -> Expr 'Buf -> Maybe W256 -> Gas t -> W256 -> EVM t s ()
+    multiCall vm0 calldata abi xGas addrW256 = do
       let targetAddr :: Expr 'EAddr = litToAddr addrW256
           contract = vm0.env.contracts Map.! targetAddr
           targetHash = contract.codehash
           targetCode = contract.code
       actualCall vm0 targetAddr targetHash targetCode calldata abi xGas
+
     getCalldataAbi = do
       calldata <- readMemory xInOffset xInSize
       abi <- maybeLitWordSimp . readBytes 4 (Lit 0) <$> readMemory xInOffset (Lit 4)
       pure (calldata, abi)
+
     litToAddr :: W256 -> Expr EAddr
     litToAddr w = LitAddr (fromInteger . toInteger $ w)
+
     actualCall :: VM t s -> Expr 'EAddr -> Expr 'EWord -> ContractCode -> Expr 'Buf -> Maybe W256 -> Gas t -> EVM t s ()
     actualCall vm0 targetAddr targetHash targetCode calldata abi xGas = do
       let newContext = CallContext
@@ -2184,7 +2186,7 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
         assign #gas xGas
         assign #pc 0
         assign #code (clearInitCode targetCode)
-        assign #codeContract xTo
+        assign #codeContract targetAddr
         assign #stack mempty
         assign #memory newMemory
         assign #memorySize 0
@@ -2192,7 +2194,7 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
         assign #calldata calldata
         assign #overrideCaller Nothing
         assign #resetCaller False
-      continue xTo
+      continue targetAddr
 
 -- -- * Contract creation
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2121,7 +2121,7 @@ delegateCall this gasGiven xTo xContext xValue xInOffset xInSize xOutOffset xOut
           when resetCaller $ assign (#state % #overrideCaller) Nothing
           vm0 <- get
           fetchAccountWithFallback xTo (actualFallback xGas vm0) $ \contract -> case contract.code of
-              UnknownCode _  -> actualFallback xGas vm0 xTo
+              UnknownCode _ -> actualFallback xGas vm0 xTo
               _ -> do
                 burn' xGas $ do
                   (calldata, abi) <- getCalldataAbi

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -49,6 +49,7 @@ data Config = Config
   , maxDepth         :: Maybe Int
   , verb             :: Int
   , simp             :: Bool
+  , onlyDeployed     :: Bool
   }
   deriving (Show, Eq)
 
@@ -68,6 +69,7 @@ defaultConfig = Config
   , maxDepth = Nothing
   , verb = 0
   , simp = True
+  , onlyDeployed = False
   }
 
 -- Write to the console

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -4,13 +4,14 @@ import EVM hiding (createAddress)
 import EVM.Concrete (createAddress)
 import EVM.FeeSchedule (feeSchedule)
 import EVM.Types
+import EVM.Effects (Config)
 
 import Control.Monad.Trans.State.Strict (get, State)
 import Data.ByteString (ByteString)
 import Data.Maybe (isNothing)
 import Optics.Core
 import Control.Monad.ST (ST)
-import EVM.Effects (Config)
+import Data.Typeable (Typeable)
 
 ethrunAddress :: Addr
 ethrunAddress = Addr 0x00a329c0648769a73afac7f9381e08fb43dbea72
@@ -47,14 +48,14 @@ vmForEthrunCreation creationCode =
     }) <&> set (#env % #contracts % at (LitAddr ethrunAddress))
              (Just (initialContract (RuntimeCode (ConcreteRuntimeCode ""))))
 
-exec :: (VMOps t) => Config -> EVM t s (VMResult t s)
+exec :: (VMOps t, Typeable t) => Config -> EVM t s (VMResult t s)
 exec conf = do
   vm <- get
   case vm.result of
     Nothing -> exec1 conf >> exec conf
     Just r -> pure r
 
-run :: (VMOps t) => Config -> EVM t s (VM t s)
+run :: (VMOps t, Typeable t) => Config -> EVM t s (VM t s)
 run conf = do
   vm <- get
   case vm.result of


### PR DESCRIPTION
## Description
This code now works when passed `--only-deployed`:
```solidity
// SPDX-License-Identifier: MIT
import {Test} from "forge-std/Test.sol";

contract Stuff {
  function myfun(uint a ) public pure returns (uint) {
    unchecked {
      return a * 2;
    }
  }
}

contract MyOnlyDeployed is Test {
  Stuff stuff;
  function setUp() public {
    stuff = new Stuff();
  }

  // cast keccak "myfun(uint256)"
  // 0xb2d71d6870ba4b4e58f932901330aa9aaf5e31a65a07d4c73632529167626820
  function prove_only_deployed(uint a, address addr) public {
    (, bytes memory ret) = addr.call(abi.encodeWithSelector(0xb2d71d68, a));
    uint x = abi.decode(ret, (uint));
    assert(x == a * 2);
  }
}
```

Without `--only-deployed`:
```
[RUNNING] prove_only_deployed(uint256,address)
   [FAIL] prove_only_deployed
   [WARNING] prove_only_deployed all branches reverted
   [WARNING] hevm was only able to partially explore the test prove_only_deployed due to:
      1x -> Unexpected symbolic arguments to opcode: CALL
```

With `--only-deployed`:
```
cabal run -f devel exe:hevm -- test --root tmp --match ".*only_deployed.*" --only-deployed
Checking 1 function(s) in contract src/contract-only-deployed-contracts.sol:MyOnlyDeployed
[RUNNING] prove_only_deployed(uint256,address)
   [PASS] prove_only_deployed
```

Needs much more love:
- [ ] test cases
- [ ] review
- [ ] testing
- [ ] changelog

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
