### PR TITLE
Use maxWidth instead of hardcoded value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   more Keccak equalities.
 - Faster word256Bytes and word160Bytes functions to help concrete execution
   performance
+- Instead of using the maxWidth, a hardcoded value of 20 was used in forcing
+  an address. This has now been fixed
 
 ## Changed
 - Updated forge to 1.2.3 and forge-std to 60acb7aa (1.9.7+)

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1610,7 +1610,7 @@ forceAddr :: (?conf :: Config, VMOps t) =>
   -> (Expr EAddr -> EVM t s ())
   -> EVM t s ()
 forceAddr n fallback continue = case wordToAddr n of
-  Nothing -> manySolutions (?conf).maxDepth n 20 $ \case
+  Nothing -> manySolutions (?conf).maxDepth n (?conf).maxWidth $ \case
     Just sol -> continue $ LitAddr (truncateToAddr sol)
     Nothing -> fallback n
   Just c -> continue c
@@ -1667,7 +1667,7 @@ forceConcreteLimitSz n bytes msg continue = case maybeLitWordSimp n of
 
 forceConcreteAddr :: (?conf :: Config, VMOps t) => Expr EAddr -> String -> (Addr -> EVM t s ()) -> EVM t s ()
 forceConcreteAddr n msg continue = case maybeLitAddrSimp n of
-  Nothing -> manySolutions (?conf).maxDepth (WAddr n) 20 $ maybe fallback $ \c -> continue (truncateToAddr c)
+  Nothing -> manySolutions (?conf).maxDepth (WAddr n) (?conf).maxWidth $ maybe fallback $ \c -> continue (truncateToAddr c)
   Just c -> continue c
   where fallback = unexpectedSymArg msg [n]
 


### PR DESCRIPTION
## Description
OOps, this was some remnant of an old hardcoded value. Should use maxWidth

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
