### PR TITLE
ci: add arm64-linux release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           - os: "ubuntu-latest"
             suffix: "x86_64-linux"
 
+          - os: "ubuntu-24.04-arm"
+            suffix: "arm64-linux"
+
     name: Build binary on ${{ matrix.os }}
     runs-on: ${{ matrix.os  }}
     steps:
@@ -69,6 +72,7 @@ jobs:
             ./hevm-x86_64-linux
             ./hevm-x86_64-macos
             ./hevm-arm64-macos
+            ./hevm-arm64-linux
       - name: prepare hackage artifacts
         run: |
           # cabal complains if we don't do this...


### PR DESCRIPTION
Add ubuntu-24.04-arm runner to build arm64-linux binaries for releases.