### PR TITLE
RPC: Small cleanup

### DIFF
--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -371,22 +371,6 @@ internalBlockFetch conf sess n url = do
         pure $ c { blockCache = Map.insert bn b c.blockCache }
       pure ret
 
-fetchSlotFrom :: App m => Session -> BlockNumber -> Text -> Addr -> W256 -> m (Maybe W256)
-fetchSlotFrom sess nPre url addr slot = do
-  conf <- readConfig
-  n <- liftIO $ getLatestBlockNum conf sess nPre url
-  cache <- liftIO $ readMVar sess.sharedCache
-  case Map.lookup (addr, slot) cache.slotCache of
-    Just s -> do
-      when (conf.debug) $ liftIO $ putStrLn $ "-> Using cached slot value for slot " <> show slot <> " at " <> show addr
-      pure $ Just s
-    Nothing -> do
-      ret <- liftIO $ fetchSlotWithSession sess.sess n url addr slot
-      when (isJust ret) $ let val = fromJust ret in
-        liftIO $ modifyMVar_ sess.sharedCache $ \c ->
-          pure $ c { slotCache = Map.insert (addr, slot) val c.slotCache }
-      pure ret
-
 cacheFileName :: W256 -> FilePath
 cacheFileName n = "rpc-cache-" ++ T.unpack (showDec Unsigned n) ++ ".json"
 
@@ -497,7 +481,13 @@ oracle solvers preSess rpcInfo q = do
             Nothing -> do
               liftIO $ putStrLn $ "Warning: no RPC info provided, returning 0 for slot at address: " <> show addr
               pure $ continue 0
-            Just (block, url) -> fetchSlotFrom sess block url addr slot >>= \case
+            Just (block, url) -> do
+              n <- liftIO $ getLatestBlockNum conf sess block url
+              ret <- liftIO $ fetchSlotWithSession sess.sess n url addr slot
+              when (isJust ret) $ let val = fromJust ret in
+                liftIO $ modifyMVar_ sess.sharedCache $ \c ->
+                  pure $ c { slotCache = Map.insert (addr, slot) val c.slotCache }
+              case ret of
                 Just x  -> pure $ continue x
                 Nothing -> internalError $ "oracle error: " ++ show q
 


### PR DESCRIPTION
## Description

In processing query to fetch a slot, the current code checks the cache twice.
First directly in the handler code, secondly in function `fetchSlotFrom`.
Since this function is not used anywhere else, we inline it and eliminate one unnecessary cache check.

We also remove debug printing that is now actually unreachable.

