### PR TITLE
Expr: Remove expensive unnecessary simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   node via `--cache-dir dir`.
 - Changed `verify*` methods to always require postcodition.
 - Removed type parameter of mutable memory from VM definition.
+- Removed simplification that were rewriting concrete bytes-to-be-overwritten
+  with zero bytes. Benefits were unclear while it had negative effect on
+  analysis' performance.
 
 ## [0.56.0] - 2025-10-13
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -1001,20 +1001,6 @@ simplifyNoLitToKeccak e = untilFixpoint (mapExpr go) e
     go (ReadByte idx buf) = readByte idx buf
     go (BufLength buf) = bufLength buf
 
-    -- We can zero out any bytes in a base ConcreteBuf that we know will be overwritten by a later write
-    -- TODO: make this fully general for entire write chains, not just a single write.
-    go o@(WriteWord (Lit idx) val (ConcreteBuf b))
-      | idx >= maxBytes = o
-      | BS.length b >= (unsafeInto idx + 32) =
-          let
-            slot = BS.take 32 (BS.drop (unsafeInto idx) b)
-            isSlotZero = BS.all (== 0) slot
-            content = if isSlotZero
-              then b
-              else (BS.take (unsafeInto idx) b)
-                <> (BS.replicate 32 0)
-                <> (BS.drop (unsafeInto idx + 32) b)
-          in writeWord (Lit idx) val (ConcreteBuf content)
     go (WriteWord a b c) = writeWord a b c
 
     go (WriteByte a b c) = writeByte a b c


### PR DESCRIPTION
## Description
This transformation is a bit expensive to check and should not be attempted repeatedly, which is what we are doing now. It might make sense to apply it once at the very end before we encode to SMT.
However, the simplification system does not support that yet. For now the simplification can be removed.
We could attempt to bring it back later.

Resolves #831.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
