### PR TITLE
Expect revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Added
+- Support for a subset of the [`expectRevert`](https://www.getfoundry.sh/reference/cheatcodes/expect-revert#expectrevert) family of foundry cheatcodes:
+  - `expectRevert()`
+  - `expectRevert(bytes)`
+  - `expectRevert(bytes4)`
+  - `expectRevert(address)`
+  - `expectRevert(bytes4,address)`
+  - `expectRevert(bytes,address)`
+  - `expectPartialRevert(bytes4)`
+  - `expectPartialRevert(bytes4,address)`
 - Support for Foundry/Hardhat `console.log` — calls to the console address are intercepted and decoded in traces
 - Source location info (file, line, code snippet) is now shown in state merge debug messages
 - New opcode: CLZ

--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752867797,
-        "narHash": "sha256-oT129SDSr7SI9ThTd6ZbpmShh5f2tzUH3S4hl6c5/7w=",
+        "lastModified": 1777456281,
+        "narHash": "sha256-Nf0j/os+7D1+pXgHePxxgQtqzN4oALV/UY4rQT6BmJM=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "d4445852933ab5bc61ca532cb6c5d3276d89c478",
+        "rev": "8f77bc850d6afe8458e105493ac150a21b3c4f51",
         "type": "github"
       },
       "original": {

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2785,6 +2785,13 @@ finishFrame how = do
             modifying (#state % #stack) (drop 1)
             pushAddr dummyCreateAddress
             assign (#state % #returndata) mempty
+      | length oldVm.frames < e.depth
+      , not (poppingCheatFrame oldVm.frames)
+      -> do
+          assign #expectedRevert Nothing
+          finishFrameNoExpectation $
+            FrameReverted (expectRevertFailureBuf
+              "call didn't revert at a lower depth than cheatcode call depth")
     _ -> finishFrameNoExpectation how
 
 -- | When a FrameReverted enters finishFrame and an expectation is active,

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2340,7 +2340,7 @@ cheatActions = Map.fromList
 --
 -- The cheat captures the depth of the call stack so that when the immediately
 -- following sub-call returns/reverts at the same depth, finishFrame consumes
--- the expectation and rewrites the result. See `consumeExpectedRevert`.
+-- the expectation and rewrites the result.
 
 setExpectedRevert
   :: VMOps t => Maybe (Expr Buf) -> Bool -> Maybe (Expr EAddr) -> EVM t ()
@@ -2452,51 +2452,6 @@ dummySuccessReturn = ConcreteBuf (BS.replicate 8192 0)
 -- https://github.com/foundry-rs/foundry/blob/master/crates/cheatcodes/src/test/revert_handlers.rs
 dummyCreateAddress :: Expr EAddr
 dummyCreateAddress = LitAddr 1
-
--- | What kind of swallow fixup the caller of consumeExpectedRevert needs to
--- apply after the FrameReverted body of finishFrameNoExpectation has run.
--- For SwallowCreate the FrameReverted path runs over the actual revert data
--- and the patch replaces the pushed 0 with dummyCreateAddress and clears
--- returndata. For SwallowCall the FrameReverted path is fed dummySuccessReturn
--- (so the rollback semantics are kept while the caller's memory and returndata
--- look like a successful call) and the patch flips the pushed 0 to 1.
-data SwallowKind = NoSwallow | SwallowCreate | SwallowCall
-  deriving (Eq, Show)
-
--- | Decide what to do at the boundary frame for an active expectation.
--- Returns the FrameResult that finishFrame's normal path should run with, plus
--- the SwallowKind telling the caller which post-pop fixup (if any) to apply.
--- Crucially we always return FrameReverted for matched cases so that the
--- normal FrameReverted body in finishFrameNoExpectation runs revertContracts
--- and revertSubstate — i.e. the reverted frame's state changes are rolled
--- back. The caller then reshapes the post-pop stack/returndata to make the
--- call look successful to the surrounding bytecode.
-consumeExpectedRevert
-  :: VMOps t => ExpectedRevert -> FrameResult -> VM t -> EVM t (FrameResult, SwallowKind)
-consumeExpectedRevert e how oldVm = do
-  let reverterAddr = fromMaybe oldVm.state.contract e.actualReverter
-      isCreate = currentFrameIsCreate oldVm
-  case how of
-    FrameReverted actual -> case matchExpectedRevert e actual reverterAddr of
-      Match
-        | isCreate  -> pure (FrameReverted actual, SwallowCreate)
-        | otherwise -> pure (FrameReverted dummySuccessReturn, SwallowCall)
-      Mismatch ->
-        pure (FrameReverted (assertionFailedBuf "expected revert did not match"), NoSwallow)
-      Indeterminate reason -> do
-        unexpectedSymArg ("expectRevert: " <> reason) [actual]
-        pure (how, NoSwallow)
-    FrameReturned _ ->
-      pure (FrameReverted (assertionFailedBuf "call did not revert as expected"), NoSwallow)
-    FrameErrored _ -> pure (how, NoSwallow)
-
--- | True when the topmost frame on `frames` is a cheat-call frame (i.e. we
--- are popping out of a cheatcode invocation). Such frames must be ignored by
--- the expectRevert interception, since cheatcodes return between the
--- expectRevert call and the target sub-call.
-poppingCheatFrame :: [Frame t] -> Bool
-poppingCheatFrame (Frame { context = CallContext { target } } : _) = target == cheatCode
-poppingCheatFrame _ = False
 
 -- * General call implementation ("delegateCall")
 -- note that the continuation is ignored in the precompile case
@@ -2826,17 +2781,32 @@ finishFrame how = do
       , not (poppingCheatFrame oldVm.frames)
       -> do
           assign #expectedRevert Nothing
-          (newHow, swallowKind) <- consumeExpectedRevert e how oldVm
-          finishFrameNoExpectation newHow
-          case swallowKind of
-            NoSwallow -> pure ()
-            SwallowCreate -> do
-              modifying (#state % #stack) (drop 1)
-              pushAddr dummyCreateAddress
-              assign (#state % #returndata) mempty
-            SwallowCall -> do
-              modifying (#state % #stack) (drop 1)
-              push 1
+          let reverterAddr = fromMaybe oldVm.state.contract e.actualReverter
+              isCreate = case oldVm.frames of
+                Frame { context = CreationContext {} } : _ -> True
+                _ -> False
+          case how of
+            FrameReverted actual -> case matchExpectedRevert e actual reverterAddr of
+              Match
+                | isCreate -> do
+                    finishFrameNoExpectation (FrameReverted actual)
+                    modifying (#state % #stack) (drop 1)
+                    pushAddr dummyCreateAddress
+                    assign (#state % #returndata) mempty
+                | otherwise -> do
+                    finishFrameNoExpectation (FrameReverted dummySuccessReturn)
+                    modifying (#state % #stack) (drop 1)
+                    push 1
+              Mismatch ->
+                finishFrameNoExpectation
+                  (FrameReverted (assertionFailedBuf "expected revert did not match"))
+              Indeterminate reason -> do
+                unexpectedSymArg ("expectRevert: " <> reason) [actual]
+                finishFrameNoExpectation how
+            FrameReturned _ ->
+              finishFrameNoExpectation
+                (FrameReverted (assertionFailedBuf "call did not revert as expected"))
+            FrameErrored _ -> finishFrameNoExpectation how
       | length oldVm.frames < e.depth
       , not (poppingCheatFrame oldVm.frames)
       -> do
@@ -2845,11 +2815,12 @@ finishFrame how = do
             FrameReverted (assertionFailedBuf
               "call didn't revert at a lower depth than cheatcode call depth")
     _ -> finishFrameNoExpectation how
-
-currentFrameIsCreate :: VM t -> Bool
-currentFrameIsCreate vm = case vm.frames of
-  Frame { context = CreationContext {} } : _ -> True
-  _ -> False
+  where
+    -- | True when the frame being popped is a cheat-call frame. Such frames
+    -- must be ignored by the expectRevert interception, since cheatcodes
+    -- return between the expectRevert call and the target sub-call.
+    poppingCheatFrame (Frame { context = CallContext { target } } : _) = target == cheatCode
+    poppingCheatFrame _ = False
 
 -- | The non-interception body of finishFrame, factored out so the wrapper
 -- above can re-enter it with a rewritten FrameResult without re-triggering

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2363,9 +2363,6 @@ setExpectedRevert reasonExp isPartial reverterExp = do
 errorMsg :: ByteString -> Expr Buf
 errorMsg err = ConcreteBuf $ selector "Error(string)" <> encodeAbiValue (AbiTuple $ V.fromList [AbiString err])
 
--- | Synthesize an Error(string) buffer with an "assertion failed: <msg>"
--- payload — used to report unsatisfied expectRevert expectations and similar
--- assertion failures.
 assertionFailedBuf :: ByteString -> Expr Buf
 assertionFailedBuf msg = errorMsg ("assertion failed: " <> msg)
 
@@ -2411,7 +2408,10 @@ matchExpectedRevert e actual reverterAddr = combine reasonMatches reverterMatche
       Nothing -> Match
       Just want -> case (want, reverterAddr) of
         (LitAddr a, LitAddr b) -> if a == b then Match else Mismatch
-        _                      -> Indeterminate "reverter address is symbolic"
+        (SymAddr a, SymAddr b) -> if a == b then Match else Mismatch
+        (SymAddr a, LitAddr b) -> Indeterminate $ "cannot compare concrete and symbolic addresses: " ++ (unpack a) ++ " and " ++ (show b)
+        (LitAddr a, SymAddr b) -> Indeterminate $ "cannot compare concrete and symbolic addresses: " ++ (show a) ++ " and " ++ (unpack b)
+        _ -> internalError "unexpected GVar"
 
 -- | Compare only the first four bytes (selector). Succeeds when both sides have
 -- a concrete 4-byte prefix even if the rest of the buffer is symbolic.
@@ -2767,16 +2767,12 @@ finishAllFramesAndStop = do
 --
 -- It also handles the case when the current stack frame is the only one;
 -- in this case, we set the final '_result' of the VM execution.
---
--- If an expectRevert expectation is active and we are about to pop the frame
--- at the matching depth, the expectation is consumed and the FrameResult is
--- rewritten before the rest of the function runs. CREATE-frame swallows of a
--- matched revert require a stack/returndata fixup after the normal pop.
 finishFrame :: VMOps t => FrameResult -> EVM t ()
 finishFrame how = do
   oldVm <- get
   case oldVm.expectedRevert of
     Just e
+      -- we are back at the start depth (ignoring calls to the cheat address)
       | length oldVm.frames == e.depth
       , not (poppingCheatFrame oldVm.frames)
       -> do
@@ -2788,14 +2784,23 @@ finishFrame how = do
           case how of
             FrameReverted actual -> case matchExpectedRevert e actual reverterAddr of
               Match
+                -- if the expected revert occured, then in order to match
+                -- foundry, we need to add some sentinel values to the stack
+                -- and pretend the actual call/create succeeded.
                 | isCreate -> do
                     finishFrameNoExpectation (FrameReverted actual)
+                    -- drop the prev return value
                     modifying (#state % #stack) (drop 1)
+                    -- add our sentinel
                     pushAddr dummyCreateAddress
+                    -- empty returndata
                     assign (#state % #returndata) mempty
                 | otherwise -> do
+                    -- process the revert with our dummy returndata
                     finishFrameNoExpectation (FrameReverted dummySuccessReturn)
+                    -- drop the prev return value
                     modifying (#state % #stack) (drop 1)
+                    -- pretend the call succeeded
                     push 1
               Mismatch ->
                 finishFrameNoExpectation
@@ -2805,26 +2810,25 @@ finishFrame how = do
                 finishFrameNoExpectation how
             FrameReturned _ ->
               finishFrameNoExpectation
-                (FrameReverted (assertionFailedBuf "call did not revert as expected"))
+                (FrameReverted (assertionFailedBuf "expected call did not revert"))
             FrameErrored _ -> finishFrameNoExpectation how
+
+      -- we have popped out past the start depth of the expected revert (i.e. returned without a revert occuring)
       | length oldVm.frames < e.depth
       , not (poppingCheatFrame oldVm.frames)
       -> do
           assign #expectedRevert Nothing
           finishFrameNoExpectation $
-            FrameReverted (assertionFailedBuf
-              "call didn't revert at a lower depth than cheatcode call depth")
+            FrameReverted (assertionFailedBuf "expected revert never occurred")
     _ -> finishFrameNoExpectation how
   where
     -- | True when the frame being popped is a cheat-call frame. Such frames
-    -- must be ignored by the expectRevert interception, since cheatcodes
-    -- return between the expectRevert call and the target sub-call.
+    -- must be ignored by the expectRevert interception, as cheatcode calls are
+    -- not checked by `expectRevert`
     poppingCheatFrame (Frame { context = CallContext { target } } : _) = target == cheatCode
     poppingCheatFrame _ = False
 
--- | The non-interception body of finishFrame, factored out so the wrapper
--- above can re-enter it with a rewritten FrameResult without re-triggering
--- the expectRevert check.
+-- | The non-interception body of finishFrame
 finishFrameNoExpectation :: VMOps t => FrameResult -> EVM t ()
 finishFrameNoExpectation how = do
   oldVm <- get

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1132,6 +1132,10 @@ exec1 conf = do
             xOffset:xSize:_ ->
               accessMemoryRange xOffset xSize $ do
                 output <- readMemory xOffset xSize
+                case vm.expectedRevert of
+                  Just e | isNothing e.actualReverter ->
+                    assign #expectedRevert (Just e { actualReverter = Just self })
+                  _ -> pure ()
                 finishFrame (FrameReverted output)
             _ -> underrun
 
@@ -2359,10 +2363,11 @@ setExpectedRevert reasonExp isPartial reverterExp = do
 errorMsg :: ByteString -> Expr Buf
 errorMsg err = ConcreteBuf $ selector "Error(string)" <> encodeAbiValue (AbiTuple $ V.fromList [AbiString err])
 
--- | The synthesized assertion-failure revert buffer used when an expectRevert
--- expectation is not satisfied.
-expectRevertFailureBuf :: ByteString -> Expr Buf
-expectRevertFailureBuf msg = errorMsg ("assertion failed: " <> msg)
+-- | Synthesize an Error(string) buffer with an "assertion failed: <msg>"
+-- payload — used to report unsatisfied expectRevert expectations and similar
+-- assertion failures.
+assertionFailedBuf :: ByteString -> Expr Buf
+assertionFailedBuf msg = errorMsg ("assertion failed: " <> msg)
 
 -- | If a concrete buffer is an Error(string)-encoded revert, return the inner
 -- string bytes. Otherwise Nothing.
@@ -2374,40 +2379,47 @@ stripErrorPrefix bs
       (CAbi [AbiString inner], _) -> Just inner
       _ -> Nothing
 
--- | Result of matching an expectation against an actual revert.
--- 'Right True'  = matches, 'Right False' = does not match,
--- 'Left reason' = cannot be decided concretely; the caller should bail.
--- The two axes (revert reason and reverter address) short-circuit on
--- 'Right False' so an indeterminate axis does not mask a known failure.
+-- | Outcome of matching an expectation against an actual revert.
+-- 'Indeterminate' carries the reason a concrete decision could not be made;
+-- the caller should bail with an unexpected-symbolic error. A definite
+-- 'Mismatch' takes precedence over an 'Indeterminate' on a different axis, so
+-- an indeterminate reason check cannot mask a known reverter mismatch (and
+-- vice versa).
+data RevertMatch
+  = Match
+  | Mismatch
+  | Indeterminate String
+  deriving (Eq, Show)
+
 matchExpectedRevert
-  :: ExpectedRevert -> Expr Buf -> Expr EAddr -> Either String Bool
+  :: ExpectedRevert -> Expr Buf -> Expr EAddr -> RevertMatch
 matchExpectedRevert e actual reverterAddr = combine reasonMatches reverterMatches
   where
-    combine (Right False) _              = Right False
-    combine _              (Right False) = Right False
-    combine (Right True)   (Right True)  = Right True
-    combine (Left s)       _             = Left s
-    combine _              (Left s)      = Left s
+    combine Mismatch     _            = Mismatch
+    combine _            Mismatch     = Mismatch
+    combine (Indeterminate s) _            = Indeterminate s
+    combine _            (Indeterminate s) = Indeterminate s
+    combine Match        Match        = Match
 
     reasonMatches = case e.reason of
-      Nothing -> Right True
+      Nothing -> Match
       Just expected
         | e.partialMatch -> matchPartialPrefix expected actual
         | otherwise      -> matchFullReason   expected actual
 
     reverterMatches = case e.reverter of
-      Nothing -> Right True
+      Nothing -> Match
       Just want -> case (want, reverterAddr) of
-        (LitAddr a, LitAddr b) -> Right (a == b)
-        _                      -> Left "reverter address is symbolic"
+        (LitAddr a, LitAddr b) -> if a == b then Match else Mismatch
+        _                      -> Indeterminate "reverter address is symbolic"
 
 -- | Compare only the first four bytes (selector). Succeeds when both sides have
 -- a concrete 4-byte prefix even if the rest of the buffer is symbolic.
-matchPartialPrefix :: Expr Buf -> Expr Buf -> Either String Bool
-matchPartialPrefix expected actual = do
-  expBs <- prefix4 (Expr.simplify expected)
-  actBs <- prefix4 (Expr.simplify actual)
-  pure (expBs == actBs)
+matchPartialPrefix :: Expr Buf -> Expr Buf -> RevertMatch
+matchPartialPrefix expected actual = case (prefix4 (Expr.simplify expected), prefix4 (Expr.simplify actual)) of
+  (Right e, Right a)   -> if e == a then Match else Mismatch
+  (Left s, _)          -> Indeterminate s
+  (_, Left s)          -> Indeterminate s
   where
     prefix4 :: Expr Buf -> Either String ByteString
     prefix4 buf = BS.pack <$> traverse (toLitByte . Expr.simplify . flip Expr.readByte buf . Lit) [0..3]
@@ -2418,22 +2430,26 @@ matchPartialPrefix expected actual = do
 -- | Full-buffer reason match. Both sides are normalized by stripping an
 -- Error(string) wrapper if present, so a wrapped expected matches a raw actual
 -- inner string and vice versa.
-matchFullReason :: Expr Buf -> Expr Buf -> Either String Bool
+matchFullReason :: Expr Buf -> Expr Buf -> RevertMatch
 matchFullReason expected actual = case (Expr.simplify expected, Expr.simplify actual) of
   (ConcreteBuf eBs, ConcreteBuf aBs) ->
     let normalize bs = fromMaybe bs (stripErrorPrefix bs)
-    in Right (normalize eBs == normalize aBs)
-  _ -> Left "revert data is symbolic"
+    in if normalize eBs == normalize aBs then Match else Mismatch
+  _ -> Indeterminate "revert data is symbolic"
 
 -- | Dummy success returndata used when swallowing a matched revert at a CALL
 -- boundary. 8192 zero bytes — large enough to satisfy Solidity's return-data
--- decoders for any reasonable return type.
+-- decoders for any reasonable return type. Matches foundry's
+-- @DUMMY_CALL_OUTPUT@ in @crates/cheatcodes/src/test/revert_handlers.rs@:
+-- https://github.com/foundry-rs/foundry/blob/master/crates/cheatcodes/src/test/revert_handlers.rs
 dummySuccessReturn :: Expr Buf
 dummySuccessReturn = ConcreteBuf (BS.replicate 8192 0)
 
 -- | Sentinel address pushed on the stack when swallowing a matched CREATE
--- revert. Matches forge's DUMMY_CREATE_ADDRESS so tests that inspect the LHS
--- of `new C()` after expectRevert behave identically across both tools.
+-- revert. Matches foundry's @DUMMY_CREATE_ADDRESS@ (= 0x01) in
+-- @crates/cheatcodes/src/test/revert_handlers.rs@ so tests that inspect the
+-- LHS of @new C()@ after expectRevert behave identically across both tools:
+-- https://github.com/foundry-rs/foundry/blob/master/crates/cheatcodes/src/test/revert_handlers.rs
 dummyCreateAddress :: Expr EAddr
 dummyCreateAddress = LitAddr 1
 
@@ -2462,16 +2478,16 @@ consumeExpectedRevert e how oldVm = do
       isCreate = currentFrameIsCreate oldVm
   case how of
     FrameReverted actual -> case matchExpectedRevert e actual reverterAddr of
-      Right True
+      Match
         | isCreate  -> pure (FrameReverted actual, SwallowCreate)
         | otherwise -> pure (FrameReverted dummySuccessReturn, SwallowCall)
-      Right False ->
-        pure (FrameReverted (expectRevertFailureBuf "expected revert did not match"), NoSwallow)
-      Left reason -> do
+      Mismatch ->
+        pure (FrameReverted (assertionFailedBuf "expected revert did not match"), NoSwallow)
+      Indeterminate reason -> do
         unexpectedSymArg ("expectRevert: " <> reason) [actual]
         pure (how, NoSwallow)
     FrameReturned _ ->
-      pure (FrameReverted (expectRevertFailureBuf "call did not revert as expected"), NoSwallow)
+      pure (FrameReverted (assertionFailedBuf "call did not revert as expected"), NoSwallow)
     FrameErrored _ -> pure (how, NoSwallow)
 
 -- | True when the topmost frame on `frames` is a cheat-call frame (i.e. we
@@ -2803,7 +2819,6 @@ finishAllFramesAndStop = do
 -- matched revert require a stack/returndata fixup after the normal pop.
 finishFrame :: VMOps t => FrameResult -> EVM t ()
 finishFrame how = do
-  recordActualReverterIfFirst how
   oldVm <- get
   case oldVm.expectedRevert of
     Just e
@@ -2827,26 +2842,9 @@ finishFrame how = do
       -> do
           assign #expectedRevert Nothing
           finishFrameNoExpectation $
-            FrameReverted (expectRevertFailureBuf
+            FrameReverted (assertionFailedBuf
               "call didn't revert at a lower depth than cheatcode call depth")
     _ -> finishFrameNoExpectation how
-
--- | When a FrameReverted enters finishFrame and an expectation is active,
--- capture the contract that just reverted as the actualReverter — but only the
--- first time, and only when the reverting frame is a CALL frame (not a
--- CREATE). CREATE-internal reverts are attributed to the parent CALL frame
--- that owns the new-contract expression (matching foundry's behaviour).
-recordActualReverterIfFirst :: VMOps t => FrameResult -> EVM t ()
-recordActualReverterIfFirst (FrameReverted _) = do
-  vm <- get
-  case vm.expectedRevert of
-    Just e
-      | isNothing e.actualReverter
-      , not (currentFrameIsCreate vm)
-      , not (poppingCheatFrame vm.frames)
-      -> assign #expectedRevert (Just e { actualReverter = Just vm.state.contract })
-    _ -> pure ()
-recordActualReverterIfFirst _ = pure ()
 
 currentFrameIsCreate :: VM t -> Bool
 currentFrameIsCreate vm = case vm.frames of

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2417,30 +2417,44 @@ dummySuccessReturn = ConcreteBuf (BS.replicate 8192 0)
 dummyCreateAddress :: Expr EAddr
 dummyCreateAddress = LitAddr 1
 
+-- | What kind of swallow fixup the caller of consumeExpectedRevert needs to
+-- apply after the FrameReverted body of finishFrameNoExpectation has run.
+-- For SwallowCreate the FrameReverted path runs over the actual revert data
+-- and the patch replaces the pushed 0 with dummyCreateAddress and clears
+-- returndata. For SwallowCall the FrameReverted path is fed dummySuccessReturn
+-- (so the rollback semantics are kept while the caller's memory and returndata
+-- look like a successful call) and the patch flips the pushed 0 to 1.
+data SwallowKind = NoSwallow | SwallowCreate | SwallowCall
+  deriving (Eq, Show)
+
 -- | Decide what to do at the boundary frame for an active expectation.
 -- Returns the FrameResult that finishFrame's normal path should run with, plus
--- a flag telling the caller to apply the CREATE-swallow fixup afterwards
--- (replace the pushed 0 with dummyCreateAddress and clear returndata).
+-- the SwallowKind telling the caller which post-pop fixup (if any) to apply.
+-- Crucially we always return FrameReverted for matched cases so that the
+-- normal FrameReverted body in finishFrameNoExpectation runs revertContracts
+-- and revertSubstate — i.e. the reverted frame's state changes are rolled
+-- back. The caller then reshapes the post-pop stack/returndata to make the
+-- call look successful to the surrounding bytecode.
 consumeExpectedRevert
-  :: VMOps t => ExpectedRevert -> FrameResult -> VM t -> EVM t (FrameResult, Bool)
+  :: VMOps t => ExpectedRevert -> FrameResult -> VM t -> EVM t (FrameResult, SwallowKind)
 consumeExpectedRevert e how oldVm = do
   let reverterAddr = fromMaybe oldVm.state.contract e.actualReverter
       isCreate = currentFrameIsCreate oldVm
   case how of
     FrameReverted actual -> case matchExpectedRevert e actual reverterAddr of
       Just True
-        | isCreate  -> pure (FrameReverted actual, True)
-        | otherwise -> pure (FrameReturned dummySuccessReturn, False)
+        | isCreate  -> pure (FrameReverted actual, SwallowCreate)
+        | otherwise -> pure (FrameReverted dummySuccessReturn, SwallowCall)
       Just False ->
-        pure (FrameReverted (expectRevertFailureBuf "expected revert did not match"), False)
+        pure (FrameReverted (expectRevertFailureBuf "expected revert did not match"), NoSwallow)
       Nothing -> do
         unexpectedSymArg
           "expectRevert: cannot decide match for symbolic revert data or reverter"
           [actual]
-        pure (how, False)
+        pure (how, NoSwallow)
     FrameReturned _ ->
-      pure (FrameReverted (expectRevertFailureBuf "call did not revert as expected"), False)
-    FrameErrored _ -> pure (how, False)
+      pure (FrameReverted (expectRevertFailureBuf "call did not revert as expected"), NoSwallow)
+    FrameErrored _ -> pure (how, NoSwallow)
 
 -- | True when the topmost frame on `frames` is a cheat-call frame (i.e. we
 -- are popping out of a cheatcode invocation). Such frames must be ignored by
@@ -2779,12 +2793,17 @@ finishFrame how = do
       , not (poppingCheatFrame oldVm.frames)
       -> do
           assign #expectedRevert Nothing
-          (newHow, swallowCreate) <- consumeExpectedRevert e how oldVm
+          (newHow, swallowKind) <- consumeExpectedRevert e how oldVm
           finishFrameNoExpectation newHow
-          when swallowCreate $ do
-            modifying (#state % #stack) (drop 1)
-            pushAddr dummyCreateAddress
-            assign (#state % #returndata) mempty
+          case swallowKind of
+            NoSwallow -> pure ()
+            SwallowCreate -> do
+              modifying (#state % #stack) (drop 1)
+              pushAddr dummyCreateAddress
+              assign (#state % #returndata) mempty
+            SwallowCall -> do
+              modifying (#state % #stack) (drop 1)
+              push 1
       | length oldVm.frames < e.depth
       , not (poppingCheatFrame oldVm.frames)
       -> do

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2222,8 +2222,6 @@ cheatActions = Map.fromList
     frameReturnExpr e = finishFrame (FrameReturned e)
     frameRevert :: VMOps t => ByteString -> EVM t ()
     frameRevert err = finishFrame (FrameReverted $ errorMsg err)
-    errorMsg :: ByteString -> Expr Buf
-    errorMsg err = ConcreteBuf $ selector "Error(string)" <> encodeAbiValue (AbiTuple $ V.fromList [AbiString err])
     continueOnce cont = do
       assign #result Nothing
       cont
@@ -2357,53 +2355,75 @@ setExpectedRevert reasonExp isPartial reverterExp = do
         }
       finishFrame (FrameReturned mempty)
 
--- | Construct the synthesized assertion-failure revert buffer used when an
--- expectRevert expectation is not satisfied. Encoded as Error(string) so the
--- unit-test harness recognizes it as an assertion failure.
+-- | ABI-encode an Error(string) revert payload.
+errorMsg :: ByteString -> Expr Buf
+errorMsg err = ConcreteBuf $ selector "Error(string)" <> encodeAbiValue (AbiTuple $ V.fromList [AbiString err])
+
+-- | The synthesized assertion-failure revert buffer used when an expectRevert
+-- expectation is not satisfied.
 expectRevertFailureBuf :: ByteString -> Expr Buf
-expectRevertFailureBuf msg =
-  ConcreteBuf $
-    selector "Error(string)" <>
-    encodeAbiValue (AbiTuple $ V.fromList [AbiString ("assertion failed: " <> msg)])
+expectRevertFailureBuf msg = errorMsg ("assertion failed: " <> msg)
 
 -- | If a concrete buffer is an Error(string)-encoded revert, return the inner
--- string bytes. Otherwise Nothing. The encoding is
--- selector(4) ++ offset(32) ++ length(32) ++ data(padded). We skip the selector
--- and the 32-byte offset, then decode AbiStringType which reads length+data.
+-- string bytes. Otherwise Nothing.
 stripErrorPrefix :: ByteString -> Maybe ByteString
 stripErrorPrefix bs
-  | BS.length bs < 4 + 32 + 32 = Nothing
-  | BS.take 4 bs /= errSel = Nothing
-  | otherwise = case decodeAbiValue AbiStringType (LS.fromStrict (BS.drop (4 + 32) bs)) of
-      AbiString inner -> Just inner
+  | BS.length bs < 4 = Nothing
+  | BS.take 4 bs /= selector "Error(string)" = Nothing
+  | otherwise = case decodeBuf [AbiStringType] (ConcreteBuf (BS.drop 4 bs)) of
+      (CAbi [AbiString inner], _) -> Just inner
       _ -> Nothing
-  where errSel = selector "Error(string)"
 
--- | True when the actual revert matches the expectation. Returns Nothing when
--- the comparison cannot be decided concretely (e.g. symbolic actual buffer or
--- symbolic reverter address); the caller should bail out as a partial result
--- in that case.
+-- | Result of matching an expectation against an actual revert.
+-- 'Right True'  = matches, 'Right False' = does not match,
+-- 'Left reason' = cannot be decided concretely; the caller should bail.
+-- The two axes (revert reason and reverter address) short-circuit on
+-- 'Right False' so an indeterminate axis does not mask a known failure.
 matchExpectedRevert
-  :: ExpectedRevert -> Expr Buf -> Expr EAddr -> Maybe Bool
-matchExpectedRevert e actual reverterAddr = do
-  reasonOk <- reasonMatches
-  reverterOk <- reverterMatches
-  pure (reasonOk && reverterOk)
+  :: ExpectedRevert -> Expr Buf -> Expr EAddr -> Either String Bool
+matchExpectedRevert e actual reverterAddr = combine reasonMatches reverterMatches
   where
+    combine (Right False) _              = Right False
+    combine _              (Right False) = Right False
+    combine (Right True)   (Right True)  = Right True
+    combine (Left s)       _             = Left s
+    combine _              (Left s)      = Left s
+
     reasonMatches = case e.reason of
-      Nothing -> Just True
-      Just expected -> case (Expr.simplify expected, Expr.simplify actual) of
-        (ConcreteBuf eBs, ConcreteBuf aBs)
-          | e.partialMatch -> Just (BS.take 4 aBs == BS.take 4 eBs)
-          | eBs == aBs     -> Just True
-          | otherwise      -> Just (Just eBs == stripErrorPrefix aBs)
-        _ -> Nothing
+      Nothing -> Right True
+      Just expected
+        | e.partialMatch -> matchPartialPrefix expected actual
+        | otherwise      -> matchFullReason   expected actual
+
     reverterMatches = case e.reverter of
-      Nothing -> Just True
+      Nothing -> Right True
       Just want -> case (want, reverterAddr) of
-        (LitAddr a, LitAddr b) -> Just (a == b)
-        (SymAddr a, SymAddr b) -> Just (a == b)
-        _                      -> Nothing
+        (LitAddr a, LitAddr b) -> Right (a == b)
+        _                      -> Left "reverter address is symbolic"
+
+-- | Compare only the first four bytes (selector). Succeeds when both sides have
+-- a concrete 4-byte prefix even if the rest of the buffer is symbolic.
+matchPartialPrefix :: Expr Buf -> Expr Buf -> Either String Bool
+matchPartialPrefix expected actual = do
+  expBs <- prefix4 (Expr.simplify expected)
+  actBs <- prefix4 (Expr.simplify actual)
+  pure (expBs == actBs)
+  where
+    prefix4 :: Expr Buf -> Either String ByteString
+    prefix4 buf = BS.pack <$> traverse (toLitByte . Expr.simplify . flip Expr.readByte buf . Lit) [0..3]
+    toLitByte :: Expr Byte -> Either String Word8
+    toLitByte (LitByte w) = Right w
+    toLitByte _           = Left "first 4 bytes of revert data are symbolic"
+
+-- | Full-buffer reason match. Both sides are normalized by stripping an
+-- Error(string) wrapper if present, so a wrapped expected matches a raw actual
+-- inner string and vice versa.
+matchFullReason :: Expr Buf -> Expr Buf -> Either String Bool
+matchFullReason expected actual = case (Expr.simplify expected, Expr.simplify actual) of
+  (ConcreteBuf eBs, ConcreteBuf aBs) ->
+    let normalize bs = fromMaybe bs (stripErrorPrefix bs)
+    in Right (normalize eBs == normalize aBs)
+  _ -> Left "revert data is symbolic"
 
 -- | Dummy success returndata used when swallowing a matched revert at a CALL
 -- boundary. 8192 zero bytes — large enough to satisfy Solidity's return-data
@@ -2442,15 +2462,13 @@ consumeExpectedRevert e how oldVm = do
       isCreate = currentFrameIsCreate oldVm
   case how of
     FrameReverted actual -> case matchExpectedRevert e actual reverterAddr of
-      Just True
+      Right True
         | isCreate  -> pure (FrameReverted actual, SwallowCreate)
         | otherwise -> pure (FrameReverted dummySuccessReturn, SwallowCall)
-      Just False ->
+      Right False ->
         pure (FrameReverted (expectRevertFailureBuf "expected revert did not match"), NoSwallow)
-      Nothing -> do
-        unexpectedSymArg
-          "expectRevert: cannot decide match for symbolic revert data or reverter"
-          [actual]
+      Left reason -> do
+        unexpectedSymArg ("expectRevert: " <> reason) [actual]
         pure (how, NoSwallow)
     FrameReturned _ ->
       pure (FrameReverted (expectRevertFailureBuf "call did not revert as expected"), NoSwallow)

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2777,37 +2777,41 @@ finishFrame how = do
       , not (poppingCheatFrame oldVm.frames)
       -> do
           assign #expectedRevert Nothing
-          let reverterAddr = fromMaybe oldVm.state.contract e.actualReverter
-              isCreate = case oldVm.frames of
+          let isCreate = case oldVm.frames of
                 Frame { context = CreationContext {} } : _ -> True
                 _ -> False
           case how of
-            FrameReverted actual -> case matchExpectedRevert e actual reverterAddr of
-              Match
-                -- if the expected revert occured, then in order to match
-                -- foundry, we need to add some sentinel values to the stack
-                -- and pretend the actual call/create succeeded.
-                | isCreate -> do
-                    finishFrameNoExpectation (FrameReverted actual)
-                    -- drop the prev return value
-                    modifying (#state % #stack) (drop 1)
-                    -- add our sentinel
-                    pushAddr dummyCreateAddress
-                    -- empty returndata
-                    assign (#state % #returndata) mempty
-                | otherwise -> do
-                    -- process the revert with our dummy returndata
-                    finishFrameNoExpectation (FrameReverted dummySuccessReturn)
-                    -- drop the prev return value
-                    modifying (#state % #stack) (drop 1)
-                    -- pretend the call succeeded
-                    push 1
-              Mismatch ->
-                finishFrameNoExpectation
-                  (FrameReverted (assertionFailedBuf "expected revert did not match"))
-              Indeterminate reason -> do
-                unexpectedSymArg ("expectRevert: " <> reason) [actual]
-                finishFrameNoExpectation how
+            FrameReverted actual ->
+              let reverterAddr =
+                    fromMaybe
+                      (internalError "expectRevert: missing actualReverter for FrameReverted")
+                      e.actualReverter
+              in case matchExpectedRevert e actual reverterAddr of
+                Match
+                  -- if the expected revert occured, then in order to match
+                  -- foundry, we need to add some sentinel values to the stack
+                  -- and pretend the actual call/create succeeded.
+                  | isCreate -> do
+                      finishFrameNoExpectation (FrameReverted actual)
+                      -- drop the prev return value
+                      modifying (#state % #stack) (drop 1)
+                      -- add our sentinel
+                      pushAddr dummyCreateAddress
+                      -- empty returndata
+                      assign (#state % #returndata) mempty
+                  | otherwise -> do
+                      -- process the revert with our dummy returndata
+                      finishFrameNoExpectation (FrameReverted dummySuccessReturn)
+                      -- drop the prev return value
+                      modifying (#state % #stack) (drop 1)
+                      -- pretend the call succeeded
+                      push 1
+                Mismatch ->
+                  finishFrameNoExpectation
+                    (FrameReverted (assertionFailedBuf "expected revert did not match"))
+                Indeterminate reason -> do
+                  unexpectedSymArg ("expectRevert: " <> reason) [actual]
+                  finishFrameNoExpectation how
             FrameReturned _ ->
               finishFrameNoExpectation
                 (FrameReverted (assertionFailedBuf "expected call did not revert"))

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -203,6 +203,7 @@ makeVm o = do
     , keccakPreImgs = fromList []
     , pathsVisited = mempty
     , mergeState = defaultMergeState
+    , expectedRevert = Nothing
     }
     where
     env = Env
@@ -2093,6 +2094,51 @@ cheatActions = Map.fromList
             doStop
         _ -> vmError (BadCheatCode "etch(address,bytes) address decoding failed" sig)
 
+  , action "expectRevert()" $
+      \_ _ -> setExpectedRevert Nothing False Nothing
+
+  , action "expectRevert(bytes)" $
+      \sig input -> case decodeBuf [AbiBytesDynamicType] input of
+        (CAbi [AbiBytesDynamic bs],"") ->
+          setExpectedRevert (Just (ConcreteBuf bs)) False Nothing
+        _ -> vmError (BadCheatCode "expectRevert(bytes) parameter decoding failed" sig)
+
+  , action "expectRevert(bytes4)" $
+      \sig input -> case decodeBuf [AbiBytesType 4] input of
+        (CAbi [AbiBytes 4 bs],"") ->
+          setExpectedRevert (Just (ConcreteBuf bs)) False Nothing
+        _ -> vmError (BadCheatCode "expectRevert(bytes4) parameter decoding failed" sig)
+
+  , action "expectRevert(address)" $
+      \sig input -> case decodeBuf [AbiAddressType] input of
+        (CAbi [AbiAddress addr],"") ->
+          setExpectedRevert Nothing False (Just (LitAddr addr))
+        _ -> vmError (BadCheatCode "expectRevert(address) parameter decoding failed" sig)
+
+  , action "expectRevert(bytes4,address)" $
+      \sig input -> case decodeBuf [AbiBytesType 4, AbiAddressType] input of
+        (CAbi [AbiBytes 4 bs, AbiAddress addr],"") ->
+          setExpectedRevert (Just (ConcreteBuf bs)) False (Just (LitAddr addr))
+        _ -> vmError (BadCheatCode "expectRevert(bytes4,address) parameter decoding failed" sig)
+
+  , action "expectRevert(bytes,address)" $
+      \sig input -> case decodeBuf [AbiBytesDynamicType, AbiAddressType] input of
+        (CAbi [AbiBytesDynamic bs, AbiAddress addr],"") ->
+          setExpectedRevert (Just (ConcreteBuf bs)) False (Just (LitAddr addr))
+        _ -> vmError (BadCheatCode "expectRevert(bytes,address) parameter decoding failed" sig)
+
+  , action "expectPartialRevert(bytes4)" $
+      \sig input -> case decodeBuf [AbiBytesType 4] input of
+        (CAbi [AbiBytes 4 bs],"") ->
+          setExpectedRevert (Just (ConcreteBuf bs)) True Nothing
+        _ -> vmError (BadCheatCode "expectPartialRevert(bytes4) parameter decoding failed" sig)
+
+  , action "expectPartialRevert(bytes4,address)" $
+      \sig input -> case decodeBuf [AbiBytesType 4, AbiAddressType] input of
+        (CAbi [AbiBytes 4 bs, AbiAddress addr],"") ->
+          setExpectedRevert (Just (ConcreteBuf bs)) True (Just (LitAddr addr))
+        _ -> vmError (BadCheatCode "expectPartialRevert(bytes4,address) parameter decoding failed" sig)
+
   -- Single-value environment read cheat actions
   , $(envReadSingleCheat "envBool(string)") AbiBool stringToBool
   , $(envReadSingleCheat "envUint(string)") (AbiUInt 256) stringToWord256
@@ -2287,6 +2333,122 @@ cheatActions = Map.fromList
       case decodeBuf [abitype] input of
         (CAbi [val],"") -> frameReturn $ AbiTuple $ V.fromList [AbiString $ Char8.pack $ show val]
         _ -> vmError (BadCheatCode ("toString parameter decoding failed for " <> show abitype) sig)
+
+-- * expectRevert support
+--
+-- The cheat captures the depth of the call stack so that when the immediately
+-- following sub-call returns/reverts at the same depth, finishFrame consumes
+-- the expectation and rewrites the result. See `consumeExpectedRevert`.
+
+setExpectedRevert
+  :: VMOps t => Maybe (Expr Buf) -> Bool -> Maybe (Expr EAddr) -> EVM t ()
+setExpectedRevert reasonExp isPartial reverterExp = do
+  vm <- get
+  case vm.expectedRevert of
+    Just _ ->
+      vmError (BadCheatCode "expectRevert: previous expectation not yet consumed" 0)
+    Nothing -> do
+      assign #expectedRevert $ Just ExpectedRevert
+        { reason         = reasonExp
+        , partialMatch   = isPartial
+        , reverter       = reverterExp
+        , depth          = length vm.frames
+        , actualReverter = Nothing
+        }
+      finishFrame (FrameReturned mempty)
+
+-- | Construct the synthesized assertion-failure revert buffer used when an
+-- expectRevert expectation is not satisfied. Encoded as Error(string) so the
+-- unit-test harness recognizes it as an assertion failure.
+expectRevertFailureBuf :: ByteString -> Expr Buf
+expectRevertFailureBuf msg =
+  ConcreteBuf $
+    selector "Error(string)" <>
+    encodeAbiValue (AbiTuple $ V.fromList [AbiString ("assertion failed: " <> msg)])
+
+-- | If a concrete buffer is an Error(string)-encoded revert, return the inner
+-- string bytes. Otherwise Nothing. The encoding is
+-- selector(4) ++ offset(32) ++ length(32) ++ data(padded). We skip the selector
+-- and the 32-byte offset, then decode AbiStringType which reads length+data.
+stripErrorPrefix :: ByteString -> Maybe ByteString
+stripErrorPrefix bs
+  | BS.length bs < 4 + 32 + 32 = Nothing
+  | BS.take 4 bs /= errSel = Nothing
+  | otherwise = case decodeAbiValue AbiStringType (LS.fromStrict (BS.drop (4 + 32) bs)) of
+      AbiString inner -> Just inner
+      _ -> Nothing
+  where errSel = selector "Error(string)"
+
+-- | True when the actual revert matches the expectation. Returns Nothing when
+-- the comparison cannot be decided concretely (e.g. symbolic actual buffer or
+-- symbolic reverter address); the caller should bail out as a partial result
+-- in that case.
+matchExpectedRevert
+  :: ExpectedRevert -> Expr Buf -> Expr EAddr -> Maybe Bool
+matchExpectedRevert e actual reverterAddr = do
+  reasonOk <- reasonMatches
+  reverterOk <- reverterMatches
+  pure (reasonOk && reverterOk)
+  where
+    reasonMatches = case e.reason of
+      Nothing -> Just True
+      Just expected -> case (Expr.simplify expected, Expr.simplify actual) of
+        (ConcreteBuf eBs, ConcreteBuf aBs)
+          | e.partialMatch -> Just (BS.take 4 aBs == BS.take 4 eBs)
+          | eBs == aBs     -> Just True
+          | otherwise      -> Just (Just eBs == stripErrorPrefix aBs)
+        _ -> Nothing
+    reverterMatches = case e.reverter of
+      Nothing -> Just True
+      Just want -> case (want, reverterAddr) of
+        (LitAddr a, LitAddr b) -> Just (a == b)
+        (SymAddr a, SymAddr b) -> Just (a == b)
+        _                      -> Nothing
+
+-- | Dummy success returndata used when swallowing a matched revert at a CALL
+-- boundary. 8192 zero bytes — large enough to satisfy Solidity's return-data
+-- decoders for any reasonable return type.
+dummySuccessReturn :: Expr Buf
+dummySuccessReturn = ConcreteBuf (BS.replicate 8192 0)
+
+-- | Sentinel address pushed on the stack when swallowing a matched CREATE
+-- revert. Matches forge's DUMMY_CREATE_ADDRESS so tests that inspect the LHS
+-- of `new C()` after expectRevert behave identically across both tools.
+dummyCreateAddress :: Expr EAddr
+dummyCreateAddress = LitAddr 1
+
+-- | Decide what to do at the boundary frame for an active expectation.
+-- Returns the FrameResult that finishFrame's normal path should run with, plus
+-- a flag telling the caller to apply the CREATE-swallow fixup afterwards
+-- (replace the pushed 0 with dummyCreateAddress and clear returndata).
+consumeExpectedRevert
+  :: VMOps t => ExpectedRevert -> FrameResult -> VM t -> EVM t (FrameResult, Bool)
+consumeExpectedRevert e how oldVm = do
+  let reverterAddr = fromMaybe oldVm.state.contract e.actualReverter
+      isCreate = currentFrameIsCreate oldVm
+  case how of
+    FrameReverted actual -> case matchExpectedRevert e actual reverterAddr of
+      Just True
+        | isCreate  -> pure (FrameReverted actual, True)
+        | otherwise -> pure (FrameReturned dummySuccessReturn, False)
+      Just False ->
+        pure (FrameReverted (expectRevertFailureBuf "expected revert did not match"), False)
+      Nothing -> do
+        unexpectedSymArg
+          "expectRevert: cannot decide match for symbolic revert data or reverter"
+          [actual]
+        pure (how, False)
+    FrameReturned _ ->
+      pure (FrameReverted (expectRevertFailureBuf "call did not revert as expected"), False)
+    FrameErrored _ -> pure (how, False)
+
+-- | True when the topmost frame on `frames` is a cheat-call frame (i.e. we
+-- are popping out of a cheatcode invocation). Such frames must be ignored by
+-- the expectRevert interception, since cheatcodes return between the
+-- expectRevert call and the target sub-call.
+poppingCheatFrame :: [Frame t] -> Bool
+poppingCheatFrame (Frame { context = CallContext { target } } : _) = target == cheatCode
+poppingCheatFrame _ = False
 
 -- * General call implementation ("delegateCall")
 -- note that the continuation is ignored in the precompile case
@@ -2602,8 +2764,56 @@ finishAllFramesAndStop = do
 --
 -- It also handles the case when the current stack frame is the only one;
 -- in this case, we set the final '_result' of the VM execution.
+--
+-- If an expectRevert expectation is active and we are about to pop the frame
+-- at the matching depth, the expectation is consumed and the FrameResult is
+-- rewritten before the rest of the function runs. CREATE-frame swallows of a
+-- matched revert require a stack/returndata fixup after the normal pop.
 finishFrame :: VMOps t => FrameResult -> EVM t ()
 finishFrame how = do
+  recordActualReverterIfFirst how
+  oldVm <- get
+  case oldVm.expectedRevert of
+    Just e
+      | length oldVm.frames == e.depth
+      , not (poppingCheatFrame oldVm.frames)
+      -> do
+          assign #expectedRevert Nothing
+          (newHow, swallowCreate) <- consumeExpectedRevert e how oldVm
+          finishFrameNoExpectation newHow
+          when swallowCreate $ do
+            modifying (#state % #stack) (drop 1)
+            pushAddr dummyCreateAddress
+            assign (#state % #returndata) mempty
+    _ -> finishFrameNoExpectation how
+
+-- | When a FrameReverted enters finishFrame and an expectation is active,
+-- capture the contract that just reverted as the actualReverter — but only the
+-- first time, and only when the reverting frame is a CALL frame (not a
+-- CREATE). CREATE-internal reverts are attributed to the parent CALL frame
+-- that owns the new-contract expression (matching foundry's behaviour).
+recordActualReverterIfFirst :: VMOps t => FrameResult -> EVM t ()
+recordActualReverterIfFirst (FrameReverted _) = do
+  vm <- get
+  case vm.expectedRevert of
+    Just e
+      | isNothing e.actualReverter
+      , not (currentFrameIsCreate vm)
+      , not (poppingCheatFrame vm.frames)
+      -> assign #expectedRevert (Just e { actualReverter = Just vm.state.contract })
+    _ -> pure ()
+recordActualReverterIfFirst _ = pure ()
+
+currentFrameIsCreate :: VM t -> Bool
+currentFrameIsCreate vm = case vm.frames of
+  Frame { context = CreationContext {} } : _ -> True
+  _ -> False
+
+-- | The non-interception body of finishFrame, factored out so the wrapper
+-- above can re-enter it with a rewritten FrameResult without re-triggering
+-- the expectRevert check.
+finishFrameNoExpectation :: VMOps t => FrameResult -> EVM t ()
+finishFrameNoExpectation how = do
   oldVm <- get
 
   case oldVm.frames of

--- a/src/EVM/Types.hs
+++ b/src/EVM/Types.hs
@@ -675,6 +675,27 @@ data MergeState = MergeState
 defaultMergeState :: MergeState
 defaultMergeState = MergeState False 0
 
+-- | An active vm.expectRevert / vm.expectPartialRevert expectation set by a
+-- cheat call. Consumed when the matching frame returns/reverts.
+data ExpectedRevert = ExpectedRevert
+  { reason         :: Maybe (Expr Buf)
+  -- ^ Nothing matches any revert data; Just expected matches concrete bytes.
+  , depth          :: Int
+  -- ^ length of vm.frames at the cheat call. The matching boundary is the
+  -- frame popping back down to this depth (i.e. the next outer subcall).
+  , partialMatch   :: Bool
+  -- ^ True for expectPartialRevert (compares only first 4 bytes of actual).
+  , reverter       :: Maybe (Expr EAddr)
+  -- ^ Nothing matches any reverter; Just want enforces actualReverter equals
+  -- this address.
+  , actualReverter :: Maybe (Expr EAddr)
+  -- ^ The first contract observed reverting in a non-CREATE frame after the
+  -- expectation was set. Captured on the first FrameReverted that arrives in a
+  -- CALL frame; subsequent reverts (bubble-ups) do not overwrite it. Used at
+  -- the matching boundary to compare against the expected reverter.
+  }
+  deriving (Show, Generic)
+
 data VMType = Symbolic | Concrete
 
 type family Gas (t :: VMType) = r | r -> t where
@@ -708,6 +729,8 @@ data VM (t :: VMType) = VM
   , exploreDepth   :: Int
   , keccakPreImgs  :: Set (ByteString, W256)
   , mergeState     :: MergeState
+  , expectedRevert :: Maybe ExpectedRevert
+  -- ^ Active expectRevert/expectPartialRevert expectation, if any.
   }
   deriving (Generic)
 

--- a/test/EVM/Test/FoundryTests.hs
+++ b/test/EVM/Test/FoundryTests.hs
@@ -109,6 +109,12 @@ tests = testGroup "Foundry tests"
     , test "Cheat-Codes-Pass" $ do
         let testFile = "test/contracts/pass/cheatCodes.sol"
         executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, False)
+    , test "Expect-Revert-Pass" $ do
+        let testFile = "test/contracts/pass/expectRevert.sol"
+        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+    , test "Expect-Revert-Fail" $ do
+        let testFile = "test/contracts/fail/expectRevert.sol"
+        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (False, True)
     , test "Cheat-Codes-Fork-Pass" $ do
         let testFile = "test/contracts/pass/cheatCodesFork.sol"
         executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)

--- a/test/contracts/fail/expectRevert.sol
+++ b/test/contracts/fail/expectRevert.sol
@@ -113,4 +113,34 @@ contract SolidityTest is Test {
         vm.expectRevert("from body");
         require(false, "from body");
     }
+
+    // Innermost reverter semantics: a top-level CREATE whose constructor
+    // reverts records the would-be-deployed address as the reverter. Naming
+    // a different address must fail.
+    function prove_expectRevert_create_wrong_reverter(uint256 x) public {
+        if (x == 0) return;
+        vm.expectRevert(address(0xdead));
+        new CtorReverter();
+    }
+
+    // Innermost reverter semantics: in a CALL that wraps a CREATE whose
+    // constructor reverts directly, the matched reverter is the inner
+    // CREATE's would-be-deployed address — not the wrapping CALL contract.
+    // Naming the wrapping CALL contract must fail.
+    function prove_expectRevert_call_wrapping_create_wrong_reverter(uint256 x) public {
+        if (x == 0) return;
+        Wrapper w = new Wrapper();
+        vm.expectRevert(address(w));
+        w.createReverter();
+    }
+}
+
+contract CtorReverter {
+    constructor() { revert("ctor revert"); }
+}
+
+contract Wrapper {
+    function createReverter() external {
+        new CtorReverter();
+    }
 }

--- a/test/contracts/fail/expectRevert.sol
+++ b/test/contracts/fail/expectRevert.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+contract Reverter {
+    error CustomError();
+
+    function revertWithMessage(string memory message) public pure {
+        revert(message);
+    }
+
+    function doNotRevert() public pure {}
+
+    function revertWithCustomError() public pure {
+        revert CustomError();
+    }
+}
+
+contract SolidityTest is Test {
+    function prove_expectRevert_some_branches_dont_revert(uint256 x) public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert();
+        if (x == 0) reverter.doNotRevert();
+        else reverter.revertWithMessage("foo");
+    }
+
+    function prove_expectRevert_message_mismatch(uint256 x) public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert("expected");
+        if (x == 0) reverter.revertWithMessage("expected");
+        else reverter.revertWithMessage("wrong");
+    }
+
+    function prove_expectRevert_wrong_reverter(uint256 x) public {
+        Reverter a = new Reverter();
+        Reverter b = new Reverter();
+        vm.expectRevert(address(a));
+        if (x == 0) a.revertWithMessage("foo");
+        else b.revertWithMessage("foo");
+    }
+
+    function prove_expectPartialRevert_wrong_selector(bool useCustom) public {
+        Reverter reverter = new Reverter();
+        vm.expectPartialRevert(Reverter.CustomError.selector);
+        if (useCustom) reverter.revertWithCustomError();
+        else reverter.revertWithMessage("any");
+    }
+}

--- a/test/contracts/fail/expectRevert.sol
+++ b/test/contracts/fail/expectRevert.sol
@@ -15,6 +15,17 @@ contract Reverter {
     function revertWithCustomError() public pure {
         revert CustomError();
     }
+
+    function revertWithoutReason() public pure {
+        revert();
+    }
+}
+
+contract WithArgError {
+    error CustomError(uint256 x);
+    function go() external pure {
+        revert CustomError(42);
+    }
 }
 
 contract SolidityTest is Test {
@@ -22,7 +33,7 @@ contract SolidityTest is Test {
         Reverter reverter = new Reverter();
         vm.expectRevert();
         if (x == 0) reverter.doNotRevert();
-        else reverter.revertWithMessage("foo");
+        else reverter.revertWithMessage("expected");
     }
 
     function prove_expectRevert_message_mismatch(uint256 x) public {
@@ -36,8 +47,8 @@ contract SolidityTest is Test {
         Reverter a = new Reverter();
         Reverter b = new Reverter();
         vm.expectRevert(address(a));
-        if (x == 0) a.revertWithMessage("foo");
-        else b.revertWithMessage("foo");
+        if (x == 0) a.revertWithMessage("expected");
+        else b.revertWithMessage("expected");
     }
 
     function prove_expectPartialRevert_wrong_selector(bool useCustom) public {
@@ -45,5 +56,61 @@ contract SolidityTest is Test {
         vm.expectPartialRevert(Reverter.CustomError.selector);
         if (useCustom) reverter.revertWithCustomError();
         else reverter.revertWithMessage("any");
+    }
+
+    function prove_expectRevert_only_reverter_mismatch(uint256 x) public {
+        Reverter a = new Reverter();
+        Reverter b = new Reverter();
+        vm.expectRevert(address(a));
+        if (x == 0) a.revertWithoutReason();
+        else b.revertWithoutReason();
+    }
+
+    function prove_expectRevert_wrong_reason_via_error_prefix(uint256 x) public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "wrong"));
+        if (x == 0) reverter.revertWithMessage("wrong");
+        else reverter.revertWithMessage("right");
+    }
+
+    function prove_expectRevert_double_set(uint256 x) public {
+        if (x == 0) return;
+        vm.expectRevert("first");
+        vm.expectRevert("second");
+    }
+
+    function prove_expectRevert_ok_then_revert(uint256 x) public {
+        Reverter reverter = new Reverter();
+        if (x == 0) return;
+        vm.expectRevert("expected");
+        reverter.doNotRevert();
+        reverter.revertWithMessage("expected");
+    }
+
+    function prove_expectRevert_empty_actual(uint256 x) public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert("expected");
+        if (x == 0) reverter.revertWithMessage("expected");
+        else reverter.revertWithoutReason();
+    }
+
+    function prove_expectRevert_full_match_extra_args(uint256 x) public {
+        WithArgError target = new WithArgError();
+        if (x == 0) return;
+        vm.expectRevert(abi.encodePacked(WithArgError.CustomError.selector));
+        target.go();
+    }
+
+    function prove_expectRevert_no_subcall(uint256 x) public {
+        if (x == 0) return;
+        vm.expectRevert("never happens");
+    }
+
+    // The expectation must be consumed by a strict sub-call. The test body's
+    // own revert does not satisfy it, even when the reason matches.
+    function prove_expectRevert_body_revert_matches(uint256 x) public {
+        if (x == 0) return;
+        vm.expectRevert("from body");
+        require(false, "from body");
     }
 }

--- a/test/contracts/pass/expectRevert.sol
+++ b/test/contracts/pass/expectRevert.sol
@@ -40,6 +40,23 @@ contract ConstructorReverter {
     }
 }
 
+contract DelegateLogic {
+    function doRevert(string memory m) external pure {
+        revert(m);
+    }
+}
+
+contract DelegateProxy {
+    address public logicAddr;
+    constructor(address _logic) { logicAddr = _logic; }
+    function relay(string memory m) external returns (bytes memory) {
+        (bool ok, bytes memory ret) = logicAddr.delegatecall(
+            abi.encodeWithSignature("doRevert(string)", m));
+        if (!ok) { assembly { revert(add(ret, 0x20), mload(ret)) } }
+        return ret;
+    }
+}
+
 struct LargeDummyStruct {
     address a;
     uint256 b;
@@ -155,6 +172,33 @@ contract ExpectRevertTest is Test {
 
         vm.expectRevert();
         reverter.revertWithoutReason();
+    }
+
+    function prove_expectRevertEmptyString() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", ""));
+        reverter.revertWithMessage("");
+    }
+
+    function prove_expectRevertCreate2Sentinel() public {
+        vm.expectRevert("ctor revert");
+        ConstructorReverter r = new ConstructorReverter{salt: bytes32(uint256(1))}("ctor revert");
+        require(address(r) == address(0x0000000000000000000000000000000000000001),
+                "swallowed CREATE2 must return DUMMY_CREATE_ADDRESS");
+    }
+
+    function prove_expectRevertSurvivesIntermediateCheat() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert("delayed");
+        vm.label(address(reverter), "reverter");
+        reverter.revertWithMessage("delayed");
+    }
+
+    function prove_expectRevertThroughDelegatecall() public {
+        DelegateLogic logic = new DelegateLogic();
+        DelegateProxy proxy = new DelegateProxy(address(logic));
+        vm.expectRevert("logic revert", address(proxy));
+        proxy.relay("logic revert");
     }
 }
 

--- a/test/contracts/pass/expectRevert.sol
+++ b/test/contracts/pass/expectRevert.sol
@@ -79,6 +79,26 @@ contract Dummy {
     }
 }
 
+contract MutatingReverter {
+    uint256 public x;
+    function setAndRevert(uint256 v, string memory m) external {
+        x = v;
+        revert(m);
+    }
+}
+
+contract StorageBox {
+    uint256 public x;
+    function set(uint256 v) external { x = v; }
+}
+
+contract CtorMutatingReverter {
+    constructor(StorageBox s, uint256 v) {
+        s.set(v);
+        revert("ctor revert");
+    }
+}
+
 contract ExpectRevertTest is Test {
     function prove_expectRevertString() public {
         Reverter reverter = new Reverter();
@@ -199,6 +219,22 @@ contract ExpectRevertTest is Test {
         DelegateProxy proxy = new DelegateProxy(address(logic));
         vm.expectRevert("logic revert", address(proxy));
         proxy.relay("logic revert");
+    }
+
+    function prove_expectRevertCallRollsBackState() public {
+        MutatingReverter r = new MutatingReverter();
+        require(r.x() == 0, "pre-state must be 0");
+        vm.expectRevert("call revert");
+        r.setAndRevert(42, "call revert");
+        require(r.x() == 0, "swallowed CALL revert must roll back state");
+    }
+
+    function prove_expectRevertCreateRollsBackState() public {
+        StorageBox s = new StorageBox();
+        require(s.x() == 0, "pre-state must be 0");
+        vm.expectRevert("ctor revert");
+        new CtorMutatingReverter(s, 42);
+        require(s.x() == 0, "swallowed CREATE revert must roll back state");
     }
 }
 

--- a/test/contracts/pass/expectRevert.sol
+++ b/test/contracts/pass/expectRevert.sol
@@ -86,6 +86,13 @@ contract ExpectRevertTest is Test {
         new ConstructorReverter("constructor revert");
     }
 
+    function prove_expectRevertConstructorReturnsDummyAddress() public {
+        vm.expectRevert("constructor revert");
+        ConstructorReverter r = new ConstructorReverter("constructor revert");
+        require(address(r) == address(0x0000000000000000000000000000000000000001),
+                "swallowed CREATE must return DUMMY_CREATE_ADDRESS");
+    }
+
     function prove_expectRevertBuiltin() public {
         Reverter reverter = new Reverter();
         vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));

--- a/test/contracts/pass/expectRevert.sol
+++ b/test/contracts/pass/expectRevert.sol
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import {Test} from "forge-std/Test.sol";
+
+contract Reverter {
+    error CustomError();
+
+    function revertWithMessage(string memory message) public pure {
+        revert(message);
+    }
+
+    function doNotRevert() public pure {}
+
+    function panic() public pure returns (uint256) {
+        return uint256(100) - uint256(101);
+    }
+
+    function revertWithCustomError() public pure {
+        revert CustomError();
+    }
+
+    function nestedRevert(Reverter inner, string memory message) public pure {
+        inner.revertWithMessage(message);
+    }
+
+    function callThenRevert(Dummy dummy, string memory message) public pure {
+        dummy.callMe();
+        revert(message);
+    }
+
+    function revertWithoutReason() public pure {
+        revert();
+    }
+}
+
+contract ConstructorReverter {
+    constructor(string memory message) {
+        revert(message);
+    }
+}
+
+struct LargeDummyStruct {
+    address a;
+    uint256 b;
+    bool c;
+    address d;
+    address e;
+    string f;
+    address[8] g;
+    address h;
+    uint256 i;
+}
+
+contract Dummy {
+    function callMe() public pure returns (string memory) {
+        return "thanks for calling";
+    }
+
+    function largeReturnType() public pure returns (LargeDummyStruct memory) {
+        revert("reverted with large return type");
+    }
+}
+
+contract ExpectRevertTest is Test {
+    function prove_expectRevertString() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert("revert");
+        reverter.revertWithMessage("revert");
+    }
+
+    function prove_expectRevertWithEncodedErrorPrefix() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "my revert reason"));
+        reverter.revertWithMessage("my revert reason");
+
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "A"));
+        reverter.revertWithMessage("A");
+
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "revert: A"));
+        reverter.revertWithMessage("revert: A");
+    }
+
+    function prove_expectRevertConstructor() public {
+        vm.expectRevert("constructor revert");
+        new ConstructorReverter("constructor revert");
+    }
+
+    function prove_expectRevertBuiltin() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(abi.encodeWithSignature("Panic(uint256)", 0x11));
+        reverter.panic();
+    }
+
+    function prove_expectRevertCustomError() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(abi.encodePacked(Reverter.CustomError.selector));
+        reverter.revertWithCustomError();
+    }
+
+    function prove_expectRevertNested() public {
+        Reverter reverter = new Reverter();
+        Reverter inner = new Reverter();
+        vm.expectRevert("nested revert");
+        reverter.nestedRevert(inner, "nested revert");
+    }
+
+    function prove_expectRevertCallsThenReverts() public {
+        Reverter reverter = new Reverter();
+        Dummy dummy = new Dummy();
+        vm.expectRevert("called a function and then reverted");
+        reverter.callThenRevert(dummy, "called a function and then reverted");
+    }
+
+    function prove_dummyReturnDataForBigType() public {
+        Dummy dummy = new Dummy();
+        vm.expectRevert("reverted with large return type");
+        dummy.largeReturnType();
+    }
+
+    function prove_expectRevertNoReason() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(bytes(""));
+        reverter.revertWithoutReason();
+    }
+
+    function prove_expectRevertAnyRevert() public {
+        vm.expectRevert();
+        new ConstructorReverter("hello this is a revert message");
+
+        Reverter reverter = new Reverter();
+        vm.expectRevert();
+        reverter.revertWithMessage("this is also a revert message");
+
+        vm.expectRevert();
+        reverter.panic();
+
+        vm.expectRevert();
+        reverter.revertWithCustomError();
+
+        Reverter reverter2 = new Reverter();
+        vm.expectRevert();
+        reverter.nestedRevert(reverter2, "this too is a revert message");
+
+        Dummy dummy = new Dummy();
+        vm.expectRevert();
+        reverter.callThenRevert(dummy, "revert message 4 i ran out of synonims for also");
+
+        vm.expectRevert();
+        reverter.revertWithoutReason();
+    }
+}
+
+contract AContract {
+    BContract bContract;
+    CContract cContract;
+
+    constructor(BContract _bContract, CContract _cContract) {
+        bContract = _bContract;
+        cContract = _cContract;
+    }
+
+    function callAndRevert() public pure {
+        require(1 > 2, "Reverted by AContract");
+    }
+
+    function callAndRevertInBContract() public {
+        bContract.callAndRevert();
+    }
+
+    function callAndRevertInCContract() public {
+        cContract.callAndRevert();
+    }
+
+    function callAndRevertInCContractThroughBContract() public {
+        bContract.callAndRevertInCContract();
+    }
+
+    function createDContract() public {
+        new DContract();
+    }
+
+    function createDContractThroughBContract() public {
+        bContract.createDContract();
+    }
+
+    function createDContractThroughCContract() public {
+        cContract.createDContract();
+    }
+
+    function doNotRevert() public {}
+}
+
+contract BContract {
+    CContract cContract;
+
+    constructor(CContract _cContract) {
+        cContract = _cContract;
+    }
+
+    function callAndRevert() public pure {
+        require(1 > 2, "Reverted by BContract");
+    }
+
+    function callAndRevertInCContract() public {
+        this.doNotRevert();
+        cContract.doNotRevert();
+        cContract.callAndRevert();
+    }
+
+    function createDContract() public {
+        this.doNotRevert();
+        cContract.doNotRevert();
+        new DContract();
+    }
+
+    function createDContractThroughCContract() public {
+        this.doNotRevert();
+        cContract.doNotRevert();
+        cContract.createDContract();
+    }
+
+    function doNotRevert() public {}
+}
+
+contract CContract {
+    error CContractError(string reason);
+
+    function callAndRevert() public pure {
+        revert CContractError("Reverted by CContract");
+    }
+
+    function createDContract() public {
+        new DContract();
+    }
+
+    function doNotRevert() public {}
+}
+
+contract DContract {
+    constructor() {
+        require(1 > 2, "Reverted by DContract");
+    }
+}
+
+contract ExpectRevertWithReverterTest is Test {
+    error CContractError(string reason);
+
+    AContract aContract;
+    BContract bContract;
+    CContract cContract;
+
+    function setUp() public {
+        cContract = new CContract();
+        bContract = new BContract(cContract);
+        aContract = new AContract(bContract, cContract);
+    }
+
+    function prove_expectRevertsWithReverter() public {
+        vm.expectRevert(address(aContract));
+        aContract.callAndRevert();
+
+        vm.expectRevert(address(bContract));
+        aContract.callAndRevertInBContract();
+
+        vm.expectPartialRevert(CContractError.selector, address(cContract));
+        aContract.callAndRevertInCContractThroughBContract();
+
+        vm.expectRevert(abi.encodeWithSelector(CContractError.selector, "Reverted by CContract"), address(cContract));
+        aContract.callAndRevertInCContract();
+    }
+
+    function prove_expectRevertsWithReverterInConstructor() public {
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(cContract));
+        cContract.createDContract();
+
+        vm.expectRevert(address(bContract));
+        bContract.createDContract();
+        vm.expectRevert(address(cContract));
+        bContract.createDContractThroughCContract();
+
+        vm.expectRevert(address(aContract));
+        aContract.createDContract();
+        vm.expectRevert(address(bContract));
+        aContract.createDContractThroughBContract();
+        vm.expectRevert(address(cContract));
+        aContract.createDContractThroughCContract();
+    }
+}

--- a/test/contracts/pass/expectRevert.sol
+++ b/test/contracts/pass/expectRevert.sol
@@ -32,6 +32,10 @@ contract Reverter {
     function revertWithoutReason() public pure {
         revert();
     }
+
+    function rawRevert(bytes memory b) public pure {
+        assembly { revert(add(b, 0x20), mload(b)) }
+    }
 }
 
 contract ConstructorReverter {
@@ -235,6 +239,15 @@ contract ExpectRevertTest is Test {
         vm.expectRevert("ctor revert");
         new CtorMutatingReverter(s, 42);
         require(s.x() == 0, "swallowed CREATE revert must roll back state");
+    }
+
+    // Wrapped expected vs raw actual: matchFullReason normalizes both sides by
+    // stripping any Error(string) wrapper, so an expected encoded as Error(string)
+    // matches a raw inner-bytes revert.
+    function prove_expectRevertWrappedExpectedRawActual() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "msg"));
+        reverter.rawRevert(bytes("msg"));
     }
 }
 

--- a/test/contracts/pass/expectRevert.sol
+++ b/test/contracts/pass/expectRevert.sol
@@ -370,20 +370,17 @@ contract ExpectRevertWithReverterTest is Test {
         aContract.callAndRevertInCContract();
     }
 
-    function prove_expectRevertsWithReverterInConstructor() public {
-        vm.expectRevert(abi.encodePacked("Reverted by DContract"), address(cContract));
-        cContract.createDContract();
-
-        vm.expectRevert(address(bContract));
-        bContract.createDContract();
-        vm.expectRevert(address(cContract));
-        bContract.createDContractThroughCContract();
-
-        vm.expectRevert(address(aContract));
-        aContract.createDContract();
-        vm.expectRevert(address(bContract));
-        aContract.createDContractThroughBContract();
-        vm.expectRevert(address(cContract));
-        aContract.createDContractThroughCContract();
+    // Innermost reverter semantics: when a CREATE constructor reverts, the
+    // matched reverter is that constructor's would-be-deployed address — not
+    // the parent CALL frame that owns the `new` expression. CREATE2 gives us
+    // a deterministic address we can predict and assert against.
+    function prove_expectRevertsCreate2WithReverter() public {
+        bytes32 salt = bytes32(uint256(0xC0FFEE));
+        address expected = address(uint160(uint256(keccak256(abi.encodePacked(
+            bytes1(0xff), address(this), salt,
+            keccak256(type(DContract).creationCode)
+        )))));
+        vm.expectRevert(abi.encodePacked("Reverted by DContract"), expected);
+        new DContract{salt: salt}();
     }
 }


### PR DESCRIPTION
## Description

Implements the following subset of the forge `expectRevert` family of cheatcodes:

- `expectRevert()`
- `expectRevert(bytes)`
- `expectRevert(bytes4)`
- `expectRevert(address)`
- `expectRevert(bytes4,address)`
- `expectRevert(bytes,address)`
- `expectPartialRevert(bytes4)`
- `expectPartialRevert(bytes4,address)`

I did my best to stay forge compatible here, but I made an exception regarding the handling of the variants that expect an address in relation to reverts within calls to `create`, where I instead implemented a consistent semantics and filed a ([partially fixed](https://github.com/foundry-rs/foundry/pull/14615)) [bug](https://github.com/foundry-rs/foundry/issues/14613) against forge.


## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
