### PR TITLE
Optional Echidna compatibility check as a Github Action

### DIFF
--- a/.github/workflows/echidna-compat.yml
+++ b/.github/workflows/echidna-compat.yml
@@ -46,30 +46,11 @@ jobs:
           with open('stack.yaml', 'r') as f:
               data = yaml.safe_load(f)
 
-          if 'extra-deps' in data:
-              new_deps = []
-              found_hevm = False
-              for dep in data['extra-deps']:
-                  # Identify if this is the remote hevm dependency
-                  is_hevm = (isinstance(dep, dict)
-                             and 'git' in dep
-                             and 'hevm' in dep['git'])
-                  if is_hevm:
-                      if not found_hevm:
-                          new_deps.append('./hevm')
-                          found_hevm = True
-                      continue
-                  if dep == './hevm':
-                      found_hevm = True
-                      new_deps.append(dep)
-                      continue
-                  new_deps.append(dep)
-
-              if not found_hevm:
-                  # Insert hevm at the beginning of extra-deps
-                  new_deps.insert(0, './hevm')
-
-              data['extra-deps'] = new_deps
+          deps = data.get('extra-deps', [])
+          deps = [d for d in deps if not (isinstance(d, str) and 'hevm' in d)
+                                  and not (isinstance(d, dict) and 'git' in d and 'hevm' in d['git'])]
+          deps.insert(0, './hevm')
+          data['extra-deps'] = deps
 
           with open('stack.yaml', 'w') as f:
               yaml.dump(data, f)


### PR DESCRIPTION
## Description

The workflow is located at  hevm/.github/workflows/echidna-compat.yml. It performs the following steps when a Pull Request is opened or updated in the hevm repository:

1. Checkouts: It clones both the current hevm PR branch and the crytic/echidna master branch.
2. Patching: It uses a Python script to safely modify echidna/stack.yaml, replacing the remote hevm git dependency with the local checkout (./hevm).
3. Environment: It leverages Nix to obtain Stack and GHC, and ensure that hevm and echidna's C dependencies (like libsecp256k1 and libff) are correctly provided to the build environment.
4. Compilation: It runs stack build --fast --test --no-run-tests to verify that echidna still compiles with the changes made in the hevm PR.

Optional Status: The job uses continue-on-error: true, which means it will act as a warning. If compatibility is broken, the PR will show a warning icon but won't be blocked (unless you specifically mark this check as required in GitHub settings). The job will also post a status update with a build log in case the build fails.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
