### PR TITLE
Fixing iteration counting for concrete branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - Fix incorrect simplification rule for `PEq (Lit 1) (IsZero (LT a b))`
+- During symbolic execution, we didn't properly handle the case where
+  a loop was being triggered by a computable condition, thereby potentially
+  looping forever.
 
 ## Changed
 - Replaced RPC mocking by a full block cache support. This allows users to cache responses from an RPC


### PR DESCRIPTION
## Description
When the branch was concrete, we actually didn't check loop iterations, oops. So we went... forever. Here:

```haskell
            case Expr.concKeccakSimpExpr cond of
              -- is the condition concrete?
              Lit c ->
                -- have we reached max iterations, are we inside a loop?
                case (maxIterationsReached vm iterConf.maxIter, isLoopHead iterConf.loopHeuristic vm) of
```

The maxIterationsReached couldn't really trigger, since the `pathsVisited` and the `iterations` were not updated. They are only updated inside:
```haskell
instance VMOps Symbolic where
  branch depthLimit cond continue = do
    ....
    assign (#pathsVisited % at (loc, iteration)) (Just v)
    assign (#iterations % at loc) (Just (iteration + 1, stack))
```

This will no longer happen. Notice that this does not affect Concrete execution, because `PleaseAskSMT` is only defined for symbolic VMs.

Fixes #854

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
