### PR TITLE
Tests: Signal failure when we inadvertently lose some ethereum tests

### DIFF
--- a/test/EVM/Test/BlockchainTests.hs
+++ b/test/EVM/Test/BlockchainTests.hs
@@ -109,6 +109,9 @@ prepareTests = do
   rootDir <- liftIO rootDirectory
   liftIO $ putStrLn $ "Loading and parsing json files from ethereum-tests from " <> show rootDir
   cases <- liftIO allTestCases
+  let testCount = sum . fmap Map.size $ cases
+  let expectedTestCount = 16989
+  when (testCount < expectedTestCount) $ internalError $ "Lower than expected number of tests!\nExpected: " <> (show expectedTestCount) <> "\nGot: " <> (show testCount)
   groups <- forM (Map.toList cases) (\(f, subtests) -> testGroup (makeRelative rootDir f) <$> (process subtests))
   liftIO $ putStrLn "Loaded."
   pure $ testGroup "ethereum-tests" groups


### PR DESCRIPTION
## Description
It has happened on two occasions before that there was an error and suddenly we were not getting any tests cases from the ethereum test repository.
(One was erroneus change in the parsing, second was an error in the url.)
Previously, such a bug could (and did) go unnoticed, because the CI job would run successfully with 0 tests passing and 0 tests failing. Therefore, we specify the expected number of tests in the code and error out if the actual number is lower than the expected number.

## Checklist

- [x] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
