### PR TITLE
EVM: fix MCOPY stack corruption on out-of-gas in nested calls

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -658,7 +658,7 @@ exec1 conf = do
 
         OpMcopy -> {-# SCC "OpMcopy" #-}
           case stk of
-            dstOff:srcOff:sz:xs ->  do
+            dstOff:srcOff:sz:xs ->
               case sz of
                 Lit sz' -> do
                   let words_copied = (sz' + 31) `div` 32
@@ -666,14 +666,16 @@ exec1 conf = do
                   burn (g_verylow + (unsafeInto g_mcopy)) $
                     accessMemoryRange srcOff sz $ accessMemoryRange dstOff sz $ do
                       next
+                      assign' (#state % #stack) xs
                       mcopy sz srcOff dstOff
                 _ -> do
                   -- symbolic, ignore gas
                   next
+                  assign' (#state % #stack) xs
                   mcopy sz srcOff dstOff
-              assign' (#state % #stack) xs
             _ -> underrun
             where
+            mcopy (Lit 0) _ _ = pure ()
             mcopy sz srcOff dstOff = do
                   m <- gets (.state.memory)
                   case m of


### PR DESCRIPTION
## Description

The MCOPY opcode handler had `assign' (#state % #stack) xs` placed outside the `burn` continuation block. When a nested call ran out of gas during MCOPY execution:

1. burn detected insufficient gas and called vmError
2. vmError called finishFrame which correctly restored the parent's stack
3. Control returned to MCOPY and the code continued past the burn block
4. `assign' (#state % #stack) xs` executed, overwriting the parent's restored stack with the callee's remaining stack

This caused the parent contract to lose its stack state, leading to an incorrect execution. This issue was detected with the newer Ethereum tests in #988 

The fix moves `assign' (#state % #stack) xs` inside the burn continuation so it only executes when burn succeeds.

This also adds an early return for zero-size MCOPY operations.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
