### PR TITLE
Fix packed array of bytes1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - Fix incorrect simplification rule for `PEq (Lit 1) (IsZero (LT a b))`
+- bytes of length k in ABI are packed, as per ABI spec
 
 ## Changed
 - Replaced RPC mocking by a full block cache support. This allows users to cache responses from an RPC

--- a/test/clitest.hs
+++ b/test/clitest.hs
@@ -247,3 +247,9 @@ main = do
           , "--number", "10307563", "--cache-dir", "test/contracts/fail/"]
         stdout `shouldContain` "[FAIL]"
         stderr `shouldNotContain` "CallStack"
+      it "bytes1-packed" $ do
+        (exitCode, stdout, stderr) <- runForge "test/contracts/fail/bytes1-packed.sol" []
+        stderr `shouldNotContain` "CallStack"
+        stdout `shouldContain` "[validated]"
+        stdout `shouldContain` "[0x37, 0x13, 0x03, 0xc0"
+        exitCode `shouldBe` (ExitFailure 1)

--- a/test/contracts/fail/bytes1-packed.sol
+++ b/test/contracts/fail/bytes1-packed.sol
@@ -1,0 +1,41 @@
+contract C {
+  bool public IS_TEST = true;
+  uint256 state;
+
+  function prop() public view {
+    assert(state == 0);
+  }
+
+  function inc() external { state++; }
+
+  function prove_callAndCheckProperty(bytes1[36] calldata arr) external {
+    address target = address(this);
+    bool success;
+    assembly {
+      // Allocate memory for the calldata copy
+      let dataPtr := mload(0x40)
+      let dataLen := 36 // N = 32 bytes
+
+      // Copy calldata (after 4-byte selector) into memory
+      calldatacopy(dataPtr, 0x04, dataLen)
+
+      // Update the free memory pointer
+      mstore(0x40, add(dataPtr, dataLen))
+
+      // Perform the low-level call
+      // this should call the inc() function, which has selector:
+      //```
+      //cast keccak "inc()"
+      //0x371303c051bff726100ad13871cababf50c20dd920fca137e519f98f089a74b4
+      //```
+      // which happens to have the first 4 bytes as
+      // 0x37, 0x13 0x03, 0xc0
+      // This will increment `state` by 1, thereby violating the property
+
+      success := call(gas(), target, 0, dataPtr, dataLen, 0, 0)
+    }
+
+    if (!success) revert("raw call failed");
+    prop();
+  }
+}

--- a/test/test.hs
+++ b/test/test.hs
@@ -1282,7 +1282,7 @@ tests = testGroup "hevm"
           -- putStrLnM $ "y type: " <> showAlter y
           -- putStrLnM $ "hevmConcretePre: " <> show hevmConcretePre
           assertEqualM "abi encoding mismatch" solidityEncoded (AbiBytesDynamic hevmConcrete)
-    , testProperty "symbolic-abi encoding-vs-solidity-2-args" $ \(SymbolicAbiVal x', SymbolicAbiVal y') -> prop $ do
+    , testProperty "symbolic-abi-encoding-vs-solidity-2-args" $ \(SymbolicAbiVal x', SymbolicAbiVal y') -> prop $ do
           Just encoded <- runStatements [i| x = abi.encode(a, b);|] [x', y'] AbiBytesDynamicType
           let solidityEncoded = case decodeAbiValue (AbiTupleType $ V.fromList [AbiBytesDynamicType]) (BS.fromStrict encoded) of
                 AbiTuple (V.toList -> [e]) -> e


### PR DESCRIPTION
This partially addresses  #917 The issue is that bytes `bytes1[36]` is packed as per ABI spec. From the ABI documentation: https://docs.soliditylang.org/en/latest/abi-spec.html#formal-specification-of-the-encoding

```
bytes, of length k (which is assumed to be of type uint256):

enc(X) = enc(k) pad_right(X), i.e. the number of bytes is encoded as a uint256 followed by the actual value of X as a byte 
sequence, followed by the minimum number of zero-bytes such that len(enc(X)) is a multiple of 32.
```

However, we treated it as a regular Array, which is padded to 32B for each element.

## Description

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
