### PR TITLE
Remove unnecessary simplification which causes problems in fuzztesting

### DIFF
--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1378,8 +1378,6 @@ simplifyProp prop =
     go (PNeg (POr a b)) = PAnd (PNeg a) (PNeg b)
     go (PNeg (PEq (Lit 1) (IsZero b))) = PEq (Lit 0) (IsZero b)
 
-    -- Empty buf
-    go (PEq (Lit 0) (BufLength k)) = peq k (ConcreteBuf "")
     go (PEq (Lit 0) (Or a b)) = peq (Lit 0) a `PAnd` peq (Lit 0) b
 
     -- PEq rewrites (notice -- GT/GEq is always rewritten to LT by simplify)

--- a/test/test.hs
+++ b/test/test.hs
@@ -668,6 +668,13 @@ tests = testGroup "hevm"
         simp = Expr.simplifyProp expr
       ret <- checkEquivPropAndLHS expr simp
       assertEqualM "Must be equivalent" True ret
+    , test "buffer-length-zero" $ do
+        let
+          p = PEq (BufLength (AbstractBuf "b")) (Lit 0x0)
+          simp = Expr.simplifyProp p
+        liftIO $ print simp
+        ret <-  checkEquivProp p simp
+        assertEqualM "Must be equivalent" True ret
     ]
   -- These tests fuzz the simplifier by generating a random expression,
   -- applying some simplification rules, and then using the smt encoding to


### PR DESCRIPTION
## Description
I don't think this reqrite rule is particularly helpful, because it rewrites equality between numbers to equality between buffers. Equality between numbers should be easier for SMT solver to process than equality between arrays.

Given how we encode buffer length at the moment, this rewrite yields an SMT formula that is not equivalent to the original one, causing false alarms in our property-based testing.

Fixes #664.

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
