### PR TITLE
Test: Increase gas limit lower bound in fuzz tests

### DIFF
--- a/test/EVM/Test/FuzzSymExec.hs
+++ b/test/EVM/Test/FuzzSymExec.hs
@@ -777,7 +777,7 @@ newtype GasLimitInt = GasLimitInt (Int)
 
 instance Arbitrary GasLimitInt where
   arbitrary = do
-    let mkLimit = chooseInt (50000, 0xfffff)
+    let mkLimit = chooseInt (60000, 0xfffff)
     fmap GasLimitInt mkLimit
 
 -- GenTxDataRaw


### PR DESCRIPTION
Due to [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623), some transactions which were allowed before would be rejected in newer EVM forks. This change is in effect since Prague.
For some random transactions we generate in our tests, evm rejects the transaction immediately without creating a trace, while hevm happily tries to execute the transaction. This results in a mismatch in behaviour where hevm produces a trace while evm produces no trace.

As a partial workaround, I propose to raise the lower bound on the gas limit when we generate random transactions.
This should make it less likely to generate a transaction that would be rejected by `evm`.

We could also explicitly discard the test if `evm` rejects the transaction.
This is a partial workaround for #1005.