### PR TITLE
Expr: sound disjointness rule for readWord/WriteWord with bounded offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controlled via `merge-max-budget`
 - Missing simplifications for Eq, Mod, SMod, XOR, SHL, SHR, and Or
 - A few more simplification rules around Eq, SHL/SHR, Sub+Add combos, and Xor
+- `readWord` disjointness rule for `WriteWord (Add (Lit c) X) …` with bounded `X`.
 
 ## Changed
 - Simplifier now rewrites `Mul(-1, x)` and `~x + 1` to `Sub(0, x)`

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -418,7 +418,7 @@ readBytes (Prelude.min 32 -> n) idx buf
 
 -- | Static upper bound on a word expression (unsigned, no wrap), or Nothing.
 upperBound :: Expr EWord -> Maybe W256
-upperBound a = \case
+upperBound e = case (simplifyNoLitToKeccak e) of
   Lit n         -> Just n
   And (Lit m) _ -> Just m
   Mod _ (Lit b)

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -416,12 +416,62 @@ readBytes :: Int -> Expr EWord -> Expr Buf -> Expr EWord
 readBytes (Prelude.min 32 -> n) idx buf
   = joinBytes [readByte (add idx (Lit . unsafeInto $ i)) buf | i <- [0 .. n - 1]]
 
+-- | Static upper bound on a word expression (unsigned, no wrap), or Nothing.
+upperBound :: Expr EWord -> Maybe W256
+upperBound = \case
+  Lit n         -> Just n
+  And (Lit m) _ -> Just m
+  And _ (Lit m) -> Just m
+  Mod _ (Lit b)
+    | b == 0    -> Just 0
+    | otherwise -> Just (b - 1)
+  Div a (Lit b)
+    | b == 0    -> Just 0
+    | otherwise -> upperBound a >>= \ua -> Just (ua `Prelude.div` b)
+  Mul (Lit a) b -> mulBound a b
+  Mul a (Lit b) -> mulBound b a
+  Add (Lit a) b -> addBound a b
+  Add a (Lit b) -> addBound b a
+  SHR (Lit n) b
+    | n >= 256  -> Just 0
+    | otherwise -> upperBound b >>= \ub ->
+        Just (ub `shiftR` fromIntegral n)
+  _ -> Nothing
+  where
+    mulBound a b
+      | a == 0    = Just 0
+      | otherwise = upperBound b >>= \ub ->
+          if ub == 0 then Just 0
+          else if ub <= (maxBound :: W256) `Prelude.div` a then Just (a * ub)
+          else Nothing
+    addBound a b = upperBound b >>= \ub ->
+      if a <= (maxBound :: W256) - ub then Just (a + ub) else Nothing
+
+-- | True if the WriteWord at @wIdx@ is provably disjoint from the 32-byte
+--   read at @i@. Sound mod 2^256: requires both windows to fit below 2^256.
+writeDisjointFromReadWord :: W256 -> Expr EWord -> Bool
+writeDisjointFromReadWord i = \case
+  Add (Lit c) x
+    | Just ux <- upperBound x ->
+        let cI        = toInteger c
+            uxI       = toInteger ux
+            iI        = toInteger i
+            maxI      = toInteger (maxBound :: W256)
+            writeMaxI = cI + uxI + 31
+            readMaxI  = iI + 31
+        in readMaxI <= maxI
+           && writeMaxI <= maxI
+           && (cI >= iI + 32 || writeMaxI < iI)
+  _ -> False
+
 -- | Reads the word starting at idx from the given buf
 readWord :: Expr EWord -> Expr Buf -> Expr EWord
 readWord idx buf@(AbstractBuf _) = ReadWord idx buf
 readWord idx b@(WriteWord idx' val buf)
   -- the word we are trying to read exactly matches a WriteWord
   | idx == idx' = val
+  -- WriteWord provably disjoint via interval bounds (Add (Lit c) X, X bounded)
+  | Lit i <- idx, writeDisjointFromReadWord i idx' = readWord idx buf
   | otherwise = case (idx, idx') of
     (Lit i, Lit i') ->
       if i' - i >= 32 && i' - i <= (maxBound :: W256) - 31

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -458,7 +458,7 @@ writeDisjointFromReadWord i = \case
             readMaxI  = iI + 31
         in readMaxI <= maxI
            && writeMaxI <= maxI
-           && (cI >= iI + 32 || writeMaxI < iI)
+           && (cI > readMaxI || writeMaxI < iI)
   _ -> False
 
 -- | Reads the word starting at idx from the given buf

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -418,10 +418,9 @@ readBytes (Prelude.min 32 -> n) idx buf
 
 -- | Static upper bound on a word expression (unsigned, no wrap), or Nothing.
 upperBound :: Expr EWord -> Maybe W256
-upperBound = \case
+upperBound a = \case
   Lit n         -> Just n
   And (Lit m) _ -> Just m
-  And _ (Lit m) -> Just m
   Mod _ (Lit b)
     | b == 0    -> Just 0
     | otherwise -> Just (b - 1)
@@ -429,9 +428,7 @@ upperBound = \case
     | b == 0    -> Just 0
     | otherwise -> upperBound a >>= \ua -> Just (ua `Prelude.div` b)
   Mul (Lit a) b -> mulBound a b
-  Mul a (Lit b) -> mulBound b a
   Add (Lit a) b -> addBound a b
-  Add a (Lit b) -> addBound b a
   SHR (Lit n) b
     | n >= 256  -> Just 0
     | otherwise -> upperBound b >>= \ub ->

--- a/test/EVM/Expr/ExprTests.hs
+++ b/test/EVM/Expr/ExprTests.hs
@@ -182,6 +182,50 @@ memoryTests = testGroup "Memory tests"
   , testCase "stripbytes-concrete-bug" $ assertEqual ""
       (Expr.simplifyReads (ReadByte (Lit 0) (ConcreteBuf "5")))
       (LitByte 53)
+
+  -- Interval-bounds disjointness for readWord over WriteWord (Add (Lit c) X).
+
+  , testCase "readWord-skip-write-above-and-bounded" $ assertEqual
+      "write at Add (Lit 100) (And (Lit 0xff) X) must be skipped when reading at 0"
+      (Lit 0)
+      (Expr.readWord (Lit 0)
+        (WriteWord (Add (Lit 100) (And (Lit 0xff) (Var "x")))
+                   (Lit 0x42)
+                   mempty))
+
+  , testCase "readWord-skip-write-above-mul-and-bounded" $ assertEqual
+      "write at Add (Lit 100) (Mul 32 (And 0xff X)) must be skipped when reading at 0"
+      (Lit 0)
+      (Expr.readWord (Lit 0)
+        (WriteWord (Add (Lit 100) (Mul (Lit 32) (And (Lit 0xff) (Var "x"))))
+                   (Lit 0x42)
+                   mempty))
+
+  , testCase "readWord-no-skip-write-above-unbounded" $ do
+      -- Unbounded X: rule must NOT fire.
+      let r = Expr.readWord (Lit 0)
+                (WriteWord (Add (Lit 100) (Var "x")) (Lit 0x42) mempty)
+      assertBool ("rule fired on unbounded X (unsound): " <> show r)
+                 (r /= Lit 0)
+
+  , testCase "readWord-no-skip-write-wrap-risk" $ do
+      -- c near maxBound: write region can wrap, so rule must NOT fire.
+      let bigC = (maxBound :: W256) - 50
+          r = Expr.readWord (Lit 0)
+                (WriteWord (Add (Lit bigC) (And (Lit 0xff) (Var "x")))
+                           (Lit 0x42)
+                           mempty)
+      assertBool ("rule fired on wrap-risk write (unsound): " <> show r)
+                 (r /= Lit 0)
+
+  , testCase "readWord-no-skip-write-possible-overlap" $ do
+      -- Read [80,111] vs write [100,355] overlap; rule must NOT fire.
+      let r = Expr.readWord (Lit 80)
+                (WriteWord (Add (Lit 100) (And (Lit 0xff) (Var "x")))
+                           (Lit 0x42)
+                           mempty)
+      assertBool ("rule fired on possibly-overlapping write (unsound): " <> show r)
+                 (r /= Lit 0)
   ]
 
 basicSimplificationTests :: TestTree


### PR DESCRIPTION
## Summary

Adds a new `readWord` clause that elides a `WriteWord` whose offset is of the form `Add (Lit c) X`, when `X` has a derivable static upper bound and the write region is provably disjoint from the read in EVM (mod 2^256) arithmetic.

- New helper `upperBound :: Expr EWord -> Maybe W256` — conservative static upper bound handling `Lit`, `And`-with-`Lit`, `Mod`-by-`Lit`, `Div`-by-`Lit`, `Mul`/`Add` with one `Lit` operand, and `SHR` by a `Lit` shift.
- New helper `writeDisjointFromReadWord :: W256 -> Expr EWord -> Bool` — uses `Integer` arithmetic to detect wrap on both the read and write byte ranges before concluding the write can be skipped, so the rule does not assume non-wrapping addition.
- Hook in `readWord` at the `WriteWord` case.

Split out from #1063 so the disjointness rule is reviewable on its own; #1063 will be rebased on top of this.

## Tests

5 new unit tests in `test/EVM/Expr/ExprTests.hs`:

- positive: `WriteWord` at `Add(Lit, And-bounded)` skipped
- positive: `WriteWord` at `Add(Lit, Mul-And-bounded)` skipped
- negative: unbounded `X` — not skipped
- negative: wrap-risk near `maxBound` — not skipped
- negative: read region overlaps write min offset — not skipped

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs — N/A, internal simplifier rule
- [x] updated the changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)