### PR TITLE
SymExec: Fix dumping formatted expression to file

### DIFF
--- a/src/EVM/SymExec.hs
+++ b/src/EVM/SymExec.hs
@@ -960,8 +960,8 @@ equivalenceCheck' solvers sess branchesA branchesB create = do
       let differingEndStates = sortBySize $ mapMaybe (view _1) ps
       let knownIssues = foldr ((<>) . (view _2)) mempty ps
       when conf.debug $ liftIO $ putStrLn $ "Asking the SMT solver for " <> (show $ length differingEndStates) <> " pairs"
-      when conf.dumpEndStates $ forM_ (zip differingEndStates [(1::Integer)..]) (\(x, i) ->
-        liftIO $ T.writeFile ("prop-checked-" <> show i <> ".prop") (T.pack $ show x))
+      when conf.dumpEndStates $ forM_ (zip differingEndStates [(1::Integer)..]) (\((props, msg), i) ->
+        liftIO $ T.writeFile ("prop-checked-" <> show i <> ".prop") (T.pack $ show props <> msg))
 
       procs <- liftIO getNumProcessors
       newDifferences <- checkAll differingEndStates procs


### PR DESCRIPTION
In equivalence checking, when comparing two branches, we can dump the end states to a file.
The information about the end state is collected as (Set Prop, String), where the first entry represents the some conditions under which the end states are different and the second entry is the formatted Expr representing the end state.
Previously, when dumping this information to a file,  we would call `show` on this pair to convert it into a string, which is then written to a file.
However, the second entry (the formatted expression) already contains newlines (and other special characters), and `show` converts that to literal string, so we lose the nice formatting.
Compare the behaviour:
```
ghci> let s :: String = "hello\nworld"
ghci> putStrLn s
hello
world
ghci> putStrLn (show s)
"hello\nworld"
```

The fix is to call `show` only on the first entry and keep the second entry as is.

