### PR TITLE
Cabal: Remove unneeded private modules from test-common

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -273,10 +273,6 @@ common test-common
     ghc-options: -threaded -with-rtsopts=-N
   build-depends:
     test-utils
-  other-modules:
-    EVM.Test.Utils
-    EVM.Test.FuzzSymExec
-    EVM.Test.BlockchainTests
 
 --- Test Suites ---
 


### PR DESCRIPTION
All these modules are already compiled as part of test-utils library which is a dependency of test-common