### PR TITLE
Fix Windows build failure

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+
+-- work around windows build failure
+-- https://github.com/kazu-yamamoto/crypton-certificate/issues/27
+constraints: crypton-x509-store <1.6.13 || >1.6.13


### PR DESCRIPTION
## Description

Windows build appears to be affected by https://github.com/kazu-yamamoto/crypton-certificate/issues/27

```
Failed to build crypton-x509-store-1.6.13.
Build log (
C:\cabal\logs\ghc-9.8.4\crypton-x509-_-1.6.13-55d2f9d81a282125cd8c29d0e632261e4600cf02.log
):
Preprocessing library for crypton-x509-store-1.6.13...
Building library for crypton-x509-store-1.6.13...
Error: [Cabal-7125]

Failed to build crypton-x509-store-1.6.13 (which is required by wreq-0.5.4.3). See the build log above for details.
Data\X509\File.hs:19:35: error:

Error:      error: function-like macro 'MIN_VERSION_unix' is not defined
   |
19 | #if !defined(mingw32_HOST_OS) && (MIN_VERSION_unix(2,8,0))
   |                                   ^
#if !defined(mingw32_HOST_OS) && (MIN_VERSION_unix(2,8,0))
                                  ^

Data\X509\File.hs:31:35: error:
Error:      error: function-like macro 'MIN_VERSION_unix' is not defined
   |
31 | #if defined(mingw32_HOST_OS) || !(MIN_VERSION_unix(2,8,0))
   |                                   ^
#if defined(mingw32_HOST_OS) || !(MIN_VERSION_unix(2,8,0))
                                  ^
2 errors generated.

Data\X509\File.hs:1:1: error:
Error:     `clang.exe' failed in phase `C pre-processor'. (Exit code: 1)
  |
1 | {-# LANGUAGE CPP #-}
  | ^
Error: Process completed with exit code 1.
```

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
