### PR TITLE
Mapping back of warnings to lines of code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New empty solver option that simply makes sure that all SMT queries return
   unknown
 - Allow `verifyInputs` to return partial expressions
+- We now map back (add,pc) warnings to lines of source code
 
 ## Fixed
 - We now extract more Keccak computations than before from the Props to assert

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -333,7 +333,7 @@ main = do
           Right out -> do
             -- TODO: which functions here actually require a BuildOutput, and which can take it as a Maybe?
             unitTestOpts <- liftIO $ unitTestOptions testOpts cOpts solvers (Just out)
-            res <- unitTest unitTestOpts out.contracts
+            res <- unitTest unitTestOpts out
             liftIO $ unless (uncurry (&&) res) exitFailure
     Exec cFileOpts execOpts cExecOpts cOpts-> do
       env <- makeEnv cOpts
@@ -415,7 +415,7 @@ equivalence eqOpts cOpts = do
       (False, False) -> putStrLn "   \x1b[32m[PASS]\x1b[0m Contracts behave equivalently"
       (True, _)      -> putStrLn "   \x1b[31m[FAIL]\x1b[0m Contracts do not behave equivalently"
       (_, True)      -> putStrLn "   \x1b[31m[FAIL]\x1b[0m Contracts may not behave equivalently"
-    liftIO $ printWarnings eq.partials (map fst eq.res) "the contracts under test"
+    liftIO $ printWarnings Nothing eq.partials (map fst eq.res) "the contracts under test"
     case any (isCex . fst) eq.res of
       False -> liftIO $ do
         when anyIssues exitFailure
@@ -527,7 +527,7 @@ symbCheck cFileOpts sOpts cExecOpts cOpts = do
                  , ""
                  ] <> fmap (formatCex (fst calldata) Nothing) cexs
         liftIO $ T.putStrLn $ T.unlines counterexamples
-        liftIO $ printWarnings [expr] res "symbolically"
+        liftIO $ printWarnings Nothing [expr] res "symbolically"
         showExtras solvers sOpts calldata expr
         liftIO exitFailure
 

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1380,7 +1380,7 @@ runBoth depthLimit exploreDepth c = do
     assign #result $ Just $ HandleEffect (RunBoth c)
   else do
     vm <- get
-    assign #result $ Just $ Unfinished (BranchTooDeep {pc = vm.state.pc})
+    assign #result $ Just $ Unfinished (BranchTooDeep {pc = vm.state.pc, addr = vm.state.contract})
 
 runAll :: Maybe Int -> Int -> RunAll s -> EVM Symbolic s ()
 runAll depthLimit exploreDepth c = do
@@ -1388,7 +1388,7 @@ runAll depthLimit exploreDepth c = do
     assign #result $ Just $ HandleEffect (RunAll c)
   else do
     vm <- get
-    assign #result $ Just $ Unfinished (BranchTooDeep {pc = vm.state.pc})
+    assign #result $ Just $ Unfinished (BranchTooDeep {pc = vm.state.pc, addr = vm.state.contract})
 
 fetchAccount :: VMOps t => Expr EAddr -> (Contract -> EVM t s ()) -> EVM t s ()
 fetchAccount addr continue =
@@ -1642,7 +1642,7 @@ unexpectedSymArg msg n = do
   pc <- use (#state % #pc)
   state <- use #state
   let opName = getOpName state
-  partial $ UnexpectedSymbolicArg pc opName msg (wrap n)
+  partial $ UnexpectedSymbolicArg pc state.contract opName msg (wrap n)
 
 unexpectedSymArgW :: (Typeable a, VMOps t) => String -> Expr a -> EVM t s ()
 unexpectedSymArgW msg n = unexpectedSymArg msg [n]
@@ -1794,7 +1794,7 @@ cheat gas (inOffset, inSize) (outOffset, outSize) xs = do
       case Map.lookup abi' cheatActions of
         Nothing -> do
           vm <- get
-          partial $ CheatCodeMissing vm.state.pc abi'
+          partial $ CheatCodeMissing vm.state.pc vm.state.contract abi'
         Just action -> action input
 
 type CheatAction t s = Expr Buf -> EVM t s ()
@@ -2495,6 +2495,7 @@ finishFrame how = do
                     Nothing -> partial $
                       UnexpectedSymbolicArg
                         oldVm.state.pc
+                        oldVm.state.contract
                         (getOpName oldVm.state)
                         "runtime code cannot have an abstract length"
                         (wrap [output])
@@ -2757,7 +2758,7 @@ noJumpIntoInitData idx cont = do
     -- init code has a symbolic region, so check if we're trying to jump into
     -- the symbolic region and return partial if we are
     InitCode ops _ -> if idx > BS.length ops
-                      then partial $ JumpIntoSymbolicCode vm.state.pc idx
+                      then partial $ JumpIntoSymbolicCode vm.state.pc vm.state.contract idx
                       else cont
     -- we're not executing init code, so nothing to check here
     _ -> cont

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -4,7 +4,7 @@ module EVM.Format
   ( formatExpr
   , formatSomeExpr
   , formatPartial
-  , formatPartialShort
+  , formatPartialDetailed
   , formatProp
   , formatState
   , formatError
@@ -40,7 +40,7 @@ import EVM (traceForest, traceForest', traceContext, cheatCode)
 import EVM.ABI (getAbiSeq, parseTypeName, AbiValue(..), AbiType(..), SolError(..), Indexed(..), Event(..))
 import EVM.Dapp (DappContext(..), DappInfo(..), findSrc, showTraceLocation)
 import EVM.Expr qualified as Expr
-import EVM.Solidity (SolcContract(..), Method(..))
+import EVM.Solidity (SolcContract(..), Method(..), SrcMap (..), WarningData (..), SourceCache(..))
 import EVM.Types
 import EVM.Expr (maybeLitWordSimp, maybeLitAddrSimp)
 
@@ -68,6 +68,8 @@ import Data.Vector (Vector)
 import Hexdump (prettyHex)
 import Numeric (showHex)
 import Witch (into, unsafeInto, tryFrom)
+import Data.Vector.Storable qualified as VS
+import Data.Sequence qualified as Seq
 
 data Signedness = Signed | Unsigned
   deriving (Show)
@@ -467,32 +469,70 @@ formatError = \case
 
 formatPartial :: PartialExec -> Text
 formatPartial = \case
-  UnexpectedSymbolicArg pc opcode msg args -> T.unlines
-    [ "Unexpected Symbolic Arguments to Opcode"
+  UnexpectedSymbolicArg pc addr opcode msg args -> T.unlines
+    [ "Unexpected symbolic arguments to opcode."
     , indent 2 $ T.unlines
       [ "msg: " <> T.pack (show msg)
-      , "opcode: " <> T.pack opcode
+      , "contract addr: " <> pack (show addr)
       , "program counter: " <> T.pack (show pc)
+      , "opcode: " <> T.pack opcode
       , "arguments: "
       , indent 2 $ T.unlines . fmap formatSomeExpr $ args
       ]
     ]
-  MaxIterationsReached pc addr -> "Max Iterations Reached in contract: " <> formatAddr addr <> " pc: " <> pack (show pc) <> " To increase the maximum, set a fixed large (or negative) value for `--max-iterations` on the command line"
-  JumpIntoSymbolicCode pc idx -> "Encountered a jump into a potentially symbolic code region while executing initcode. pc: " <> pack (show pc) <> " jump dst: " <> pack (show idx)
-  CheatCodeMissing pc selector ->T.unlines
-    [ "Cheat code not recognized"
-    , "program counter: " <> T.pack (show pc)
-    , "function selector: " <> T.pack (show selector)
+  MaxIterationsReached pc addr -> T.unlines
+    ["Max iterations reached."
+    , indent 2 $ T.unlines
+      [ "contract addr: " <> T.pack (show addr)
+      , "program counter: " <> T.pack (show pc)
+      ]
     ]
-  BranchTooDeep pc -> T.unlines ["Branches too deep at program counter: " <> pack (show pc)]
+  JumpIntoSymbolicCode pc addr idx -> T.unlines
+    ["Encountered a jump into a symbolic code region."
+    , indent 2 $ T.unlines
+      [ "contract addr: " <> T.pack (show addr)
+      , "program counter: " <> T.pack (show pc)
+      , "jump dst: " <> pack (show idx)
+      ]
+    ]
+  CheatCodeMissing pc addr selector -> T.unlines
+    [ "Cheat code not recognized."
+    , indent 2 $ T.unlines
+      [ "contract addr: " <> T.pack (show addr)
+      , "program counter: " <> T.pack (show pc)
+      , "function selector: " <> T.pack (show selector)
+      ]
+    ]
+  BranchTooDeep pc addr -> T.unlines
+    ["Branch too deep."
+    , indent 2 $ T.unlines
+      [ "contract addr: " <> pack (show addr)
+      , "program counter: " <> pack (show pc)]
+    ]
 
-formatPartialShort :: PartialExec -> Text
-formatPartialShort = \case
-  UnexpectedSymbolicArg _ opcode _ _ -> "Unexpected symbolic arguments to opcode: " <> T.pack opcode
-  MaxIterationsReached {}            -> "Max iterations reached"
-  JumpIntoSymbolicCode {}            -> "Encountered a jump into a potentially symbolic code region while executing initcode"
-  CheatCodeMissing _ selector        -> "Cheat code not recognized: " <> T.pack (show selector)
-  BranchTooDeep pc                   -> "Branches too deep at program counter: " <> pack (show pc)
+formatPartialDetailed :: Maybe (WarningData s t) -> PartialExec -> Text
+formatPartialDetailed warnData p =
+  let toTxt addr pc = pack $ getSrcInfo warnData addr pc
+  in case p of
+    UnexpectedSymbolicArg {..} -> "Unexpected symbolic arguments to opcode: " <> T.pack opcode <> toTxt addr pc
+    MaxIterationsReached {..}  -> "Max iterations reached" <> toTxt addr pc
+    JumpIntoSymbolicCode {..}  -> "Encountered a jump into a symbolic code" <> toTxt addr pc
+    CheatCodeMissing {..}      -> "Cheat code not recognized: " <> T.pack (show selector) <> toTxt addr pc
+    BranchTooDeep {..}         -> "Branches too deep" <> toTxt addr pc
+
+getSrcInfo :: Maybe (WarningData s t) -> Expr EAddr -> Int -> String
+getSrcInfo Nothing addr pc = " at addr: " <> show addr <> " at pc: " <> show pc
+getSrcInfo (Just dat) addr pc = fromMaybe (getSrcInfo Nothing addr pc) $ do
+  contr <- Map.lookup addr dat.vm.env.contracts
+  pcOp <- contr.opIxMap VS.!? pc
+  sMap <- Seq.lookup pcOp dat.solcContr.runtimeSrcmap
+  (fname, fcontent) <- Map.lookup sMap.file dat.sourceCache.files
+  let eols = BS.count 10 $ BS.take sMap.offset fcontent  -- 10 is \n
+  let str = " in file \"" <> fname <> "\" on line " <> show (eols+1)
+  case (BS.length fcontent > (sMap.offset + sMap.length)) of
+    False -> pure str
+    True  -> let relevant = BS.take sMap.length $ BS.drop sMap.offset fcontent
+      in pure $ str <> " : " <> show relevant
 
 formatSomeExpr :: SomeExpr -> Text
 formatSomeExpr (SomeExpr e) = formatExpr $ Expr.simplify e

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -38,7 +38,7 @@ import EVM.ABI
 import EVM.Effects
 import EVM.Expr qualified as Expr
 import EVM.FeeSchedule (feeSchedule)
-import EVM.Format (formatExpr, formatPartial, formatPartialShort, showVal, indent, formatBinary, formatProp, formatState, formatError)
+import EVM.Format (formatExpr, formatPartial, formatPartialDetailed, showVal, indent, formatBinary, formatProp, formatState, formatError)
 import EVM.SMT qualified as SMT
 import EVM.Solvers
 import EVM.Stepper (Stepper)
@@ -53,6 +53,7 @@ import Optics.Core
 import Options.Generic (ParseField, ParseFields, ParseRecord)
 import Text.Printf (printf)
 import Witch (into, unsafeInto)
+import EVM.Solidity (WarningData (..))
 
 data LoopHeuristic
   = Naive
@@ -68,11 +69,11 @@ groupIssues results = map (\g -> (into (length g), NE.head g)) grouped
     getIssue _ = Nothing
     grouped = NE.group $ sort $ mapMaybe getIssue results
 
-groupPartials :: [Expr End] -> [(Integer, String)]
-groupPartials e = map (\g -> (into (length g), NE.head g)) grouped
+groupPartials :: Maybe (WarningData s t) -> [Expr End] -> [(Integer, String)]
+groupPartials warnData e = map (\g -> (into (length g), NE.head g)) grouped
   where
     getPartial :: Expr End -> Maybe String
-    getPartial (Partial _ _ reason) = Just $ T.unpack $ formatPartialShort reason
+    getPartial (Partial _ _ reason) = Just $ T.unpack $ formatPartialDetailed warnData reason
     getPartial _ = Nothing
     grouped = NE.group $ sort $ mapMaybe getPartial e
 

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -587,11 +587,11 @@ evmErrToString = \case
 
 -- | Sometimes we can only partially execute a given program
 data PartialExec
-  = UnexpectedSymbolicArg { pc :: Int, opcode :: String, msg  :: String, args  :: [SomeExpr] }
+  = UnexpectedSymbolicArg { pc :: Int, addr :: Expr EAddr, opcode :: String, msg  :: String, args  :: [SomeExpr] }
   | MaxIterationsReached  { pc :: Int, addr :: Expr EAddr }
-  | JumpIntoSymbolicCode  { pc :: Int, jumpDst :: Int }
-  | CheatCodeMissing      { pc :: Int, selector :: FunctionSelector }
-  | BranchTooDeep         { pc :: Int}
+  | JumpIntoSymbolicCode  { pc :: Int, addr :: Expr EAddr, jumpDst :: Int }
+  | CheatCodeMissing      { pc :: Int, addr :: Expr EAddr, selector :: FunctionSelector }
+  | BranchTooDeep         { pc :: Int, addr :: Expr EAddr}
   deriving (Show, Eq, Ord)
 
 -- | Effect types used by the vm implementation for side effects & control flow
@@ -775,7 +775,7 @@ data FrameState (t :: VMType) s = FrameState
   { contract     :: Expr EAddr
   , codeContract :: Expr EAddr
   , code         :: ContractCode
-  , pc           :: {-# UNPACK #-} !Int
+  , pc           :: {-# UNPACK #-} !Int -- program counter in BYTES (not ops). PUSH ops will increment pc by more than 1
   , stack        :: [Expr EWord]
   , memory       :: Memory s
   , memorySize   :: Word64
@@ -847,7 +847,7 @@ data Contract = Contract
   , balance     :: Expr EWord
   , nonce       :: Maybe W64
   , codehash    :: Expr EWord
-  , opIxMap     :: VS.Vector Int
+  , opIxMap     :: VS.Vector Int -- ^ map from byte index to op index
   , codeOps     :: V.Vector (Int, Op)
   , external    :: Bool
   }

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -115,15 +115,15 @@ makeVeriOpts opts =
 
 -- | Top level CLI endpoint for hevm test
 -- | Returns tuple of (No Cex, No warnings)
-unitTest :: App m => UnitTestOptions RealWorld -> Contracts -> m (Bool, Bool)
-unitTest opts (Contracts cs) = do
+unitTest :: App m => UnitTestOptions RealWorld -> BuildOutput -> m (Bool, Bool)
+unitTest opts bo@(BuildOutput (Contracts cs) _) = do
   let unitTestContrs = findUnitTests opts.prefix opts.match $ Map.elems cs
   conf <- readConfig
   when conf.debug $ liftIO $ do
     putStrLn $ "Found " ++ show (length unitTestContrs) ++ " unit test contract(s) to test:"
     let x = map (\(a,b) -> "  --> " <> a <> "  ---  functions: " <> (Text.pack $ show b)) unitTestContrs
     putStrLn $ unlines $ map Text.unpack x
-  results <- concatMapM (runUnitTestContract opts cs) unitTestContrs
+  results <- concatMapM (runUnitTestContract opts bo) unitTestContrs
   when conf.debug $ liftIO $ putStrLn $ "unitTest individual results: " <> show results
   let (firsts, seconds) = unzip results
   pure (and firsts, and seconds)
@@ -163,22 +163,22 @@ initializeUnitTest opts theContract = do
 runUnitTestContract
   :: App m
   => UnitTestOptions RealWorld
-  -> Map Text SolcContract
+  -> BuildOutput
   -> (Text, [Sig])
   -> m [(Bool, Bool)]
 runUnitTestContract
-  opts@(UnitTestOptions {..}) contractMap (name, testSigs) = do
+  opts@(UnitTestOptions {..}) buildOut (name, testSigs) = do
   liftIO $ putStrLn $ "Checking " ++ show (length testSigs) ++ " function(s) in contract " ++ unpack name
 
   -- Look for the wanted contract by name from the Solidity info
-  case Map.lookup name contractMap of
+  case Map.lookup name (getContractsMap buildOut.contracts) of
     Nothing -> internalError $ "Contract " ++ unpack name ++ " not found"
-    Just theContract -> do
+    Just solcContr -> do
       -- Construct the initial VM and begin the contract's constructor
-      vm0 :: VM Concrete RealWorld <- liftIO $ stToIO $ initialUnitTestVm opts theContract
+      vm0 :: VM Concrete RealWorld <- liftIO $ stToIO $ initialUnitTestVm opts solcContr
       vm1 <- Stepper.interpret (Fetch.oracle solvers rpcInfo) vm0 $ do
         Stepper.enter name
-        initializeUnitTest opts theContract
+        initializeUnitTest opts solcContr
         Stepper.evm get
 
       writeTraceDapp dapp vm1
@@ -189,13 +189,13 @@ runUnitTestContract
           tick $ indentLines 3 failOut
           pure [(True, False)]
         Just (VMSuccess _) -> do
-          forM testSigs $ \s -> symRun opts vm1 s
+          forM testSigs $ \s -> symRun opts vm1 s solcContr buildOut.sources
         _ -> internalError "setUp() did not end with a result"
 
 -- Define the thread spawner for symbolic tests
 -- Returns tuple of (No Cex, No warnings)
-symRun :: App m => UnitTestOptions RealWorld -> VM Concrete RealWorld -> Sig -> m (Bool, Bool)
-symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
+symRun :: App m => UnitTestOptions RealWorld -> VM Concrete RealWorld -> Sig -> SolcContract -> SourceCache -> m (Bool, Bool)
+symRun opts@UnitTestOptions{..} vm (Sig testName types) solcContr sourceCache = do
     let callSig = testName <> "(" <> (Text.intercalate "," (map abiTypeSolidity types)) <> ")"
     liftIO $ putStrLn $ "\x1b[96m[RUNNING]\x1b[0m " <> Text.unpack callSig
     cd <- symCalldata callSig types [] (AbstractBuf "txdata")
@@ -266,7 +266,8 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
     when (unexpectedAllRevert && (warnings || (any isCex results))) $ do
       -- if we display a FAILED due to Cex/warnings, we should also mention everything reverted
       liftIO $ putStrLn $ "   \x1b[33m[WARNING]\x1b[0m " <> Text.unpack testName <> " all branches reverted\n"
-    liftIO $ printWarnings ends results t
+    let warnData = Just $ WarningData solcContr sourceCache vm'
+    liftIO $ printWarnings warnData ends results t
     pure (not (any isCex results), not (warnings || unexpectedAllRevert))
     where
       -- The offset of the text is: the selector (4B), the offset value (aligned to 32B), and the length of the string (aligned to 32B)
@@ -294,13 +295,13 @@ symRun opts@UnitTestOptions{..} vm (Sig testName types) = do
               lhs = LitByte (c2w a)
               rhs = Expr.readByte (Lit (fromIntegral n)) b
 --
-printWarnings :: GetUnknownStr b => [Expr 'End] -> [ProofResult a b] -> String -> IO ()
-printWarnings e results testName = do
+printWarnings :: Maybe (WarningData s t) -> GetUnknownStr b => [Expr 'End] -> [ProofResult a b] -> String -> IO ()
+printWarnings warnData e results testName = do
   when (any isUnknown results || any isError results || any Expr.isPartial e) $ do
     putStrLn $ "   \x1b[33m[WARNING]\x1b[0m hevm was only able to partially explore " <> testName <> " due to: ";
     forM_ (groupIssues (filter isError results)) $ \(num, str) -> putStrLn $ "      " <> show num <> "x -> " <> str
     forM_ (groupIssues (filter isUnknown results)) $ \(num, str) -> putStrLn $ "      " <> show num <> "x -> " <> str
-    forM_ (groupPartials e) $ \(num, str) -> putStrLn $ "      " <> show num <> "x -> " <> str
+    forM_ (groupPartials warnData e) $ \(num, str) -> putStrLn $ "      " <> show num <> "x -> " <> str
   putStrLn ""
 
 symFailure :: App m => UnitTestOptions RealWorld -> Text -> Expr Buf -> [AbiType] -> [(Expr End, SMTCex)] -> m Text

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -36,10 +36,10 @@ runSolidityTestCustom testFile match timeout maxIter ffiAllowed rpcinfo projectT
         putStrLn e
         internalError $ "Error compiling test file " <> show testFile <> " in directory "
           <> show root <> " using project type " <> show projectType
-      Right bo@(BuildOutput contracts _) -> do
+      Right buildOut -> do
         withSolvers Bitwuzla 3 1 timeout $ \solvers -> do
-          opts <- liftIO $ testOpts solvers root (Just bo) match maxIter ffiAllowed rpcinfo
-          unitTest opts contracts
+          opts <- liftIO $ testOpts solvers root (Just buildOut) match maxIter ffiAllowed rpcinfo
+          unitTest opts buildOut
 
 -- Returns tuple of (No cex, No warnings)
 runSolidityTest

--- a/test/test.hs
+++ b/test/test.hs
@@ -1880,7 +1880,7 @@ tests = testGroup "hevm"
         let sig = (Just $ Sig "foo(address,uint256)" [AbiAddressType, AbiUIntType 256])
         (e, res) <- withDefaultSolver $
           \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
-        liftIO $ printWarnings [e] res "the contracts under test"
+        liftIO $ printWarnings Nothing [e] res "the contracts under test"
         assertEqualM "Must be QED" res [Qed]
     , test "extcodesize-symbolic2" $ do
         Just c <- solcRuntime "C"
@@ -1898,7 +1898,7 @@ tests = testGroup "hevm"
         let sig = (Just $ Sig "foo(address,uint256)" [AbiAddressType, AbiUIntType 256])
         (e, res@[Cex _]) <- withDefaultSolver $
           \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
-        liftIO $ printWarnings [e] res "the contracts under test"
+        liftIO $ printWarnings Nothing [e] res "the contracts under test"
     , test "jump-into-symbolic-region" $ do
         let
           -- our initCode just jumps directly to the end
@@ -1931,7 +1931,7 @@ tests = testGroup "hevm"
           let iterConf = IterConfig {maxIter=Nothing, askSmtIters=1, loopHeuristic=StackBased }
           expr <- Expr.simplify <$> interpret (Fetch.oracle s Nothing) iterConf vm runExpr
           case expr of
-            Partial _ _ (JumpIntoSymbolicCode _ _) -> assertBoolM "" True
+            Partial _ _ (JumpIntoSymbolicCode _ _ _) -> assertBoolM "" True
             _ -> assertBoolM "did not encounter expected partial node" False
     ]
   , testGroup "Dapp-Tests"


### PR DESCRIPTION
## Description
Draft. Needs cleanup etc. 

With this PR, we can map back warnings to lines of code:
```
[FAIL] prove_maxiters_fail
[WARNING] hevm was only able to partially explore the test prove_maxiters_fail due to:
       2x -> Max iterations reached in file "src/contract-maxiters.sol" on line 16 at: "for(uint256 i = 0; i < k; i++) balance += k*1000"
```

## Checklist
- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
