### PR TITLE
EVM: optimize OpSwap to use direct list manipulation

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -418,14 +418,12 @@ exec1 conf = do
 
         OpSwap i -> {-# SCC "OpSwap" #-}
           let idx = into i in
-          case stk of
-            e0:rest -> case splitAt (idx - 1) rest of
-              (middle, ei:after) ->
-                burn g_verylow $ do
-                  next
-                  assign' (#state % #stack) $ ei : middle ++ (e0 : after)
-              _ -> underrun
-            _ -> underrun
+          case splitAt idx stk of
+          (e0:middle, ei:after) ->
+            burn g_verylow $ do
+              next
+              assign' (#state % #stack) $ ei : middle ++ (e0 : after)
+          _ -> underrun
 
         OpLog n -> {-# SCC "OpLog" #-}
           notStatic $

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -417,16 +417,15 @@ exec1 conf = do
                   pushSym y
 
         OpSwap i -> {-# SCC "OpSwap" #-}
-          case (stk ^? ix_i, stk ^? ix_0) of
-            (Just ei, Just e0) ->
-              burn g_verylow $ do
-                next
-                zoom (#state % #stack) $ do
-                  ix_i .= e0
-                  ix_0 .= ei
+          let idx = into i in
+          case stk of
+            e0:rest -> case splitAt (idx - 1) rest of
+              (middle, ei:after) ->
+                burn g_verylow $ do
+                  next
+                  assign' (#state % #stack) $ ei : middle ++ (e0 : after)
+              _ -> underrun
             _ -> underrun
-          where
-            (ix_i, ix_0) = (ix (into i), ix 0)
 
         OpLog n -> {-# SCC "OpLog" #-}
           notStatic $


### PR DESCRIPTION
## Description

Replace optics-based ix/zoom swap with direct splitAt-based list swap. The old code used two ix traversals + zoom + two .= assignments. The new code uses a single splitAt + list construction.

bench-perf shows a ∼10% reduction in primes and loop. The optimization was suggested by Claude Code.


## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
