### PR TITLE
Replace `cryptonite` with `crypton`

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -161,7 +161,7 @@ library
     mtl                               >= 2.2 && < 2.4,
     filepath                          >= 1.4.2 && < 1.6,
     cereal                            >= 0.5.8 && < 0.6,
-    cryptonite                        >= 0.30 && < 0.31,
+    crypton                           >= 0.32 && < 1.1,
     memory                            >= 0.16.0 && < 0.20,
     data-dword                        >= 0.3.1 && < 0.4,
     process                           >= 1.6.5 && < 1.7,

--- a/src/EVM/Sign.hs
+++ b/src/EVM/Sign.hs
@@ -48,7 +48,7 @@ sign hash sk = (v, r, s)
     r = unsafeInto $ sign_r sig
     s = unsafeInto lowS
 
-    -- this is a little bit sad, but cryptonite doesn't give us back a v value
+    -- this is a little bit sad, but crypton doesn't give us back a v value
     -- so we compute it by guessing one, and then seeing if that gives us the right answer from ecrecover
     v = if ecrec 28 r s hash == deriveAddr sk
         then 28


### PR DESCRIPTION
## Description

Replace deprecated `cryptonite` with `crypton`. Closes #969

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
