### PR TITLE
CI: Clean up space in ubuntu worker for extra-tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,15 +54,21 @@ jobs:
     strategy:
       matrix:
        os: [ ubuntu-latest, macos-15 ]
-       include:
-         - os: ubuntu-latest
-         - os: macos-15
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Free disk space (Ubuntu runners only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          large-packages: false
+          swap-storage: false
+          tool-cache: true
+
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v30
       - name: Nix cache


### PR DESCRIPTION
## Description

We introduce a cleanup action to remove unnecessary stuff from the Ubuntu worker.
This cleans significant amount of space and our tests no longer take all the remaining space.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
