### PR TITLE
With `--only-deployed`, only resolve addresses to deployed contracts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - Allow dumping unsolved SMT files via `--dump-unsolved`
+- Allow resolving unknown addresses to only those that are already deployed
+  via option `--only-deployed`
 
 ## Fixed
 - We now extract more Keccak computations than before from the Props to assert

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -95,6 +95,7 @@ data CommonOptions = CommonOptions
   , maxWidth      ::Int
   , maxDepth      ::Maybe Int
   , noSimplify    ::Bool
+  , onlyDeployed  ::Bool
   }
 
 commonOptions :: Parser CommonOptions
@@ -123,6 +124,7 @@ commonOptions = CommonOptions
   <*> (option auto $ long "max-width"      <> showDefault <> value 100 <> help "Max number of concrete values to explore when encountering a symbolic value. This is a form of branch width limitation per symbolic value")
   <*> (optional $ option auto $ long "max-depth" <> help "Limit maximum depth of branching during exploration (default: unlimited)")
   <*> (switch $ long "no-simplify" <> help "Don't perform simplification of expressions")
+  <*> (switch $ long "only-deployed" <> help "When trying to resolve unknown addresses, only use addresses of deployed contracts")
 
 data CommonExecOptions = CommonExecOptions
   { address       ::Maybe Addr
@@ -361,6 +363,7 @@ main = do
         , maxDepth = cOpts.maxDepth
         , verb = cOpts.verb
         , simp = Prelude.not cOpts.noSimplify
+        , onlyDeployed = cOpts.onlyDeployed
         } }
 
 

--- a/src/EVM/Effects.hs
+++ b/src/EVM/Effects.hs
@@ -50,6 +50,7 @@ data Config = Config
   , maxDepth         :: Maybe Int
   , verb             :: Int
   , simp             :: Bool
+  , onlyDeployed     :: Bool
   }
   deriving (Show, Eq)
 
@@ -70,6 +71,7 @@ defaultConfig = Config
   , maxDepth = Nothing
   , verb = 0
   , simp = True
+  , onlyDeployed = False
   }
 
 -- Write to the console

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -11,6 +11,7 @@ import Data.Maybe (isNothing)
 import Optics.Core
 import Control.Monad.ST (ST)
 import EVM.Effects (Config)
+import Data.Data (Typeable)
 
 ethrunAddress :: Addr
 ethrunAddress = Addr 0x00a329c0648769a73afac7f9381e08fb43dbea72
@@ -47,14 +48,14 @@ vmForEthrunCreation creationCode =
     }) <&> set (#env % #contracts % at (LitAddr ethrunAddress))
              (Just (initialContract (RuntimeCode (ConcreteRuntimeCode ""))))
 
-exec :: (VMOps t) => Config -> EVM t s (VMResult t s)
+exec :: (VMOps t, Typeable t) => Config -> EVM t s (VMResult t s)
 exec conf = do
   vm <- get
   case vm.result of
     Nothing -> exec1 conf >> exec conf
     Just r -> pure r
 
-run :: (VMOps t) => Config -> EVM t s (VM t s)
+run :: (VMOps t, Typeable t) => Config -> EVM t s (VM t s)
 run conf = do
   vm <- get
   case vm.result of

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -252,7 +252,7 @@ getSolutions solvers symExprPreSimp numBytes pathconditions = do
   conf <- readConfig
   liftIO $ do
     let symExpr = Expr.concKeccakSimpExpr symExprPreSimp
-    -- when conf.debug $ putStrLn $ "Collecting solutions to symbolic query: " <> show symExpr
+    when conf.debug $ putStrLn $ "Collecting solutions to symbolic query: " <> show symExpr
     ret <- collectSolutions symExpr pathconditions conf
     case ret of
       Nothing -> pure Nothing

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -252,7 +252,7 @@ getSolutions solvers symExprPreSimp numBytes pathconditions = do
   conf <- readConfig
   liftIO $ do
     let symExpr = Expr.concKeccakSimpExpr symExprPreSimp
-    when conf.debug $ putStrLn $ "Collecting solutions to symbolic query: " <> show symExpr
+    -- when conf.debug $ putStrLn $ "Collecting solutions to symbolic query: " <> show symExpr
     ret <- collectSolutions symExpr pathconditions conf
     case ret of
       Nothing -> pure Nothing

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -344,11 +344,11 @@ interpret fetcher iterConf vm =
         ends <- withRunInIO $ \runInIO -> mapConcurrently (runInIO . runOne frozen newDepth) vals
         pure $ goITE (zip vals ends)
         where
-          goITE :: [(W256, Expr End)] -> Expr End
+          goITE :: [(Expr EWord, Expr End)] -> Expr End
           goITE [] = internalError "goITE: empty list"
           goITE [(_, end)] = end
-          goITE ((val,end):ps) = ITE (Eq expr (Lit val)) end (goITE ps)
-          runOne :: App m => VM 'Symbolic RealWorld -> Int -> W256 -> m (Expr 'End)
+          goITE ((val,end):ps) = ITE (Eq expr val) end (goITE ps)
+          runOne :: App m => VM 'Symbolic RealWorld -> Int -> Expr EWord -> m (Expr 'End)
           runOne frozen newDepth v = do
             (ra, vma) <- liftIO $ stToIO $ runStateT (continue v) frozen { result = Nothing, exploreDepth = newDepth }
             interpret fetcher iterConf vma (k ra)

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -1610,13 +1610,13 @@ forceEAddrToEWord :: Expr EAddr -> Expr EWord
 forceEAddrToEWord = \case
   LitAddr a -> Lit (into a)
   SymAddr a ->  WAddr (SymAddr a)
-  _ -> internalError "Unexpected forceAddr"
+  _ -> internalError "Unexpected address type forced to EWord"
 
 forceEWordToEAddr :: Expr 'EWord -> Expr 'EAddr
 forceEWordToEAddr = \case
   Lit a -> LitAddr (truncateToAddr a)
   WAddr (SymAddr a) -> SymAddr a
-  _ -> internalError "delegateCall: expected concrete address"
+  _ -> internalError "Unexpected EWord type forced to address"
 
 -- Optics ------------------------------------------------------------------------------------------
 

--- a/test/contracts/pass/only-deployed-contracts.sol
+++ b/test/contracts/pass/only-deployed-contracts.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+import {Test} from "forge-std/Test.sol";
+
+contract Stuff {
+  function myfun(uint a ) public pure returns (uint) {
+    unchecked {
+      return a * 2;
+    }
+  }
+}
+
+contract MyOnlyDeployed is Test {
+  Stuff stuff;
+  function setUp() public {
+    stuff = new Stuff();
+  }
+
+  // cast keccak "myfun(uint256)"
+  // 0xb2d71d6870ba4b4e58f932901330aa9aaf5e31a65a07d4c73632529167626820
+  function prove_only_deployed(uint a, address addr) public {
+    (, bytes memory ret) = addr.call(abi.encodeWithSelector(0xb2d71d68, a));
+    uint x = abi.decode(ret, (uint));
+    assert(x == a * 2);
+  }
+}


### PR DESCRIPTION
## Description
Note that NOT all addresses deployed are concrete addresses! e.g. `origin` is a symbolic deployed contract.

This code now works when passed `--only-deployed`:
```solidity
// SPDX-License-Identifier: MIT
import {Test} from "forge-std/Test.sol";

contract Stuff {
  function myfun(uint a ) public pure returns (uint) {
    unchecked {
      return a * 2;
    }
  }
}

contract MyOnlyDeployed is Test {
  Stuff stuff;
  function setUp() public {
    stuff = new Stuff();
  }

  // cast keccak "myfun(uint256)"
  // 0xb2d71d6870ba4b4e58f932901330aa9aaf5e31a65a07d4c73632529167626820
  function prove_only_deployed(uint a, address addr) public {
    (, bytes memory ret) = addr.call(abi.encodeWithSelector(0xb2d71d68, a));
    uint x = abi.decode(ret, (uint));
    assert(x == a * 2);
  }
}
```

Without `--only-deployed`:
```
[RUNNING] prove_only_deployed(uint256,address)
   [FAIL] prove_only_deployed
   [WARNING] prove_only_deployed all branches reverted
   [WARNING] hevm was only able to partially explore the test prove_only_deployed due to:
      1x -> Unexpected symbolic arguments to opcode: CALL
```

With `--only-deployed`:
```
cabal run -f devel exe:hevm -- test --root tmp --match ".*only_deployed.*" --only-deployed
Checking 1 function(s) in contract src/contract-only-deployed-contracts.sol:MyOnlyDeployed
[RUNNING] prove_only_deployed(uint256,address)
   [PASS] prove_only_deployed
```

Needs much more love:
- [x] test cases
- [ ] review
- [x] testing
- [x] changelog

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
