### PR TITLE
EVM: EIP-1153: preserve transient storage in replaceCode

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2345,6 +2345,7 @@ replaceCode target newCode =
               { balance = now.balance
               , nonce = now.nonce
               , storage = now.storage
+              , tStorage = now.tStorage
               }
         RuntimeCode _ ->
           internalError $ "Can't replace code of deployed contract " <> show target


### PR DESCRIPTION
## Description
The `replaceCode` function now preserves the `tStorage` field when converting from `InitCode` to `RuntimeCode`. Per EIP-1153, transient storage set during constructor execution should be accessible in the deployed contract.

This fixes 4 failing `eip1153_tstore` tests from #988: 
https://github.com/ethereum/execution-specs/blob/2c549ce0b655dab328e917ed251acbae5a655cbb/tests/cancun/eip1153_tstore/test_tstorage_create_contexts.py#L72-L126

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
