### PR TITLE
This fixes release due to directory being too high

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -143,7 +143,7 @@ library
   install-includes:
     ethjet/tinykeccak.h, ethjet/ethjet.h, ethjet/ethjet-ff.h, ethjet/blake2.h
   build-depends:
-    directory                         >=1.3.7.0 && <= 1.3.9.0,
+    directory                         >= 1.3.6 && < 1.4,
     system-cxx-std-lib                >= 1.0 && < 2.0,
     QuickCheck                        >= 2.13.2 && < 2.16,
     Decimal                           >= 0.5.1 && < 0.6,


### PR DESCRIPTION
## Description

This fixes the release build issue that we had before. Another issue pops up, but that's for another PR to fix, besides, I think it's already fixed:

```
       > src/EVM/SymExec.hs:17:1: error: [-Wunused-imports, -Werror=unused-imports]
       >     The import of ‘Control.Monad’ is redundant
       >       except perhaps to import instances from ‘Control.Monad’
       >     To import instances alone, use: import Control.Monad()
       >    |
       > 17 | import Control.Monad (when, forM_, forM, forever)
       >    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
So I 'd like to merge this.

Coses #928

## Checklist

I tested this as part of the msooseth/hevm release pipeline. It fixes the original problem.
