### PR TITLE
chore: fix some typos in comments

### DIFF
--- a/doc/src/common-options.md
+++ b/doc/src/common-options.md
@@ -29,7 +29,7 @@ specific (low) number via the `--num-solvers` flag.
 ## Promising no reentrancy, ``--promise-no-reent``
 
 hevm can be instructed to assume that no reentrancy will occur during the
-execution of the contract. This is currently neccessary to fully explore
+execution of the contract. This is currently necessary to fully explore
 certain contracts. This is because value transfer is usually done via a `CALL`,
 which can be reentrant. By promising no reentrancy, the system can assume that
 no reentrancy will occur and can explore the contract more fully.

--- a/doc/src/limitations-and-workarounds.md
+++ b/doc/src/limitations-and-workarounds.md
@@ -89,7 +89,7 @@ dynamically computed JUMP destinations can be avoided via pre-computed jump tabl
 
 **Best Practices**:
 * Use `require()` statements to concretize symbolic values
-* Avoid dynamically computed jumps -- use pre-computed jump-tables, if neccesary
+* Avoid dynamically computed jumps -- use pre-computed jump-tables, if necessary
 
 ## Jumping into symbolic code
 

--- a/doc/src/std-test-tutorial.md
+++ b/doc/src/std-test-tutorial.md
@@ -258,7 +258,7 @@ developers define, such as:
 ```solidity
 error InsufficientBalance(uint256 requested, uint256 available);
 ....
-uint reqested = ...;
+uint requested = ...;
 uint available = ...;
 if (requested > available) {
     revert InsufficientBalance(requested, available);

--- a/ethjet/ethjet-ff.cc
+++ b/ethjet/ethjet-ff.cc
@@ -40,7 +40,7 @@ namespace ethjet_ff {
   // for loading an element of F_{q^2} (a coordinate of G_2)
   // consumes 64 bytes
   alt_bn128_Fq2 read_Fq2_element (uint8_t *in) {
-    // suprising "big-endian" encoding
+    // surprising "big-endian" encoding
     alt_bn128_Fq x0 = read_Fq_element(in+32);
     alt_bn128_Fq x1 = read_Fq_element(in);
 


### PR DESCRIPTION
## Description

fix some typos in comments

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
