### PR TITLE
Fix incorrect prop simplification involving comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## Fixed
+- Fix incorrect simplification rule for `PEq (Lit 1) (IsZero (LT a b))`
+
 ## [0.56.0] - 2025-10-13
 
 ## Added

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1383,8 +1383,8 @@ simplifyProp prop =
     go (PEq (Lit 0) (Or a b)) = peq (Lit 0) a `PAnd` peq (Lit 0) b
 
     -- PEq rewrites (notice -- GT/GEq is always rewritten to LT by simplify)
-    go (PEq (Lit 1) (IsZero (LT a b))) = PLT a b
-    go (PEq (Lit 1) (IsZero (LEq a b))) = PLEq a b
+    go (PEq (Lit 1) (IsZero (LT a b))) = PLEq b a
+    go (PEq (Lit 1) (IsZero (LEq a b))) = PLT b a
     go (PEq (Lit 0) (IsZero a)) = PLT (Lit 0) a
     go (PEq a1 (Add a2 y)) | a1 == a2 = peq (Lit 0) y
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -662,6 +662,12 @@ tests = testGroup "hevm"
         e2 = ConcreteBuf "Definitely not the same!"
       equal <- checkEquiv e1 e2
       assertBoolM "Should not be equivalent!" $ not equal
+    , testNoSimplify "simplify-comparison-GEq" $ do
+      let
+        expr = PEq (Lit 0x1) (GEq (Var "v") (Lit 0x2))
+        simp = Expr.simplifyProp expr
+      ret <- checkEquivPropAndLHS expr simp
+      assertEqualM "Must be equivalent" True ret
     ]
   -- These tests fuzz the simplifier by generating a random expression,
   -- applying some simplification rules, and then using the smt encoding to


### PR DESCRIPTION
## Description
Currently, the expression `GEq (Var "v") (Lit 0x2)` is rewritten to `IsZero (LT (Var "v") (Lit 0x2))`.

Then, in `simplifyProp`, this rewriting was triggered: `go (PEq (Lit 1) (IsZero (LT a b))) = PLT a b`.

However, this rewriting is incorrect, the result should be `PGEq a b`, or equivalently `PLEq b a`.
We prefer the latter because comparisons on prop level are rewritten in terms of `PLT` and `PLEq` anyway.

Same reasoning can be applied for the other rule,
`go (PEq (Lit 1) (IsZero (LEq a b))) = PLEq a b`,
The result should be `PGT a b`, or equivalently, `PLT b a`. Note however, that this rule seems to be redundant currently, as the inner expression rewriting always rewrites `IsZero (LEq a b)` to `LT b a`.

Fixes #898.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
