### PR TITLE
SymEx: Introduce a type synonym and noop helper for path handler

### DIFF
--- a/test/EVM/Test/FuzzSymExec.hs
+++ b/test/EVM/Test/FuzzSymExec.hs
@@ -406,7 +406,7 @@ runCodeWithTrace rpcinfo evmEnv alloc txn fromAddr toAddress = withSolvers Z3 0 
       code' = alloc.code
       iterConf = IterConfig { maxIter = Nothing, askSmtIters = 1, loopHeuristic = Naive }
       fetcherSym = Fetch.oracle solvers Nothing rpcinfo
-      buildExpr vm = interpret fetcherSym iterConf vm runExpr (pure . pure)
+      buildExpr vm = interpret fetcherSym iterConf vm runExpr noopPathHandler
   origVM <- liftIO $ stToIO $ vmForRuntimeCode code' calldata' evmEnv alloc txn fromAddr toAddress
   expr <- buildExpr $ symbolify origVM
 

--- a/test/test.hs
+++ b/test/test.hs
@@ -1995,7 +1995,7 @@ tests = testGroup "hevm"
           let calldata = (WriteWord (Lit 0x0) (Var "u") (ConcreteBuf ""), [])
           initVM <- liftIO $ stToIO $ abstractVM calldata initCode Nothing True
           let iterConf = IterConfig {maxIter=Nothing, askSmtIters=1, loopHeuristic=StackBased }
-          paths <- interpret (Fetch.noRpcFetcher s) iterConf initVM runExpr (pure . pure)
+          paths <- interpret (Fetch.noRpcFetcher s) iterConf initVM runExpr noopPathHandler
           let exprSimp = map Expr.simplify paths
           assertBoolM "unexptected partial execution" (not $ any isPartial exprSimp)
     , test "mixed-concrete-symbolic-args" $ do
@@ -2087,7 +2087,7 @@ tests = testGroup "hevm"
         withDefaultSolver $ \s -> do
           vm <- liftIO $ stToIO $ loadSymVM runtimecode (Lit 0) initCode False
           let iterConf = IterConfig {maxIter=Nothing, askSmtIters=1, loopHeuristic=StackBased }
-          paths <- interpret (Fetch.noRpcFetcher s) iterConf vm runExpr (pure . pure)
+          paths <- interpret (Fetch.noRpcFetcher s) iterConf vm runExpr noopPathHandler
           let exprSimp = map Expr.simplify paths
           assertBoolM "expected partial execution" (any isPartial exprSimp)
     ]


### PR DESCRIPTION
## Description

The type synonym and helper will enable making change in one place instead of updating type and/or usage of noop handler at every location they are used.
It will also hopefully make it a bit more clear what this type represents.

This is a follow up on #965.