### PR TITLE
Fix sender extraction for EIP-155 transactions

### DIFF
--- a/src/EVM/Transaction.hs
+++ b/src/EVM/Transaction.hs
@@ -107,6 +107,7 @@ sender tx = ecrec v' tx.r  tx.s hash
   where hash = keccak' (signingData tx)
         v    = tx.v
         v'   = if v == 27 || v == 28 then v
+               else if v >= 35 then 28 - (v `mod` 2) -- EIP155
                else 27 + v
 
 sign :: Integer -> Transaction -> Transaction


### PR DESCRIPTION
## Description

The 0x01 precompile expects v in {27, 28} but EIP-155 sets v to be `chainid * 2 + 35 + {0, 1}`. This normalizes v back to {27, 28} when it is  >= 35

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
