### PR TITLE
Small fix in `--debug` printing: it should say "potential" cex

### DIFF
--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -875,7 +875,7 @@ verifyInputsWithHandler solvers opts fetcher preState post cexHandler = do
     putStrLn $ "   Exploration and solving finished, " <> show (length results) <> " branch(es) checked in call " <> call <> " of which partial: "
                 <> show (length smtResults)
     let cexs = filter (\(res, _) -> not . isQed $ res) smtResults
-    putStrLn $ "   Found " <> show (length cexs) <> " counterexample(s) in call " <> call
+    putStrLn $ "   Found " <> show (length cexs) <> " potential counterexample(s) in call " <> call
 
   pure (smtResults, catMaybes partials)
   where


### PR DESCRIPTION
## Description
The printing is misleading. It's a _potential_ cex, not an actual one -- it's simply checked for _not_ being a QeD. This ONLY affects `--debug` printing:
```
cabal run exe:hevm -- symbolic --code "608060405234801561000f575f80fd5b5060043610610029575f3560e01c80630eb414601461002d575b5f80fd5b610047600480360381019061004291906100df565b610049565b005b5f60405160200161005a9190610203565b604051602081830303815290604052805190602001205f6040516020016100819190610203565b60405160208183030381529060405280519060200120146100a5576100a4610219565b5b50565b5f80fd5b5f819050919050565b6100be816100ac565b81146100c8575f80fd5b50565b5f813590506100d9816100b5565b92915050565b5f602082840312156100f4576100f36100a8565b5b5f610101848285016100cb565b91505092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f600282049050600182168061014e57607f821691505b6020821081036101615761016061010a565b5b50919050565b5f81905092915050565b5f819050815f5260205f209050919050565b5f815461018f81610137565b6101998186610167565b9450600182165f81146101b357600181146101c8576101fa565b60ff19831686528115158202860193506101fa565b6101d185610171565b5f5b838110156101f2578154818901526001820191506020810190506101d3565b838801955050505b50505092915050565b5f61020e8284610183565b915081905092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52600160045260245ffdfea2646970667358221220cec117ff0217f83b6fd5f689e473af23a54dee02df46ad5142284d4fc1bb80e364736f6c634300081a0033" --debug
Configuration is affected by the following files:
- cabal.project
Using assertion code(s): 1
   Keccak preimages in state: 0
   Exploring call prefix 0xunknown
Interpretation finished, collected 56 results.
   Exploration and solving finished, 56 branch(es) checked in call prefix 0xunknown of which partial: 56
   Found 12 potential counterexample(s) in call prefix 0xunknown

   [WARNING] hevm was only able to partially explore symbolically due to:
      12x -> CopySlice with a symbolically sized region not currently implemented, cannot execute SMT solver on this query
      12x -> Max iterations reached at addr: SymAddr "entrypoint" at pc: 475
```

Notice the `   Found 12 counterexample(s) in call prefix 0xunknown`. It's not a CeX just a potential CeX.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
