### PR TITLE
Stepper: Unify Fork and ForkMany instructions

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1371,18 +1371,10 @@ getCodeLocation vm = (vm.state.contract, vm.state.pc)
 query :: Query t -> EVM t ()
 query q = assign #result $ Just $ HandleEffect (Query q)
 
-runBoth :: Maybe Int -> Int -> RunBoth -> EVM Symbolic ()
-runBoth depthLimit exploreDepth c = do
+fork :: Maybe Int -> Int -> BranchContext -> EVM Symbolic ()
+fork depthLimit exploreDepth forkContext = do
   if (isNothing depthLimit || (exploreDepth < fromJust depthLimit)) then do
-    assign #result $ Just $ HandleEffect (RunBoth c)
-  else do
-    vm <- get
-    assign #result $ Just $ Unfinished (BranchTooDeep {pc = vm.state.pc, addr = vm.state.contract})
-
-runAll :: Maybe Int -> Int -> RunAll -> EVM Symbolic ()
-runAll depthLimit exploreDepth c = do
-  if (isNothing depthLimit || (exploreDepth < fromJust depthLimit)) then do
-    assign #result $ Just $ HandleEffect (RunAll c)
+    assign #result $ Just $ HandleEffect (Branch forkContext)
   else do
     vm <- get
     assign #result $ Just $ Unfinished (BranchTooDeep {pc = vm.state.pc, addr = vm.state.contract})
@@ -1615,7 +1607,7 @@ onlyDeployed addrExpr fallback continue = do
     else case eqT @t @Symbolic of
       Just Refl -> do
         let deployedAddrs = map forceEAddrToEWord $ mapMaybe (codeMustExist vm) $ Map.keys vm.env.contracts
-        runAll (?conf.maxDepth) vm.exploreDepth $ PleaseRunAll deployedAddrs runAllPaths
+        fork (?conf.maxDepth) vm.exploreDepth $ PleaseRunAll deployedAddrs runAllPaths
       _ -> internalError "Unknown address in Concrete mode"
   where
     codeMustExist :: (VM t) -> Expr EAddr -> Maybe (Expr EAddr)
@@ -3084,7 +3076,7 @@ instance VMOps Symbolic where
         continue v
       -- Both paths are possible; we ask for more input
       runBothPaths loc exploreDepth UnknownBranch =
-        (runBoth depthLimit exploreDepth ) . PleaseRunBoth $ (runBothPaths loc exploreDepth) . Case
+        (fork depthLimit exploreDepth ) . PleaseRunBoth $ (runBothPaths loc exploreDepth) . Case
 
   -- numBytes allows us to specify how many bytes of the returned value is relevant
   -- if it's e.g.a JUMP, only 2 bytes can be relevant. This allows us to avoid
@@ -3103,7 +3095,7 @@ instance VMOps Symbolic where
             assign #result Nothing
             pushTo #constraints $ Expr.simplifyProp (ewordExpr .== (Lit val))
             continue $ Just val
-          _ -> runAll maxDepth vm.exploreDepth $ PleaseRunAll (map Lit concVals) runAllPaths
+          _ -> fork maxDepth vm.exploreDepth $ PleaseRunAll (map Lit concVals) runAllPaths
       Nothing -> do
         assign #result Nothing
         continue Nothing

--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -471,7 +471,7 @@ interpretInternal t@InterpTask{..} = eval (Operational.view stepper)
       Stepper.EVM m -> do
         (r, vm') <- liftIO $ stToIO $ runStateT m vm
         interpretInternal t { vm = vm', stepper = (k r) }
-      Stepper.ForkMany (PleaseRunAll vals continue) -> do
+      Stepper.Fork (PleaseRunAll vals continue) -> do
         when (length vals < 2) $ internalError "PleaseRunAll requires at least 2 branches"
         frozen <- liftIO $ stToIO $ freezeVM vm
         let newDepth = vm.exploreDepth+1

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -599,8 +599,7 @@ data PartialExec
 -- | Effect types used by the vm implementation for side effects & control flow
 data Effect t where
   Query :: Query t -> Effect t
-  RunBoth :: RunBoth -> Effect Symbolic
-  RunAll :: RunAll -> Effect Symbolic
+  Branch :: BranchContext -> Effect Symbolic
 deriving instance Show (Effect t)
 
 -- | Queries halt execution until resolved through RPC calls or SMT queries
@@ -612,13 +611,9 @@ data Query t where
   PleaseDoFFI         :: [String] -> Map String String -> (ByteString -> EVM t ()) -> Query t
   PleaseReadEnv       :: String -> (String -> EVM t ()) -> Query t
 
--- | Execution could proceed down one of two branches
-data RunBoth where
-  PleaseRunBoth    :: (Bool -> EVM Symbolic ()) -> RunBoth
-
--- | Execution could proceed down one of several branches
-data RunAll where
-  PleaseRunAll    :: [Expr EWord] -> (Expr EWord -> EVM Symbolic ()) -> RunAll
+data BranchContext where
+  PleaseRunBoth :: (Bool -> EVM Symbolic ()) -> BranchContext
+  PleaseRunAll  :: [Expr EWord] -> (Expr EWord -> EVM Symbolic ()) -> BranchContext
 
 -- | The possible return values of a SMT query
 data BranchCondition = Case Bool | UnknownBranch
@@ -647,13 +642,11 @@ instance Show (Query t) where
     PleaseReadEnv variable _ ->
       (("<EVM.Query: read env: " ++ variable) ++)
 
-instance Show (RunBoth) where
+instance Show (BranchContext) where
   showsPrec _ = \case
     PleaseRunBoth _ ->
       (("<EVM.RunBoth: system running both paths") ++)
 
-instance Show (RunAll) where
-  showsPrec _ = \case
     PleaseRunAll _ _ ->
       (("<EVM.RunAll: system running all paths for Expr EWord-s") ++)
 


### PR DESCRIPTION
## Description

A single `Fork` type is enough, we can distinguish the instances with different data constructors.
This removes a bit of duplication in the code.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
