### PR TITLE
SymEx: Always require postcondition in verify* methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - Replaced RPC mocking by a full block cache support. This allows users to cache responses from an RPC
   node via `--cache-dir dir`.
+- Changed `verify*` methods to always require postcodition.
 
 ## [0.56.0] - 2025-10-13
 

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -522,7 +522,7 @@ symbCheck cFileOpts sOpts cExecOpts cOpts = do
                             , rpcInfo = mempty {Fetch.blockNumURL = blockUrlInfo}
                             }
     let fetcher = Fetch.oracle solvers (Just sess) veriOpts.rpcInfo
-    (expr, res) <- verify solvers fetcher veriOpts preState (Just $ checkAssertions errCodes)
+    (expr, res) <- verify solvers fetcher veriOpts preState (checkAssertions errCodes)
     liftIO $ forM_ ((,) <$> cOpts.cacheDir <*> cExecOpts.block) $ \(dir, block) -> do
       cache <- readMVar sess.sharedCache
       Fetch.saveCache dir block cache

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -285,7 +285,7 @@ symRun opts@UnitTestOptions{..} vm sig@(Sig testName types) solcContr sourceCach
 
     -- check postconditions against vm
     let fetcherSym = Fetch.oracle solvers (Just sess) rpcInfo
-    (end, results) <- verify solvers fetcherSym (makeVeriOpts opts) (symbolify vm') (Just postcondition)
+    (end, results) <- verify solvers fetcherSym (makeVeriOpts opts) (symbolify vm') postcondition
     let ends = flattenExpr end
     conf <- readConfig
     when conf.debug $ liftIO $ forM_ (filter Expr.isFailure ends) $ \case

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -116,7 +116,7 @@ tests = testGroup "rpc"
         vm <- weth9VM sess blockNum calldata'
         (_, [Cex (_, model)]) <- withSolvers Z3 1 1 Nothing $ \s ->
           let rpcInfo ::RpcInfo =  mempty { blockNumURL = Just (BlockNumber blockNum, testRpc) }
-          in verify s (oracle s (Just sess) rpcInfo) (rpcVeriOpts (fromJust rpcInfo.blockNumURL)) (symbolify vm) (Just postc)
+          in verify s (oracle s (Just sess) rpcInfo) (rpcVeriOpts (fromJust rpcInfo.blockNumURL)) (symbolify vm) postc
         liftIO $ assertBool "model should exceed caller balance" (getVar model "arg2" >= 695836005599316055372648)
     ]
   ]

--- a/test/test.hs
+++ b/test/test.hs
@@ -2195,8 +2195,8 @@ tests = testGroup "hevm"
         Just a <- solcRuntime "A" src
         Just c <- solcRuntime "C" src
         let sig = Sig "fun(uint256)" [AbiUIntType 256]
-        (expr, [Qed]) <- withDefaultSolver $ \s ->
-          verifyContract s c (Just sig) [] defaultVeriOpts Nothing Nothing
+        expr <- withDefaultSolver $ \s ->
+          exploreContract s c (Just sig) [] defaultVeriOpts Nothing
         let isSuc (Success {}) = True
             isSuc _ = False
         case filter isSuc (flattenExpr expr) of
@@ -2394,7 +2394,7 @@ tests = testGroup "hevm"
           |]
         -- NOTE: we have a postcondition here, not just a regular verification
         (_, [Cex _]) <- withDefaultSolver $ \s ->
-          verifyContract s c Nothing [] defaultVeriOpts Nothing (Just $ checkBadCheatCode "load(address,bytes32)")
+          verifyContract s c Nothing [] defaultVeriOpts Nothing (checkBadCheatCode "load(address,bytes32)")
         pure ()
     , test "vm.store fails for a potentially aliased address" $ do
         Just c <- solcRuntime "C"
@@ -2411,7 +2411,7 @@ tests = testGroup "hevm"
           |]
         -- NOTE: we have a postcondition here, not just a regular verification
         (_, [Cex _]) <- withDefaultSolver $ \s ->
-          verifyContract s c Nothing [] defaultVeriOpts Nothing (Just $ checkBadCheatCode "store(address,bytes32,bytes32)")
+          verifyContract s c Nothing [] defaultVeriOpts Nothing (checkBadCheatCode "store(address,bytes32,bytes32)")
         pure ()
     -- TODO: make this work properly
     , test "transfering-eth-does-not-dealias" $ do
@@ -3601,7 +3601,7 @@ tests = testGroup "hevm"
                    _ -> PBool True
             sig = Just (Sig "add(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])
         (res, [Qed]) <- withDefaultSolver $ \s ->
-          verifyContract s safeAdd sig [] defaultVeriOpts (Just pre) (Just post)
+          verifyContract s safeAdd sig [] defaultVeriOpts (Just pre) post
         putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
      ,
 
@@ -3628,7 +3628,7 @@ tests = testGroup "hevm"
                    Success _ _ b _ -> (ReadWord (Lit 0) b) .== (Mul (Lit 2) y)
                    _ -> PBool True
         (res, [Qed]) <- withDefaultSolver $ \s ->
-          verifyContract s safeAdd (Just (Sig "add(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts (Just pre) (Just post)
+          verifyContract s safeAdd (Just (Sig "add(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])) [] defaultVeriOpts (Just pre) post
         putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
       ,
       test "summary storage writes" $ do
@@ -3659,7 +3659,7 @@ tests = testGroup "hevm"
                 _ -> PBool True
             sig = Just (Sig "f(uint256)" [AbiUIntType 256])
         (res, [Qed]) <- withDefaultSolver $ \s ->
-          verifyContract s c sig [] defaultVeriOpts (Just pre) (Just post)
+          verifyContract s c sig [] defaultVeriOpts (Just pre) post
         putStrLnM $ "successfully explored: " <> show (Expr.numBranches res) <> " paths"
         ,
         -- tests how whiffValue handles Neg via application of the triple IsZero simplification rule
@@ -3721,7 +3721,7 @@ tests = testGroup "hevm"
                      _ -> PBool True
               sig = Just (Sig "f(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])
           (_, [Qed]) <- withDefaultSolver $ \s ->
-            verifyContract s c sig [] defaultVeriOpts (Just pre) (Just post)
+            verifyContract s c sig [] defaultVeriOpts (Just pre) post
           putStrLnM "Correct, this can never fail"
         ,
         -- Inspired by these `msg.sender == to` token bugs
@@ -3758,7 +3758,7 @@ tests = testGroup "hevm"
                      _ -> PBool True
               sig = Just (Sig "f(uint256,uint256)" [AbiUIntType 256, AbiUIntType 256])
           (_, [Cex (_, ctr)]) <- withDefaultSolver $ \s ->
-            verifyContract s c sig [] defaultVeriOpts (Just pre) (Just post)
+            verifyContract s c sig [] defaultVeriOpts (Just pre) post
           let x = getVar ctr "arg1"
           let y = getVar ctr "arg2"
           putStrLnM $ "y:" <> show y
@@ -4211,7 +4211,7 @@ tests = testGroup "hevm"
                     <&> set (#state % #callvalue) (Lit 0)
                     <&> over (#env % #contracts)
                        (Map.insert aAddr (initialContract (RuntimeCode (ConcreteRuntimeCode a))))
-            verify s (Fetch.oracle s Nothing mempty) defaultVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
+            verify s (Fetch.oracle s Nothing mempty) defaultVeriOpts vm (checkAssertions defaultPanicCodes)
 
           let storeCex = cex.store
               testCex = case (Map.lookup cAddr storeCex, Map.lookup aAddr storeCex) of
@@ -4287,7 +4287,7 @@ tests = testGroup "hevm"
           let yulsafeDistributivity = hex "6355a79a6260003560e01c14156016576015601f565b5b60006000fd60a1565b603d602d604435600435607c565b6039602435600435607c565b605d565b6052604b604435602435605d565b600435607c565b141515605a57fe5b5b565b6000828201821115151560705760006000fd5b82820190505b92915050565b6000818384048302146000841417151560955760006000fd5b82820290505b92915050565b"
           calldata <- mkCalldata (Just (Sig "distributivity(uint256,uint256,uint256)" [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256])) []
           vm <- liftIO $ stToIO $ abstractVM calldata yulsafeDistributivity Nothing False
-          (_, [Qed]) <-  withDefaultSolver $ \s -> verify s (Fetch.oracle s Nothing mempty) defaultVeriOpts vm (Just $ checkAssertions defaultPanicCodes)
+          (_, [Qed]) <-  withDefaultSolver $ \s -> verify s (Fetch.oracle s Nothing mempty) defaultVeriOpts vm (checkAssertions defaultPanicCodes)
           putStrLnM "Proven"
         ,
         test "safemath-distributivity-sol" $ do
@@ -4378,7 +4378,7 @@ tests = testGroup "hevm"
             |]
           let sig = Just (Sig "fun(uint256)" [AbiUIntType 256])
           (_, [Cex (_, cex)]) <- withDefaultSolver $
-            \s -> verifyContract s c sig [] defaultVeriOpts Nothing (Just $ checkAssertions [0x01])
+            \s -> verifyContract s c sig [] defaultVeriOpts Nothing (checkAssertions [0x01])
           let addr = SymAddr "entrypoint"
               testCex = Map.size cex.store == 1 &&
                         case Map.lookup addr cex.store of
@@ -6344,16 +6344,16 @@ checkBadCheatCode sig _ = \case
       _ -> Nothing
 
 allBranchesFail :: App m => ByteString -> Maybe Sig -> m (Either [SMTCex] (Expr End))
-allBranchesFail = checkPost (Just p)
+allBranchesFail = checkPost p
   where
     p _ = \case
       Success _ _ _ _ -> PBool False
       _ -> PBool True
 
 reachableUserAsserts :: App m => ByteString -> Maybe Sig -> m (Either [SMTCex] (Expr End))
-reachableUserAsserts = checkPost (Just $ checkAssertions [0x01])
+reachableUserAsserts = checkPost (checkAssertions [0x01])
 
-checkPost :: App m => Maybe (Postcondition RealWorld) -> ByteString -> Maybe Sig -> m (Either [SMTCex] (Expr End))
+checkPost :: App m => Postcondition RealWorld -> ByteString -> Maybe Sig -> m (Either [SMTCex] (Expr End))
 checkPost post c sig = do
   (e, res) <- withDefaultSolver $ \s ->
     verifyContract s c sig [] defaultVeriOpts Nothing post


### PR DESCRIPTION
## Description

To make the core method simpler we always require postcondition to be given.
If there is no postcondition, we are not really "verifying". However, there is a use case where we don't want to verify anything, we just want to explore a contract.
For such use case, we provide a new helper method to do exactly that. `exploreContract` executes the contract symbolically, and returns its Expr representation.



## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
