### PR TITLE
ABI: Do not add extra constraints for symbolic arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The printed expressions when running in `symbolic` mode are now simplified
 - The printed reachable expression is now simplified
 - hevm and solidity has been moved to under github.com/argotorg
+- Extra range constraints for ABI symbolic types are no longer added. They are
+  not needed as they are enforced in the bytecode.
 
 ## [0.55.1] - 2025-07-22
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1691,9 +1691,6 @@ containsNode p = getAny . foldExpr go (Any False)
 inRange :: Int -> Expr EWord -> Prop
 inRange sz e = if sz == 256 then PBool True else PLEq e (Lit $ 2 ^ sz - 1)
 
-inRangeSigned :: Int -> Expr EWord -> Prop
-inRangeSigned sz e = ((PLEq e (Lit $ 2 ^ (sz - 1) - 1)) `POr` (PGEq e $ Lit $ ((2 ^ sz) - 2 ^ (sz -  1))))
-
 -- | images of keccak(bytes32(x)) where 0 <= x < 256
 preImages :: [(W256, Word8)]
 preImages = [(keccak' (word256Bytes . into $ i), i) | i <- [0..255]]

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -112,26 +112,23 @@ extractCex :: VerifyResult -> Maybe (Expr End, SMTCex)
 extractCex (Cex c) = Just c
 extractCex _ = Nothing
 
-bool :: Expr EWord -> Prop
-bool e = POr (PEq (Lit 1) e) (PEq (Lit 0) e)
 
 -- | Abstract calldata argument generation
 symAbiArg :: Text -> AbiType -> CalldataFragment
 symAbiArg name = \case
   AbiUIntType n ->
     if n `mod` 8 == 0 && n <= 256
-    then St [Expr.inRange n v] v
+    then St [] v
     else internalError "bad type"
   AbiIntType n ->
     if n `mod` 8 == 0 && n <= 256
-    -- TODO: is this correct?
-    then St [Expr.inRangeSigned n v] v
+    then St [] v
     else internalError "bad type"
-  AbiBoolType -> St [bool v] v
+  AbiBoolType -> St [] v
   AbiAddressType -> St [] (WAddr (SymAddr name))
   AbiBytesType n ->
     if n > 0 && n <= 32
-    then St [Expr.inRange (n * 8) v] v
+    then St [] v
     else internalError "bad type"
   AbiArrayType sz tps -> do
     Comp . V.toList . V.imap (\(T.pack . show -> i) tp -> symAbiArg (name <> "-a-" <> i) tp) $ (V.replicate sz tps)

--- a/test/test.hs
+++ b/test/test.hs
@@ -1159,6 +1159,40 @@ tests = testGroup "hevm"
         assertEqualM "number of counterexamples" 1 numCexes
         assertEqualM "number of errors" 0 numErrs
         assertEqualM "number of qed-s" 0 numQeds
+    , test "signed-int8-range" $ do
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function fun(int8 x) public {
+              int256 y = x;
+              assert (y != 1000);
+            }
+          } |]
+        let sig = Just $ Sig "fun(int8)" [AbiIntType 8]
+        (e, ret) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+        assertBoolM "The expression must not be partial" $ not (Expr.containsNode isPartial e)
+        let numCexes = sum $ map (fromEnum . isCex) ret
+        let numErrs = sum $ map (fromEnum . isError) ret
+        let numQeds = sum $ map (fromEnum . isQed) ret
+        assertEqualM "number of counterexamples" 0 numCexes
+        assertEqualM "number of errors" 0 numErrs
+        assertEqualM "number of qed-s" 1 numQeds
+    , test "unsigned-int8-range" $ do
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function fun(uint8 x) public {
+              uint256 y = x;
+              assert (y != 1000);
+            }
+          } |]
+        let sig = Just $ Sig "fun(uint8)" [AbiUIntType 8]
+        (e, ret) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c sig [] defaultVeriOpts
+        assertBoolM "The expression must not be partial" $ not (Expr.containsNode isPartial e)
+        let numCexes = sum $ map (fromEnum . isCex) ret
+        let numErrs = sum $ map (fromEnum . isError) ret
+        let numQeds = sum $ map (fromEnum . isQed) ret
+        assertEqualM "number of counterexamples" 0 numCexes
+        assertEqualM "number of errors" 0 numErrs
+        assertEqualM "number of qed-s" 1 numQeds
     , test "negative-numbers-zero-comp" $ do
         Just c <- solcRuntime "C" [i|
             contract C {


### PR DESCRIPTION
## Description

The extra constraints are not necessary because the proper range should be enforced directly in the bytecode.
Moreover, the constraints added by `inRangeSigned` were equivalent to `True` anyway.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
