### PR TITLE
Cheat: Abort VM on failed assume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SMT queries now run in separate processes, which allows us to better manage
   timeouts and memory usage by the SMT solver.
 - We now allow limiting the SMT solver's memory usage via `--smt-memory` (in MB).
-
-## Changed
 - The option `--smttimeout` is now called `--smt-timeout` for consistency with other
   options.
+- We now abort VM run on a failed `assume`.
 
 ## [0.57.0] - 2026-01-08
 

--- a/src/EVM/Format.hs
+++ b/src/EVM/Format.hs
@@ -440,6 +440,7 @@ prettyError = \case
   NonceOverflow -> "Nonce overflow"
   BadCheatCode reason a -> "Bad cheat code: " <>  reason <> " sig: " <> show a
   NonexistentFork a -> "Fork ID does not exist: " <> show a
+  AssumeCheatFailed -> "Assume failed"
 
 prettyvmresult :: Expr End -> String
 prettyvmresult (Failure _ _ (Revert (ConcreteBuf ""))) = "Revert"

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -558,6 +558,7 @@ data EvmError
   | NonceOverflow
   | BadCheatCode String FunctionSelector
   | NonexistentFork Int
+  | AssumeCheatFailed
   deriving (Show, Eq, Ord)
 
 evmErrToString :: EvmError -> String


### PR DESCRIPTION
## Description

Previously, we would simply ignore assume cheatcode on concrete mode. Now, we terminate VM if the condition is falsified. We introduce new error result to indicate this situation at the end of transaction.



## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
