### PR TITLE
Fixing github page publishing via SSH deploy key

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,3 +22,4 @@ jobs:
         with:
           branch: gh-pages
           folder: doc/book
+          ssh-key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
## Description
The old GitHub organization allowed actions to push to the repository. This is a global setting. With argotorg, we don't allow this, Actions can only read: https://github.com/argotorg/hevm/settings/actions (notice that actions can only read, and this cannot be changed)

This means that our page generation has been failing -- no publishing to hevm.dev has been successful since. The way to fix it is to add an SSH deployment key: https://github.com/JamesIves/github-pages-deploy-action This can be done via: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys I have done this, and added a DEPLOY_KEY secret.

Thanks to @clonker for the help!

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [x] updated the docs
- [ ] updated the changelog
