### PR TITLE
CI: Use action to clean up space in more jobs

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,16 @@
+name: Free disk space
+description: Free disk space on Linux runners
+runs:
+  using: composite
+  steps:
+    - name: Free disk space (Linux runners only)
+      if: runner.os == 'Linux'
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        android: true
+        dotnet: false
+        haskell: true
+        large-packages: false
+        swap-storage: false
+        tool-cache: false
+        docker-images: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,14 +60,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-
-      - name: Free disk space (Ubuntu runners only)
-        if: matrix.os == 'ubuntu-latest'
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          large-packages: false
-          swap-storage: false
-          tool-cache: true
+      - uses: ./.github/actions/free-disk-space
 
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v34
@@ -289,6 +282,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: ./.github/actions/free-disk-space
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v34
       - name: Nix cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,15 +47,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Free disk space (Ubuntu runners only)
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          large-packages: false
-          swap-storage: false
-          tool-cache: true
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - uses: ./.github/actions/free-disk-space
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v34
       - name: download binaries


### PR DESCRIPTION
To avoid code duplication we extract the step into a custom composite action.