### PR TITLE
Test: Small adjustments to run property tests faster

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -697,7 +697,7 @@ tests = testGroup "hevm"
     , testProperty "byte-simplification" $ \(expr :: Expr Byte) -> propNoSimp $ do
         let simplified = Expr.simplify expr
         checkEquivAndLHS expr simplified
-    , testProperty "word-simplification" $ \(ZeroDepthWord expr) -> propNoSimp $ do
+    , askOption $ \(QuickCheckTests n) -> testProperty "word-simplification" $ withMaxSuccess (min n 20) $ \(ZeroDepthWord expr) -> propNoSimp $ do
         let simplified = Expr.simplify expr
         checkEquivAndLHS expr simplified
     , testProperty "readStorage-equivalance" $ \(store, slot) -> propNoSimp $ do
@@ -6266,7 +6266,7 @@ genBuf bound sz = oneof
 genStorage :: Int -> Gen (Expr Storage)
 genStorage 0 = oneof
   [ liftM2 AbstractStore arbitrary (pure Nothing)
-  , fmap ConcreteStore arbitrary
+  , fmap ConcreteStore $ resize 5 arbitrary
   ]
 genStorage sz = liftM3 SStore key val subStore
   where


### PR DESCRIPTION
I suggest to modification to our property tests:

1. Run word-simplification at most 20 times Currently it runs 50 times and it often takes tens of seconds to finish on my machine (and even more on CI).

2. Limit the size of concrete storage. While looking at the generated expressions I noticed a relatively large concrete stores (tens of elements). I don't think large concrete stores add value, so let's keep them small.
