### PR TITLE
[RFC] Track failures, expose stats, return cache info

### DIFF
--- a/cli/cli.hs
+++ b/cli/cli.hs
@@ -646,10 +646,13 @@ vmFromCommand cOpts cExecOpts cFileOpts execOpts sess = do
         exitFailure
       else
         Fetch.fetchContractWithSession conf sess block url addr' >>= \case
-          (Nothing, _) -> do
+          Fetch.FetchFailure _ -> do
             putStrLn $ "Error: contract not found: " <> show address
             exitFailure
-          (Just rpcContract, _) ->
+          Fetch.FetchError e -> do
+            putStrLn $ "Error: RPC failure: " <> show e
+            exitFailure
+          Fetch.FetchSuccess rpcContract _ ->
             -- if both code and url is given,
             -- fetch the contract and overwrite the code
               pure $ initialContract (mkCode $ fromJust code)
@@ -658,10 +661,13 @@ vmFromCommand cOpts cExecOpts cFileOpts execOpts sess = do
 
     (Just url, Just addr', Nothing) ->
       liftIO $ Fetch.fetchContractWithSession conf sess block url addr' >>= \case
-        (Nothing, _) -> do
+        Fetch.FetchFailure _ -> do
           putStrLn $ "Error, contract not found: " <> show address
           exitFailure
-        (Just rpcContract, _) -> pure $ Fetch.makeContractFromRPC rpcContract
+        Fetch.FetchError e -> do
+          putStrLn $ "Error: RPC failure: " <> show e
+          exitFailure
+        Fetch.FetchSuccess rpcContract _ -> pure $ Fetch.makeContractFromRPC rpcContract
 
     (_, _, Just c)  -> do
       let code = hexByteString $ strip0x c
@@ -759,10 +765,13 @@ symvmFromCommand cExecOpts sOpts cFileOpts sess calldata = do
   contract <- case (cExecOpts.rpc, cExecOpts.address, codeWrapped) of
     (Just url, Just addr', _) ->
       liftIO $ Fetch.fetchContractWithSession conf sess block url addr' >>= \case
-        (Nothing, _) -> do
+        Fetch.FetchFailure _ -> do
           putStrLn "Error, contract not found."
           exitFailure
-        (Just rpcContract', _) -> case codeWrapped of
+        Fetch.FetchError e -> do
+          putStrLn $ "Error: RPC failure: " <> show e
+          exitFailure
+        Fetch.FetchSuccess rpcContract' _ -> case codeWrapped of
               Nothing -> pure $ Fetch.makeContractFromRPC rpcContract'
               -- if both code and url is given,
               -- fetch the contract and overwrite the code

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -129,8 +129,9 @@ vmFromRpc :: App m => Session -> BlockNumber -> (Expr Buf, [Prop]) -> Expr EWord
 vmFromRpc sess blockNum calldata callvalue caller address = do
   conf <- readConfig
   ctrct <- liftIO $ fetchContractWithSession conf sess blockNum testRpc address >>= \case
-        (Nothing, _) -> internalError $ "contract not found: " <> show address
-        (Just contract', _) -> pure contract'
+        FetchFailure _ -> internalError $ "contract not found: " <> show address
+        FetchError e -> internalError $ "rpc error: " <> show e
+        FetchSuccess contract' _ -> pure contract'
 
   liftIO $ addFetchCache sess address ctrct
   blk <- liftIO $ fetchBlockWithSession conf sess blockNum testRpc >>= \case


### PR DESCRIPTION
## Description

@elopez kindly provided this WIP for some cache additional code. This allows third-party programs like Echidna to know if  the cache was hit or not. It also keeps tracks of the number of slots fetched per contract as well as track failures. This information is shown in Echidna, but it can also shown in hevm if you are interested (in this PR). After this is merged, we will proceed with the release of Echidna 2.3.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
