### PR TITLE
EVM: enable -O2 -fworker-wrapper-cbv for main EVM module

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -O2 -fworker-wrapper-cbv #-}
 
 module EVM where
 


### PR DESCRIPTION

## Description

bench-perf shows a >10% reduction in primes, loop, swapOperations. The optimization was suggested by Claude Code.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
