### PR TITLE
EVM: Introduce deafult VMOpts

### DIFF
--- a/bench/bench-perf.hs
+++ b/bench/bench-perf.hs
@@ -20,7 +20,6 @@ import EVM.Types
 import EVM.UnitTest
 import Test.Tasty.Bench
 import Control.Monad.ST
-import EVM.FeeSchedule (feeSchedule)
 
 -- benchmark hevm using tasty-bench
 
@@ -38,36 +37,10 @@ vm0 :: Contract -> ST RealWorld (VM Concrete)
 vm0 c = makeVm $ vm0Opts c
 
 vm0Opts :: Contract -> VMOpts Concrete
-vm0Opts c =
-  VMOpts
-    { contract = c,
-      calldata = (ConcreteBuf "", []),
-      value = Lit 0xfffffffffffff, -- balance
-      baseState = EmptyBase,
-      address = LitAddr 0xacab,
-      caller = LitAddr 0,
-      origin = LitAddr 0,
-      gas = 0xffffffffffffffff,
-      baseFee = 0,
-      priorityFee = 0,
-      gaslimit = 0xffffffffffffffff,
-      coinbase = LitAddr 0,
-      number = Lit 0,
-      timestamp = Lit 0,
-      blockGaslimit = 0xffffffffffffffff,
-      gasprice = 0,
-      maxCodeSize = 0xffffffff,
-      prevRandao = 0,
-      schedule = feeSchedule,
-      chainId = 1,
-      create = False,
-      txAccessList = mempty, -- TODO: support me soon
-      allowFFI = False,
-      otherContracts = [],
-      freshAddresses = 0,
-      beaconRoot = 0,
-      parentHash = 0
-    }
+vm0Opts c = defaultVMOpts
+  { contract = c,
+    value = Lit 0xfffffffffffff -- balance
+  }
 
 vmOptsToTestVMParams :: VMOpts Concrete -> TestVMParams
 vmOptsToTestVMParams v =

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -15,6 +15,7 @@ import EVM.Expr (readStorage, concStoreContains, writeStorage, readByte, readWor
   writeByte, bufLength, indexWord, readBytes, copySlice, wordToAddr, maybeLitByteSimp, maybeLitWordSimp, maybeLitAddrSimp)
 import EVM.Expr qualified as Expr
 import EVM.FeeSchedule (FeeSchedule (..))
+import EVM.FeeSchedule qualified as Fees (feeSchedule)
 import EVM.Op
 import EVM.Precompiled qualified
 import EVM.Solidity
@@ -65,6 +66,37 @@ import Witch (into, tryFrom, unsafeInto, tryInto)
 import Crypto.Hash (Digest, SHA256, RIPEMD160)
 import Crypto.Hash qualified as Crypto
 import Crypto.Number.ModArithmetic (expFast)
+
+defaultVMOpts :: VMOps t => VMOpts t
+defaultVMOpts = VMOpts
+  { contract       = emptyContract
+  , otherContracts = []
+  , calldata       = mempty
+  , value          = Lit 0
+  , address        = LitAddr 0xacab
+  , caller         = LitAddr 0
+  , origin         = LitAddr 0
+  , gas            = toGas maxBound
+  , gaslimit       = maxBound
+  , baseFee        = 0
+  , priorityFee    = 0
+  , coinbase       = LitAddr 0
+  , number         = Lit 0
+  , timestamp      = Lit 0
+  , blockGaslimit  = maxBound
+  , gasprice       = 0
+  , maxCodeSize    = 0xffffffff
+  , prevRandao     = 0
+  , schedule       = Fees.feeSchedule
+  , chainId        = 1
+  , create         = False
+  , baseState      = EmptyBase
+  , txAccessList   = mempty
+  , allowFFI       = False
+  , freshAddresses = 0
+  , beaconRoot     = 0
+  , parentHash     = 0
+  }
 
 blankState :: VMOps t => ST RealWorld (FrameState t)
 blankState = do

--- a/src/EVM/Exec.hs
+++ b/src/EVM/Exec.hs
@@ -2,7 +2,6 @@ module EVM.Exec where
 
 import EVM hiding (createAddress)
 import EVM.Concrete (createAddress)
-import EVM.FeeSchedule (feeSchedule)
 import EVM.Types
 
 import Control.Monad.Trans.State.Strict (get, State)
@@ -18,34 +17,13 @@ ethrunAddress = Addr 0x00a329c0648769a73afac7f9381e08fb43dbea72
 
 vmForEthrunCreation :: VMOps t => ByteString -> ST RealWorld (VM t)
 vmForEthrunCreation creationCode =
-  (makeVm $ VMOpts
+  (makeVm $ defaultVMOpts
     { contract = initialContract (InitCode creationCode mempty)
-    , otherContracts = []
-    , calldata = mempty
-    , value = Lit 0
-    , baseState = EmptyBase
     , address = createAddress ethrunAddress 1
     , caller = LitAddr ethrunAddress
     , origin = LitAddr ethrunAddress
-    , coinbase = LitAddr 0
-    , number = Lit 0
-    , timestamp = Lit 0
     , blockGaslimit = 0
-    , gasprice = 0
     , prevRandao = 42069
-    , gas = toGas 0xffffffffffffffff
-    , gaslimit = 0xffffffffffffffff
-    , baseFee = 0
-    , priorityFee = 0
-    , maxCodeSize = 0xffffffff
-    , schedule = feeSchedule
-    , chainId = 1
-    , create = False
-    , txAccessList = mempty
-    , allowFFI = False
-    , freshAddresses = 0
-    , beaconRoot = 0
-    , parentHash = 0
     }) <&> set (#env % #contracts % at (LitAddr ethrunAddress))
              (Just (initialContract (RuntimeCode (ConcreteRuntimeCode ""))))
 

--- a/src/EVM/UnitTest.hs
+++ b/src/EVM/UnitTest.hs
@@ -11,7 +11,6 @@ import EVM.Dapp
 import EVM.Effects
 import EVM.Exec
 import EVM.Expr qualified as Expr
-import EVM.FeeSchedule (feeSchedule)
 import EVM.Fetch qualified as Fetch
 import EVM.Format
 import EVM.Solidity
@@ -524,13 +523,10 @@ makeTxCall params (cd, cdProps) = do
   vm <- get
   put $ initTx vm
 
-initialUnitTestVm :: VMOps t => UnitTestOptions -> SolcContract -> ST RealWorld (VM t)
+initialUnitTestVm :: forall t. VMOps t => UnitTestOptions -> SolcContract -> ST RealWorld (VM t)
 initialUnitTestVm (UnitTestOptions {..}) theContract = do
-  vm <- makeVm $ VMOpts
+  vm <- makeVm $ (defaultVMOpts @t)
            { contract = initialContract (InitCode theContract.creationCode mempty)
-           , otherContracts = []
-           , calldata = mempty
-           , value = Lit 0
            , address = testParams.address
            , caller = testParams.caller
            , origin = testParams.origin
@@ -545,15 +541,9 @@ initialUnitTestVm (UnitTestOptions {..}) theContract = do
            , priorityFee = testParams.priorityFee
            , maxCodeSize = testParams.maxCodeSize
            , prevRandao = testParams.prevrandao
-           , schedule = feeSchedule
            , chainId = testParams.chainId
            , create = True
-           , baseState = EmptyBase
-           , txAccessList = mempty -- TODO: support unit test access lists???
            , allowFFI = ffiAllowed
-           , freshAddresses = 0
-           , beaconRoot = 0
-           , parentHash = 0
            }
   let creator =
         initialContract (RuntimeCode (ConcreteRuntimeCode ""))

--- a/test/EVM/ConcreteExecution/ConcreteExecutionTests.hs
+++ b/test/EVM/ConcreteExecution/ConcreteExecutionTests.hs
@@ -14,14 +14,13 @@ import Data.Vector qualified as V
 
 import EVM.ABI
 import EVM.Effects qualified as Effects
-import EVM.FeeSchedule
 import EVM.Fetch qualified as Fetch
 import EVM.Solidity (solcRuntime)
 import EVM.Solvers (defMemLimit)
 import EVM.Stepper qualified
 import EVM.Transaction (initTx)
 import EVM.Types
-import EVM (initialContract, makeVm)
+import EVM (initialContract, makeVm, defaultVMOpts)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -42,34 +41,9 @@ executeSingleCall sourceCode contractName functionName abiArgs = do
   let functionSignature = functionName <> "(" <> T.intercalate "," (map (abiTypeSolidity . abiValueType) abiArgs) <> ")"
   let callData = abiMethod functionSignature (AbiTuple $ V.fromList abiArgs)
   let contractWithCode = initialContract (RuntimeCode $ ConcreteRuntimeCode runtimeCode)
-  initialVM <- stToIO $ makeVm $ VMOpts
-    { contract     = contractWithCode
-    , otherContracts = []
-    , calldata       = (ConcreteBuf callData, [])
-    , value          = Lit 0
-    , address        = (LitAddr 0xacab)
-    , caller         = (LitAddr 0)
-    , origin         = (LitAddr 0)
-    , gas            = maxBound
-    , baseFee        = 0
-    , priorityFee    = 0
-    , gaslimit       = maxBound
-    , coinbase       = (LitAddr 0)
-    , number         = Lit 0
-    , timestamp      = Lit 0
-    , blockGaslimit  = maxBound
-    , gasprice       = 0
-    , maxCodeSize    = maxBound
-    , prevRandao     = 0
-    , schedule       = feeSchedule
-    , chainId        = 1
-    , create         = False
-    , baseState      = EmptyBase
-    , txAccessList   = mempty
-    , allowFFI       = False
-    , freshAddresses = 0
-    , beaconRoot     = 0
-    , parentHash     = 0
+  initialVM <- stToIO $ makeVm $ defaultVMOpts
+    { contract = contractWithCode
+    , calldata = (ConcreteBuf callData, [])
     }
   let withInitializedTransactionVM = EVM.Transaction.initTx initialVM
   let fetcher = Fetch.zero 0 Nothing defMemLimit

--- a/test/rpc.hs
+++ b/test/rpc.hs
@@ -10,7 +10,7 @@ import Data.Map qualified as Map
 import Data.Text (Text)
 import Data.Vector qualified as V
 
-import EVM (makeVm, symbolify)
+import EVM (makeVm, symbolify, defaultVMOpts)
 import EVM.ABI
 import EVM.Fetch
 import EVM.SMT
@@ -138,34 +138,20 @@ vmFromRpc sess blockNum calldata callvalue caller address = do
     Nothing -> internalError "could not fetch block"
     Just b -> pure b
 
-  liftIO $ stToIO (makeVm $ VMOpts
+  liftIO $ stToIO (makeVm $ defaultVMOpts
     { contract       = makeContractFromRPC ctrct
-    , otherContracts = []
     , calldata       = calldata
     , value          = callvalue
     , address        = LitAddr address
     , caller         = caller
-    , origin         = LitAddr 0xacab
-    , gas            = 0xffffffffffffffff
-    , gaslimit       = 0xffffffffffffffff
     , baseFee        = blk.baseFee
-    , priorityFee    = 0
     , coinbase       = blk.coinbase
     , number         = blk.number
     , timestamp      = blk.timestamp
     , blockGaslimit  = blk.gaslimit
-    , gasprice       = 0
     , maxCodeSize    = blk.maxCodeSize
     , prevRandao     = blk.prevRandao
     , schedule       = blk.schedule
-    , chainId        = 1
-    , create         = False
-    , baseState      = EmptyBase
-    , txAccessList   = mempty
-    , allowFFI       = False
-    , freshAddresses = 0
-    , beaconRoot     = 0
-    , parentHash     = 0
     })
 
 testRpc :: Text


### PR DESCRIPTION
This value represents decent choice for the VMOpts fields. It can be easily customized using record update syntax. This should make it easy if we need to introduce a new field there.