### PR TITLE
Explicit last case in ForkMany

### DIFF
--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -346,7 +346,7 @@ interpret fetcher iterConf vm =
         where
           goITE :: [(Expr EWord, Expr End)] -> Expr End
           goITE [] = internalError "goITE: empty list"
-          goITE [(_, end)] = end
+          goITE [(val, end)] = ITE (Eq expr val) end end
           goITE ((val,end):ps) = ITE (Eq expr val) end (goITE ps)
           runOne :: App m => VM 'Symbolic RealWorld -> Int -> Expr EWord -> m (Expr 'End)
           runOne frozen newDepth v = do


### PR DESCRIPTION
## Description
Not sure if this is the right fix, but I was getting nonsensical reports since the `val` in the last case is never used. This is a problem when `onlyDeployed` is true, as it seems that the last address from the list of possible ones is never included in any constraint and therefore, the solver has no way to know it. 🤔 

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
