### PR TITLE
Better error propagation in reading bytecode from JSON

### DIFF
--- a/test/clitest.hs
+++ b/test/clitest.hs
@@ -183,8 +183,8 @@ main = do
                    sstore(0, sum)
                }
            } |]
-        Just aPrgm <- yul (T.pack "") $ T.pack a
-        Just bPrgm <- yul (T.pack "") $ T.pack b
+        Right aPrgm <- yul (T.pack "") $ T.pack a
+        Right bPrgm <- yul (T.pack "") $ T.pack b
         let hexStrA = Types.bsToHex aPrgm
             hexStrB = Types.bsToHex bPrgm
         (_, stdout, _) <- readProcessWithExitCode "cabal" ["run", "exe:hevm", "--", "equivalence", "--num-solvers", "1", "--debug", "--code-a", hexStrA, "--code-b", hexStrB] ""

--- a/test/test.hs
+++ b/test/test.hs
@@ -3631,7 +3631,7 @@ tests = testGroup "hevm"
                       }
                     }
                     |]
-            Just c <- liftIO $ yulRuntime "Neg" src
+            Right c <- liftIO $ yulRuntime "Neg" src
             (res, [Qed]) <- withSolvers Z3 4 1 Nothing $ \s -> checkAssert s defaultPanicCodes c (Just (Sig "hello(address)" [AbiAddressType])) [] defaultVeriOpts
             putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
@@ -4836,7 +4836,7 @@ tests = testGroup "hevm"
           let buf = prettyBuf $ Expr.concKeccakSimpExpr def
           assertBoolM "Must start with specific string" (T.isPrefixOf "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0cf" buf)
       , test "eq-yul-simple-cex" $ do
-        Just aPrgm <- liftIO $ yul ""
+        Right aPrgm <- liftIO $ yul ""
           [i|
           {
             calldatacopy(0, 0, 32)
@@ -4846,7 +4846,7 @@ tests = testGroup "hevm"
             default { invalid() }
           }
           |]
-        Just bPrgm <- liftIO $ yul ""
+        Right bPrgm <- liftIO $ yul ""
           [i|
           {
             calldatacopy(0, 0, 32)
@@ -5492,8 +5492,8 @@ tests = testGroup "hevm"
             putStrLnM "------------- Filtered B + Symb below-----------------"
             mapM_ putStrLn filteredBSym
             putStrLnM "------------- END -----------------"
-          Just aPrgm <- liftIO $ yul "" $ T.pack $ unlines filteredASym
-          Just bPrgm <- liftIO $ yul "" $ T.pack $ unlines filteredBSym
+          Right aPrgm <- liftIO $ yul "" $ T.pack $ unlines filteredASym
+          Right bPrgm <- liftIO $ yul "" $ T.pack $ unlines filteredBSym
           procs <- liftIO $ getNumProcessors
           withSolvers CVC5 (unsafeInto procs) 1 (Just 100) $ \s -> do
             calldata <- mkCalldata Nothing []


### PR DESCRIPTION
## Description

Previously, some errors encountered when trying to read bytecode from JSON would crash hevm.
Now we propagate the error to the caller.

As part of this change I introduce strong types for possible errors and defer how exactly to report these errors to the caller.
The advantage is that different callers can decide on how to process these errors.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
