### PR TITLE
Allow verifyInputs to return partial expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow dumping unsolved SMT files via `--dump-unsolved`
 - New empty solver option that simply makes sure that all SMT queries return
   unknown
+- Allow `verifyInputs` to return partial expressions
 
 ## Fixed
 - We now extract more Keccak computations than before from the Props to assert

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -648,14 +648,14 @@ printPartialIssues flattened call =
   when (any isPartial flattened) $ do
     T.putStrLn $ indent 3 "\x1b[33m[WARNING]\x1b[0m: hevm was only able to partially explore "
                 <> T.pack call <> " due to the following issue(s):"
-    T.putStr . T.unlines . fmap (indent 5 . ("- " <>)) . fmap formatPartial . getPartials $ flattened
+    T.putStr . T.unlines . fmap (indent 5 . ("- " <>)) . fmap formatPartial . (map fst) . getPartials $ flattened
 
-getPartials :: [Expr End] -> [PartialExec]
+getPartials :: [Expr End] -> [(PartialExec, Expr End)]
 getPartials = mapMaybe go
   where
-    go :: Expr End -> Maybe PartialExec
+    go :: Expr End -> Maybe (PartialExec, Expr End)
     go = \case
-      Partial _ _ p -> Just p
+      e@(Partial _ _ p) -> Just (p, e)
       _ -> Nothing
 
 -- | Symbolically execute the VM and check all endstates against the
@@ -690,7 +690,7 @@ verifyInputs
   -> Fetch.Fetcher Symbolic m RealWorld
   -> VM Symbolic RealWorld
   -> Maybe (Postcondition RealWorld)
-  -> m (Expr End, [(SMTResult, Expr End)], [PartialExec])
+  -> m (Expr End, [(SMTResult, Expr End)], [(PartialExec, Expr End)])
 verifyInputs solvers opts fetcher preState maybepost = do
   conf <- readConfig
   let call = mconcat ["prefix 0x", getCallPrefix preState.state.calldata]


### PR DESCRIPTION
## Description

`verifyInputs` only returns the partial execution datatype, but not the collected expression. This PR allow the caller to handle these expressions

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
