### PR TITLE
SMT: Do not mix `MaybeT IO a` and `IO (Maybe a)` computations

### DIFF
--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -31,8 +31,7 @@ module EVM.SMT
 import Prelude hiding (LT, GT, Foldable(..))
 
 import Control.Monad
-import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Maybe (MaybeT(..), runMaybeT, hoistMaybe)
+import Control.Monad.Trans.Maybe (hoistMaybe)
 import Data.Containers.ListUtils (nubOrd, nubInt)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
@@ -771,21 +770,22 @@ parseTxCtx name
   | Just a <- TS.stripPrefix "codehash_" name = CodeHash (parseEAddr a)
   | otherwise = internalError $ "cannot parse " <> (TS.unpack name) <> " into an Expr"
 
-getAddrs :: (TS.Text -> Expr EAddr) -> (Text -> IO (Maybe Text)) -> [TS.Text] -> IO (Maybe (Map (Expr EAddr) Addr))
-getAddrs parseName getVal names = runMaybeT $ do
+type ValGetter = Text -> MaybeIO Text
+
+getAddrs :: (TS.Text -> Expr EAddr) -> ValGetter -> [TS.Text] -> MaybeIO (Map (Expr EAddr) Addr)
+getAddrs parseName getVal names = do
   m <- foldM (getOne parseAddr getVal) mempty names
   pure $ Map.mapKeys parseName m
 
-getVars :: (TS.Text -> Expr EWord) -> (Text -> IO (Maybe Text)) -> [TS.Text] -> IO (Maybe (Map (Expr EWord) W256))
-getVars parseName getVal names = runMaybeT $ do
+getVars :: (TS.Text -> Expr EWord) -> ValGetter -> [TS.Text] -> MaybeIO (Map (Expr EWord) W256)
+getVars parseName getVal names = do
   m <- foldM (getOne parseW256 getVal) mempty names
   pure $ Map.mapKeys parseName m
 
-getOne :: (SpecConstant -> a) -> (Text -> IO (Maybe Text)) -> Map TS.Text a -> TS.Text -> MaybeT IO (Map TS.Text a)
+getOne :: (SpecConstant -> a) -> ValGetter -> Map TS.Text a -> TS.Text -> MaybeIO (Map TS.Text a)
 getOne parseVal getVal acc name = do
-  maybeRaw <- lift $ getVal (T.fromStrict name)
+  raw <- getVal (T.fromStrict name)
   val <- hoistMaybe $ do
-    raw <- maybeRaw
     Right (ResSpecific (valParsed :| [])) <- pure $ parseCommentFreeFileMsg getValueRes (T.toStrict raw)
     (TermQualIdentifier (Unqualified (IdSymbol symbol)), TermSpecConstant sc) <- pure valParsed
     guard (symbol == name)
@@ -794,29 +794,27 @@ getOne parseVal getVal acc name = do
 
 -- | Queries the solver for models for each of the expressions representing the
 -- max read index for a given buffer
-queryMaxReads :: (Text -> IO (Maybe Text)) -> Map Text (Expr EWord) -> IO (Maybe (Map Text W256))
-queryMaxReads getVal maxReads = runMaybeT $ mapM (MaybeT . queryValue getVal) maxReads
+queryMaxReads :: ValGetter -> Map Text (Expr EWord) -> MaybeIO (Map Text W256)
+queryMaxReads getVal maxReads = mapM (queryValue getVal) maxReads
 
 -- | Gets the initial model for each buffer, these will often be much too large for our purposes
-getBufs :: (Text -> IO (Maybe Text)) -> [Text] -> IO (Maybe (Map (Expr Buf) BufModel))
-getBufs getVal bufs = runMaybeT $ foldM getBuf mempty bufs
+getBufs :: ValGetter -> [Text] -> MaybeIO (Map (Expr Buf) BufModel)
+getBufs getVal bufs = foldM getBuf mempty bufs
   where
-    getLength :: Text -> MaybeT IO W256
+    getLength :: Text -> MaybeIO W256
     getLength name = do
-      maybeVal <- lift $ getVal (name <> "_length ")
+      val <- getVal (name <> "_length ")
       hoistMaybe $ do
-        val <- maybeVal
         Right (ResSpecific (parsed :| [])) <- pure $ parseCommentFreeFileMsg getValueRes (T.toStrict val)
         (TermQualIdentifier (Unqualified (IdSymbol symbol)), TermSpecConstant sc) <- pure parsed
         guard (symbol == T.toStrict (name <> "_length"))
         pure $ parseW256 sc
 
-    getBuf :: Map (Expr Buf) BufModel -> Text -> MaybeT IO (Map (Expr Buf) BufModel)
+    getBuf :: Map (Expr Buf) BufModel -> Text -> MaybeIO (Map (Expr Buf) BufModel)
     getBuf acc name = do
       len <- getLength name
-      maybeVal <- lift $ getVal name
+      val <- getVal name
       buf <- hoistMaybe $ do
-        val <- maybeVal
         Right (ResSpecific (valParsed :| [])) <- pure $ parseCommentFreeFileMsg getValueRes (T.toStrict val)
         (TermQualIdentifier (Unqualified (IdSymbol symbol)), term) <- pure valParsed
         guard (T.fromStrict symbol == name)
@@ -862,35 +860,33 @@ getBufs getVal bufs = runMaybeT $ foldM getBuf mempty bufs
 -- well as the concrete part of the storage prestate and returns a fully
 -- concretized storage
 getStore
-  :: (Text -> IO (Maybe Text))
+  :: ValGetter
   -> StorageReads
-  -> IO (Maybe (Map (Expr EAddr) (Map W256 W256)))
-getStore getVal (StorageReads innerMap) = runMaybeT $ do
+  -> MaybeIO (Map (Expr EAddr) (Map W256 W256))
+getStore getVal (StorageReads innerMap) = do
   results <- forM (Map.toList innerMap) $ \((addr, idx), slots) -> do
     let name = toLazyText (storeName addr idx)
-    maybeRaw <- lift $ getVal name
+    raw <- getVal name
     fun <- hoistMaybe $ do
-      raw <- maybeRaw
       Right (ResSpecific (valParsed :| [])) <- pure $ parseCommentFreeFileMsg getValueRes (T.toStrict raw)
       (TermQualIdentifier (Unqualified (IdSymbol symbol)), term) <- pure valParsed
       guard (symbol == T.toStrict name)
       pure $ interpret1DArray Map.empty term
     -- create a map by adding only the locations that are read by the program
     store <- foldM (\m slot -> do
-      slot' <- MaybeT $ queryValue getVal slot
+      slot' <- queryValue getVal slot
       pure $ Map.insert slot' (fun slot') m) Map.empty (Set.toList slots)
     pure (addr, store)
   pure $ Map.fromList results
 
 -- | Ask the solver to give us the concrete value of an arbitrary abstract word
-queryValue :: (Text -> IO (Maybe Text)) -> Expr EWord -> IO (Maybe W256)
-queryValue _ (Lit w) = pure (Just w)
+queryValue :: ValGetter -> Expr EWord -> MaybeIO W256
+queryValue _ (Lit w) = pure w
 queryValue getVal w = do
   -- this exprToSMT should never fail, since we have already ran the solver
   let expr = toLazyText $ fromRight' $ exprToSMT w
-  maybeRaw <- getVal expr
-  pure $ do
-    raw <- maybeRaw
+  raw <- getVal expr
+  hoistMaybe $ do
     valTxt <- extractValue raw
     Right sc <- pure $ parseString specConstant (T.toStrict valTxt)
     pure $ parseW256 sc

--- a/src/EVM/SMT/Types.hs
+++ b/src/EVM/SMT/Types.hs
@@ -1,12 +1,15 @@
 module EVM.SMT.Types where
 
-import Data.Text.Lazy (Text)
-import Data.Text.Lazy.Builder
+import Control.Monad.Trans.Maybe (MaybeT)
 import Data.Map (Map)
 import Data.Map qualified as Map (unionWith)
 import Data.Set (Set)
+import Data.Text.Lazy (Text)
+import Data.Text.Lazy.Builder
 
 import EVM.Types
+
+type MaybeIO = MaybeT IO
 
 data SMTEntry = SMTCommand Builder | SMTComment Builder
   deriving (Eq)


### PR DESCRIPTION
For most of the internal computations, we can stay within `MaybeT IO`, we convert to `IO (Maybe a)` only once at the end.