### PR TITLE
Added missing assert condition to catch failures in solc < 0.8

### DIFF
--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -509,6 +509,7 @@ getExpr solvers c signature' concreteArgs opts = do
 -}
 checkAssertions :: [Word256] -> Postcondition s
 checkAssertions errs _ = \case
+  Failure _ _ (UnrecognizedOpcode 0xfe)  -> PBool False
   Failure _ _ (Revert (ConcreteBuf msg)) -> PBool $ msg `notElem` (fmap panicMsg errs)
   Failure _ _ (Revert b) -> foldl' PAnd (PBool True) (fmap (PNeg . PEq b . ConcreteBuf . panicMsg) errs)
   _ -> PBool True


### PR DESCRIPTION
## Description
This condition is needed to catch assertions failures when using solc strictly below 0.8. It is even part of the documentation of checkAssertions but it was missing. 

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
