### PR TITLE
Remove type parameter from VM definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced RPC mocking by a full block cache support. This allows users to cache responses from an RPC
   node via `--cache-dir dir`.
 - Changed `verify*` methods to always require postcodition.
+- Removed type parameter of mutable memory from VM definition.
 
 ## [0.56.0] - 2025-10-13
 

--- a/bench/bench-perf.hs
+++ b/bench/bench-perf.hs
@@ -24,7 +24,7 @@ import EVM.FeeSchedule (feeSchedule)
 
 -- benchmark hevm using tasty-bench
 
-vmFromRawByteString :: App m => ByteString -> m (VM Concrete RealWorld)
+vmFromRawByteString :: App m => ByteString -> m (VM Concrete)
 vmFromRawByteString bs = liftIO $
   bs
     & ConcreteRuntimeCode
@@ -34,7 +34,7 @@ vmFromRawByteString bs = liftIO $
     & stToIO
     & fmap EVM.Transaction.initTx
 
-vm0 :: Contract -> ST s (VM Concrete s)
+vm0 :: Contract -> ST RealWorld (VM Concrete)
 vm0 c = makeVm $ vm0Opts c
 
 vm0Opts :: Contract -> VMOpts Concrete

--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -9,7 +9,7 @@ module Main where
 
 import Control.Monad (when, forM_, unless)
 import Control.Monad.State.Strict (runStateT)
-import Control.Monad.ST (RealWorld, stToIO)
+import Control.Monad.ST (stToIO)
 import Control.Monad.IO.Unlift
 import Control.Exception (try, IOException)
 import Data.ByteString (ByteString)
@@ -619,7 +619,7 @@ launchExec cFileOpts execOpts cExecOpts cOpts = do
         internalError "no EVM result"
 
 -- | Creates a (concrete) VM from command line options
-vmFromCommand :: App m => CommonOptions -> CommonExecOptions -> CommonFileOptions -> ExecOptions -> Fetch.Session -> m (VM Concrete RealWorld)
+vmFromCommand :: App m => CommonOptions -> CommonExecOptions -> CommonFileOptions -> ExecOptions -> Fetch.Session -> m (VM Concrete)
 vmFromCommand cOpts cExecOpts cFileOpts execOpts sess = do
   conf <- readConfig
   (miner,ts,baseFee,blockNum,prevRan) <- case cExecOpts.rpc of
@@ -732,7 +732,7 @@ vmFromCommand cOpts cExecOpts cFileOpts execOpts sess = do
 
 symvmFromCommand :: App m =>
   CommonExecOptions -> SymbolicOptions -> CommonFileOptions -> Fetch.Session ->
-  (Expr Buf, [Prop]) -> m (VM EVM.Types.Symbolic RealWorld)
+  (Expr Buf, [Prop]) -> m (VM EVM.Types.Symbolic)
 symvmFromCommand cExecOpts sOpts cFileOpts sess calldata = do
   conf <- readConfig
   (miner,blockNum,baseFee,prevRan) <- case cExecOpts.rpc of
@@ -832,7 +832,7 @@ symvmFromCommand cExecOpts sOpts cFileOpts sess calldata = do
     word64 f def = fromMaybe def (f cExecOpts)
     eaddr f def = maybe def LitAddr (f cExecOpts)
 
-unitTestOptions :: App m => TestOptions -> CommonOptions -> SolverGroup -> Maybe BuildOutput -> m (UnitTestOptions RealWorld)
+unitTestOptions :: App m => TestOptions -> CommonOptions -> SolverGroup -> Maybe BuildOutput -> m (UnitTestOptions)
 unitTestOptions testOpts cOpts solvers buildOutput = do
   root <- liftIO $ getRoot cOpts
 

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -9,14 +9,14 @@ import Control.Monad.Trans.State.Strict (get, State)
 import Data.ByteString (ByteString)
 import Data.Maybe (isNothing)
 import Optics.Core
-import Control.Monad.ST (ST)
+import Control.Monad.ST (ST, RealWorld)
 import EVM.Effects (Config)
 import Data.Data (Typeable)
 
 ethrunAddress :: Addr
 ethrunAddress = Addr 0x00a329c0648769a73afac7f9381e08fb43dbea72
 
-vmForEthrunCreation :: VMOps t => ByteString -> ST s (VM t s)
+vmForEthrunCreation :: VMOps t => ByteString -> ST RealWorld (VM t)
 vmForEthrunCreation creationCode =
   (makeVm $ VMOpts
     { contract = initialContract (InitCode creationCode mempty)
@@ -48,21 +48,21 @@ vmForEthrunCreation creationCode =
     }) <&> set (#env % #contracts % at (LitAddr ethrunAddress))
              (Just (initialContract (RuntimeCode (ConcreteRuntimeCode ""))))
 
-exec :: (VMOps t, Typeable t) => Config -> EVM t s (VMResult t s)
+exec :: (VMOps t, Typeable t) => Config -> EVM t (VMResult t)
 exec conf = do
   vm <- get
   case vm.result of
     Nothing -> exec1 conf >> exec conf
     Just r -> pure r
 
-run :: (VMOps t, Typeable t) => Config -> EVM t s (VM t s)
+run :: (VMOps t, Typeable t) => Config -> EVM t (VM t)
 run conf = do
   vm <- get
   case vm.result of
     Nothing -> exec1 conf >> run conf
     Just _ -> pure vm
 
-execWhile :: (VM t s -> Bool) -> State (VM t s) Int
+execWhile :: (VM t -> Bool) -> State (VM t) Int
 execWhile p = go 0
   where
     go i = do

--- a/src/EVM/Fetch.hs
+++ b/src/EVM/Fetch.hs
@@ -67,7 +67,7 @@ import EVM.Effects
 import qualified EVM.Expr as Expr
 import Control.Concurrent.MVar (MVar, newMVar, readMVar, modifyMVar_)
 
-type Fetcher t m s = App m => Query t s -> m (EVM t s ())
+type Fetcher t m = App m => Query t -> m (EVM t ())
 
 data Session = Session
   { sess           :: NetSession.Session
@@ -418,14 +418,14 @@ mkSessionWithoutCache :: App m => m Session
 mkSessionWithoutCache = mkSession Nothing Nothing
 
 -- Only used for testing (test.hs, BlockchainTests.hs)
-zero :: Natural -> Maybe Natural -> Fetcher t m s
+zero :: Natural -> Maybe Natural -> Fetcher t m
 zero smtjobs smttimeout q = do
   sess <- mkSessionWithoutCache
   withSolvers Z3 smtjobs 1 smttimeout $ \s ->
     oracle s (Just sess) mempty q
 
 -- SMT solving + RPC data fetching + reading from environment
-oracle :: forall t m s . App m => SolverGroup -> Maybe Session -> RpcInfo -> Fetcher t m s
+oracle :: forall t m . App m => SolverGroup -> Maybe Session -> RpcInfo -> Fetcher t m
 oracle solvers preSess rpcInfo q = do
   case q of
     PleaseDoFFI vals envs continue -> case vals of

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -191,7 +191,7 @@ formatSBinary e = format $ Expr.concKeccakSimpExpr e
     format (AbstractBuf t) = "<" <> t <> " abstract buf>"
     format e2 = T.pack $ "Symbolic expression: " <> show e2
 
-showTraceTree :: DappInfo -> VM t s -> Text
+showTraceTree :: DappInfo -> VM t -> Text
 showTraceTree dapp vm =
   let ?context = DappContext { info = dapp
                              , contracts = vm.env.contracts
@@ -520,7 +520,7 @@ formatPartial = \case
     ]
 
 
-formatPartialDetailed :: Maybe (WarningData s t) -> PartialExec -> Text
+formatPartialDetailed :: Maybe (WarningData t) -> PartialExec -> Text
 formatPartialDetailed warnData p =
   let toTxt addr pc = pack $ getSrcInfo warnData addr pc
   in case p of
@@ -531,7 +531,7 @@ formatPartialDetailed warnData p =
     PrecompileMissing {..}     -> "Precompile at address " <> pack (show preAddr) <> " does not exist, called from" <> toTxt addr pc
     BranchTooDeep {..}         -> "Branches too deep" <> toTxt addr pc
 
-getSrcInfo :: Maybe (WarningData s t) -> Expr EAddr -> Int -> String
+getSrcInfo :: Maybe (WarningData t) -> Expr EAddr -> Int -> String
 getSrcInfo Nothing addr pc = " at addr: " <> show addr <> " at pc: " <> show pc
 getSrcInfo (Just dat) addr pc = fromMaybe (getSrcInfo Nothing addr pc) $ do
   contr <- Map.lookup addr dat.vm.env.contracts

--- a/src/EVM/Solidity.hs
+++ b/src/EVM/Solidity.hs
@@ -232,10 +232,10 @@ data SrcMap = SM {
   modifierDepth :: {-# UNPACK #-} !Int
 } deriving (Show, Eq, Ord, Generic)
 
-data WarningData s t = WarningData
+data WarningData t = WarningData
   {solcContr :: SolcContract,
    sourceCache :: SourceCache,
-   vm :: VM s t
+   vm :: VM t
   }
 
 data SrcMapParseState

--- a/src/EVM/Transaction.hs
+++ b/src/EVM/Transaction.hs
@@ -254,7 +254,7 @@ setupTx origin coinbase gasPrice gasLimit prestate =
 -- | Given a valid tx loaded into the vm state,
 -- subtract gas payment from the origin, increment the nonce
 -- and pay receiving address
-initTx :: VM t s -> VM t s
+initTx :: VM t -> VM t
 initTx vm =
   let
     toAddr   = vm.state.contract

--- a/test/EVM/Test/Utils.hs
+++ b/test/EVM/Test/Utils.hs
@@ -17,7 +17,6 @@ import EVM.Solidity
 import EVM.Solvers
 import EVM.UnitTest
 import EVM.SymExec qualified as SymExec
-import Control.Monad.ST (RealWorld)
 import Control.Monad.IO.Unlift
 import Control.Monad.Catch (MonadMask)
 import EVM.Effects
@@ -49,7 +48,7 @@ runForgeTest
   => FilePath -> Text -> m (Bool, Bool)
 runForgeTest testFile match = runForgeTestCustom testFile match Nothing Nothing True mempty
 
-testOpts :: forall m . App m => SolverGroup -> FilePath -> Maybe BuildOutput -> Text -> Maybe Integer -> Bool -> RpcInfo -> m (UnitTestOptions RealWorld)
+testOpts :: forall m . App m => SolverGroup -> FilePath -> Maybe BuildOutput -> Text -> Maybe Integer -> Bool -> RpcInfo -> m (UnitTestOptions)
 testOpts solvers root buildOutput match maxIter allowFFI rpcinfo = do
   let srcInfo = maybe emptyDapp (dappInfo root) buildOutput
   sess <- Fetch.mkSessionWithoutCache

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -19,7 +19,7 @@ import EVM.Stepper qualified as Stepper
 import EVM.SymExec
 import EVM.Test.Utils
 import EVM.Types hiding (BlockNumber, Env)
-import Control.Monad.ST (stToIO, RealWorld)
+import Control.Monad.ST (stToIO)
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.IO.Unlift
 import EVM.Effects
@@ -122,7 +122,7 @@ tests = testGroup "rpc"
   ]
 
 -- call into WETH9 from 0xf04a... (a large holder)
-weth9VM :: App m => Session -> W256 -> (Expr Buf, [Prop]) -> m (VM Concrete RealWorld)
+weth9VM :: App m => Session -> W256 -> (Expr Buf, [Prop]) -> m (VM Concrete)
 weth9VM sess blockNum calldata' = do
   let
     caller' = LitAddr 0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e
@@ -130,7 +130,7 @@ weth9VM sess blockNum calldata' = do
     callvalue' = Lit 0
   vmFromRpc sess blockNum calldata' callvalue' caller' weth9
 
-vmFromRpc :: App m => Session -> W256 -> (Expr Buf, [Prop]) -> Expr EWord -> Expr EAddr -> Addr -> m (VM Concrete RealWorld)
+vmFromRpc :: App m => Session -> W256 -> (Expr Buf, [Prop]) -> Expr EWord -> Expr EAddr -> Addr -> m (VM Concrete)
 vmFromRpc sess blockNum calldata callvalue caller address = do
   conf <- readConfig
   ctrct <- liftIO $ fetchContractWithSession conf sess (BlockNumber blockNum) testRpc address >>= \case


### PR DESCRIPTION
## Description

Rationale: We never use VM within a local computation, the type parameter always resolves to RealWorld.
The extra type parameter currently does not serve any purpose, but it presents a cognitive overhead.

We can hard-code RealWorld as the region of the mutable memory and remove the type parameter.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [x] updated the changelog
