### PR TITLE
Expr: Fix collecting reads from abstract storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   threads of the symbolic execution
 - During running in --only-deployed mode, we forgot to force the address
   in the constraints to be the one we computed it to be. Fixed.
+- We now properly collect all storage reads from the program and build
+  a proper counterexample. Previously, some information might have been missing.
 
 ## Changed
 - Updated forge to 1.2.3 and forge-std to 60acb7aa (1.9.7+)


### PR DESCRIPTION
## Description

Previously, we would lose some storage reads, because `foldProp` uses `<>` to join the results and the implementation for Map discards the value from the second map if both maps have entries with the same key. That's not the behaviour we want, we need to take the set union.

The proposed solution is to use a wrapper type (`newtype`) for which we implement our own operation `<>`.

Fixes #880.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
