### PR TITLE
Test: Small cleanup

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -234,8 +234,6 @@ common test-base
   autogen-modules:
     Paths_hevm
   build-depends:
-    QuickCheck,
-    quickcheck-instances,
     aeson,
     base,
     containers,
@@ -248,11 +246,9 @@ common test-base
     process,
     tasty,
     tasty-hunit,
-    tasty-quickcheck,
     tasty-expected-failure,
     temporary,
     text,
-    vector,
     witherable,
     optics-core,
     witch,
@@ -264,7 +260,6 @@ library test-utils
   default-language: GHC2021
   exposed-modules:
     EVM.Test.Utils
-    EVM.Test.FuzzSymExec
     EVM.Test.BlockchainTests
 
 common test-common
@@ -273,10 +268,10 @@ common test-common
   if flag(devel)
     ghc-options: -threaded -with-rtsopts=-N
   build-depends:
-    test-utils
+    test-utils,
+    vector,
   other-modules:
     EVM.Test.Utils
-    EVM.Test.FuzzSymExec
     EVM.Test.BlockchainTests
 
 --- Test Suites ---
@@ -290,6 +285,7 @@ test-suite test
     test.hs
   other-modules:
     EVM.Expr.ExprTests
+    EVM.Test.FuzzSymExec
   build-depends:
     base16,
     binary,
@@ -298,7 +294,10 @@ test-suite test
     here,
     time,
     optics-extra,
-    regex
+    QuickCheck,
+    quickcheck-instances,
+    regex,
+    tasty-quickcheck,
 
 -- these tests require network access so we split them into a separate test
 -- suite to make it easy to skip them when running nix-build


### PR DESCRIPTION
## Description

We explicitly export only the main test tree from `FuzzSymExec.hs`. This reveales that we can remove some unused code. We also move this module to the `test` test-suite in cabal since this is the only place where it is used.
