### PR TITLE
Tweak default RTS options

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -381,7 +381,7 @@ benchmark bench-perf
   hs-source-dirs:
     bench
   ghc-options:
-    -O2 -threaded "-with-rtsopts=-N -A32m" -fproc-alignment=64
+    -O2 -threaded -rtsopts "-with-rtsopts=-N1 -A32m" -fproc-alignment=64
   other-modules:
     Paths_hevm
   autogen-modules:

--- a/hevm.cabal
+++ b/hevm.cabal
@@ -200,7 +200,7 @@ executable hevm
     cli
   main-is:
     cli.hs
-  ghc-options: -threaded -with-rtsopts=-N
+  ghc-options: -threaded "-with-rtsopts=-N -A32m"
   other-modules:
     Paths_hevm
   autogen-modules:
@@ -267,7 +267,7 @@ common test-common
   import: test-base
   default-language: GHC2021
   if flag(devel)
-    ghc-options: -threaded -with-rtsopts=-N
+    ghc-options: -threaded "-with-rtsopts=-N -A32m"
   build-depends:
     test-utils,
     vector,
@@ -381,7 +381,7 @@ benchmark bench-perf
   hs-source-dirs:
     bench
   ghc-options:
-    -O2 -threaded -with-rtsopts=-N -fproc-alignment=64
+    -O2 -threaded "-with-rtsopts=-N -A32m" -fproc-alignment=64
   other-modules:
     Paths_hevm
   autogen-modules:


### PR DESCRIPTION
## Description

This tweaks -A4m -> -A32m; see https://downloads.haskell.org/ghc/latest/docs/users_guide/runtime_control.html#rts-flag-A-size

bench-perf shows 60%+ improvements across tests due to less time spent in GC. I haven't tested symbolic execution through hevm CLI but it's likely to benefit too.

For comparison, [we ship -A64m as default in echidna](https://github.com/crytic/echidna/blob/master/package.yaml#L101) but even higher values like -A1g show improvement for very large machines.

## Checklist

- [ ] tested locally
- [ ] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
