### PR TITLE
ci: windows: pin runner to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,8 +89,8 @@ jobs:
         run: nix develop --command bash -c "cabal --active-repositories=:none run cli-test"
 
   build-windows:
-    name: build (windows-latest)
-    runs-on: windows-latest
+    name: build (windows-2022)
+    runs-on: windows-2022
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
## Description

windows-2025 runners appear to fail. Pin to windows-2022 until it can be investigated further.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
