### PR TITLE
Move to macos15-intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      main
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,10 +19,10 @@ jobs:
           os: ubuntu-latest
 
         - runtime: osx-x64
-          os: macos-13
+          os: macos-15-intel
 
         - runtime: osx-arm64
-          os: macos-14
+          os: macos-15
 
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -53,10 +53,10 @@ jobs:
   extra-tests:
     strategy:
       matrix:
-       os: [ ubuntu-latest, macos-latest ]
+       os: [ ubuntu-latest, macos-15 ]
        include:
          - os: ubuntu-latest
-         - os: macos-latest
+         - os: macos-15
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,16 @@ jobs:
     strategy:
       matrix:
         include:
-          # macos-13 is x86
-          - os: "macos-13"
+          - os: "macos-15-intel"
             suffix: "x86_64-macos"
-          # macos-14 is arm, see https://github.com/orgs/community/discussions/102846
-          # "Workflows executed on this image will run exclusively on the 3 vCPU M1 runner"
-          - os: "macos-14"
+
+          # macos-15 is arm64
+          - os: "macos-15"
             suffix: "arm64-macos"
+
           - os: "ubuntu-latest"
             suffix: "x86_64-linux"
+
     name: Build binary on ${{ matrix.os }}
     runs-on: ${{ matrix.os  }}
     steps:
@@ -28,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v30      
+        uses: nixbuild/nix-quick-install-action@v30
       - name: build hevm
         run: |
           nix build .#redistributable --out-link hevm
@@ -47,7 +48,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v30      
+        uses: nixbuild/nix-quick-install-action@v30
       - name: download binaries
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Description
The Intel macos-13 runner is being deprecated. This moves to macos-15-intel. Also moves macos-14 to macos-15 (which is arm64). And now it's no longer mixed `-latest` and `-15` in macos.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
