### PR TITLE
Add assertApproxEqRel cheatcode (uint256 and int256)

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2298,24 +2298,19 @@ cheatActions = Map.fromList
     scale1e18 = 10^(18::Int)
     scale1e18W :: W256
     scale1e18W = 10^(18::Int)
-    -- largest absDelta for which (absDelta * 1e18) does not overflow 256 bits.
-    -- Used by the symbolic relative-equality path to detect when the truncating
-    -- Expr.mul would produce a wrong result.
+    -- largest absDelta with absDelta*1e18 < 2^256 (symbolic overflow guard)
     maxSafeRelDelta :: W256
     maxSafeRelDelta = (maxBound :: W256) `Prelude.div` scale1e18W
-    -- shared failure message for the relative-equality assertions; realDelta is
-    -- already rendered (a scaled integer, or the literal "undefined")
+    -- shared rel-assertion failure message; realDelta is pre-rendered
     relFailMsg :: Show a => a -> a -> Word256 -> String -> ByteString
     relFailMsg a b maxPercentDelta realDelta = "assertion failed: " <>
       BS8.pack (show a) <> " !~= " <> BS8.pack (show b) <>
       " (max delta: " <> BS8.pack (show maxPercentDelta) <>
       ", real delta: " <> BS8.pack realDelta <> ")"
     genAssert = genAssertN []
-    -- as genAssert, but ignores `extra` trailing ABI args (foundry's `err`-string
-    -- overloads). Used directly only for the string-operand variants; static
-    -- operands instead strip the trailing arg upstream via withMsg so they keep
-    -- the symbolic comparison path (decodeBuf yields no SAbi once a dynamic type
-    -- like the string is present in the signature).
+    -- like genAssert but ignores `extra` trailing ABI args (the err-string
+    -- overloads). Only used directly for string operands; static operands strip
+    -- the err arg upstream via withMsg to keep the symbolic path.
     genAssertN extra comp exprComp invComp name abitype sig input = do
       case decodeBuf ([abitype, abitype] ++ extra) input of
         (CAbi (a:b:_),"") | a `comp` b -> doStop
@@ -2327,19 +2322,16 @@ cheatActions = Map.fromList
             False -> doStop
             True -> revertErr ew1 ew2 invComp
         abivals -> vmError (BadCheatCode (paramDecodeErr abitype name abivals) sig)
-    -- Keep only the first n 32-byte head words of the calldata, dropping the
-    -- trailing (dynamic) `err` string so the operand-only handlers can decode
-    -- normally and still produce SAbi for symbolic operands.
+    -- keep the first n 32-byte head words, dropping the trailing err string so
+    -- operand-only handlers decode normally (and keep SAbi for symbolic operands)
     keepHeadWords n input =
       foldr (\i acc -> let off = Lit (fromIntegral (i * 32 :: Int))
                        in writeWord off (readWord off input) acc)
             mempty [0 .. n - 1]
     -- Run a no-message handler after stripping the trailing `err` string.
     withMsg n handler sig input = handler sig (keepHeadWords n input)
-    -- Message variants whose OPERANDS are dynamic (string, bytes): they can't be
-    -- sliced, so decode [op, op, string] and compare the first two operands
-    -- concretely (dynamic operands have no symbolic path), ignoring the trailing
-    -- `err` string. Matches the concrete-only behaviour of assertEq(string,string).
+    -- dynamic operands (string/bytes) can't be sliced: decode [op,op,string] and
+    -- compare the first two concretely (no symbolic path), ignoring the err string
     assertEqMsgDyn    op = genAssertN [AbiStringType] (==) Expr.eq "!=" "assertEq" op
     assertNotEqMsgDyn op = genAssertN [AbiStringType] (/=) (\a b -> Expr.iszero $ Expr.eq a b) "==" "assertNotEq" op
     assertEq =    genAssert (==) Expr.eq "!=" "assertEq"
@@ -2407,15 +2399,9 @@ cheatActions = Map.fromList
               False -> doStop
               True -> frameRevert "assertion failed: assertApproxEqAbs (symbolic)"
         abivals -> vmError (BadCheatCode ("assertApproxEqAbs(int256,int256,uint256) parameter decoding failed: " <> show abivals) sig)
-    -- | assertApproxEqRel for uint256: passes when the relative difference in
-    -- percents is <= maxPercentDelta. maxPercentDelta is an 18-decimal fixed
-    -- point number where 1e18 == 100%. The denominator is the second argument
-    -- (the reference value), matching foundry/forge-std semantics:
-    --   percentDelta = |a - b| * 1e18 / b
-    -- Special cases (mirroring the native foundry cheatcode):
-    --   * b == 0 && a == 0 -> pass (treated as equal)
-    --   * b == 0 && a /= 0 -> fail with "real delta: undefined"
-    --   * if the U512 intermediate doesn't fit in uint256 -> "overflow in delta calculation"
+    -- | assertApproxEqRel(uint256): pass iff |a-b|*1e18/b <= maxPercentDelta
+    -- (1e18 == 100%, denominator is the reference b), per forge-std. Special cases:
+    -- b==0&&a==0 -> pass; b==0&&a/=0 -> "undefined"; result > uint256 -> overflow.
     assertApproxEqRelUint sig input = do
       case decodeBuf [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256] input of
         (CAbi [AbiUInt _ a, AbiUInt _ b, AbiUInt _ maxPercentDelta],"")
@@ -2424,22 +2410,17 @@ cheatActions = Map.fromList
             else frameRevert $ relFailMsg a b maxPercentDelta "undefined"
           | otherwise ->
             let absDelta = if a > b then a - b else b - a
-                -- compute in Integer to avoid the intermediate overflow that
-                -- foundry sidesteps by widening to U512
+                -- in Integer to avoid the intermediate overflow (foundry uses U512)
                 percentDelta = (toInteger absDelta * scale1e18) `Prelude.div` toInteger b
             in if percentDelta > toInteger (maxBound :: Word256)
                then frameRevert "assertion failed: overflow in delta calculation"
                else if percentDelta <= toInteger maxPercentDelta then doStop
                else frameRevert $ relFailMsg a b maxPercentDelta (show percentDelta)
         (SAbi [ew1, ew2, ew3],"") ->
-          -- Sound symbolic encoding. percentDelta = |a-b| * 1e18 / b, and the
-          -- assertion passes iff percentDelta <= maxPercentDelta. hevm's Expr has
-          -- no full-precision div, so Expr.mul truncates mod 2^256 and the result
-          -- is only trustworthy when (absDelta * 1e18) cannot overflow, i.e.
-          -- absDelta <= maxSafeRelDelta. We therefore PASS only when we can prove
-          -- the assertion holds; in every other case (overflow possible, or
-          -- b == 0 && a /= 0) we fail. This can produce false positives but never
-          -- an unsound pass. b == 0 && a == 0 is treated as equal (pass).
+          -- Sound encoding: Expr.mul truncates mod 2^256, so it's only trustworthy
+          -- when absDelta*1e18 can't overflow (absDelta <= maxSafeRelDelta). Pass
+          -- only when provably within bound; overflow-possible or b==0&&a/=0 fail
+          -- (b==0&&a==0 passes). May give false positives, never an unsound pass.
           let absDelta     = Expr.sub (Expr.max ew1 ew2) (Expr.min ew1 ew2)
               percentDelta = Expr.div (Expr.mul absDelta (Lit scale1e18W)) ew2
               bZero        = Expr.iszero ew2
@@ -2456,9 +2437,8 @@ cheatActions = Map.fromList
               False -> doStop
               True -> frameRevert "assertion failed: assertApproxEqRel (symbolic)"
         abivals -> vmError (BadCheatCode ("assertApproxEqRel(uint256,uint256,uint256) parameter decoding failed: " <> show abivals) sig)
-    -- | assertApproxEqRel for int256. Same as the uint version but the absolute
-    -- delta accounts for signs (same sign: ||a|-|b||, opposite: |a|+|b|) and the
-    -- denominator is |b|.
+    -- | assertApproxEqRel(int256): as uint, but signed absDelta (same sign
+    -- ||a|-|b||, opposite |a|+|b|) over denominator |b|.
     assertApproxEqRelInt sig input = do
       case decodeBuf [AbiIntType 256, AbiIntType 256, AbiUIntType 256] input of
         (CAbi [AbiInt _ a, AbiInt _ b, AbiUInt _ maxPercentDelta],"") ->
@@ -2481,12 +2461,9 @@ cheatActions = Map.fromList
                   else if percentDelta <= toInteger maxPercentDelta then doStop
                   else frameRevert $ relFailMsg a b maxPercentDelta (show percentDelta)
         (SAbi [_, _, _],"") ->
-          -- A sound symbolic encoding for signed operands would need full-precision
-          -- signed abs and a |b| denominator (||a|-|b|| / |a|+|b| over the reference
-          -- |b|), which hevm's Expr language cannot express without an unsound,
-          -- overflow-prone Expr.mul/Expr.div. Rather than risk a false pass we
-          -- conservatively report failure for symbolic int256 operands. This may
-          -- be a false positive but is never an unsound pass.
+          -- A sound signed encoding isn't expressible with hevm's Expr (would need
+          -- full-precision signed abs + |b| division), so we conservatively fail
+          -- rather than risk an unsound pass. May be a false positive.
           frameRevert "assertion failed: assertApproxEqRel (symbolic int256 operands not supported)"
         abivals -> vmError (BadCheatCode ("assertApproxEqRel(int256,int256,uint256) parameter decoding failed: " <> show abivals) sig)
     toStringCheat abitype sig input = do

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2188,6 +2188,7 @@ cheatActions = Map.fromList
   , action "assertEq(address,address)" $ assertEq AbiAddressType
   , action "assertEq(bytes32,bytes32)" $ assertEq (AbiBytesType 32)
   , action "assertEq(string,string)"   $ assertEq (AbiStringType)
+  , action "assertEq(bytes,bytes)"     $ assertEq AbiBytesDynamicType
   --
   , action "assertNotEq(bool,bool)"       $ assertNotEq AbiBoolType
   , action "assertNotEq(uint256,uint256)" $ assertNotEq (AbiUIntType 256)
@@ -2195,6 +2196,7 @@ cheatActions = Map.fromList
   , action "assertNotEq(address,address)" $ assertNotEq AbiAddressType
   , action "assertNotEq(bytes32,bytes32)" $ assertNotEq (AbiBytesType 32)
   , action "assertNotEq(string,string)"   $ assertNotEq (AbiStringType)
+  , action "assertNotEq(bytes,bytes)"      $ assertNotEq AbiBytesDynamicType
   --
   , action "assertLt(uint256,uint256)" $ assertLt (AbiUIntType 256)
   , action "assertLt(int256,int256)"   $ assertSLt (AbiIntType 256)
@@ -2210,6 +2212,39 @@ cheatActions = Map.fromList
   --
   , action "assertApproxEqRel(uint256,uint256,uint256)" $ assertApproxEqRelUint
   , action "assertApproxEqRel(int256,int256,uint256)"   $ assertApproxEqRelInt
+  --
+  -- Variants with a trailing `err` string. The string is decoded away and never
+  -- used; each behaves exactly like its non-message counterpart.
+  , action "assertEq(bool,bool,string)"       $ withMsg 2 (assertEq AbiBoolType)
+  , action "assertEq(uint256,uint256,string)" $ withMsg 2 (assertEq (AbiUIntType 256))
+  , action "assertEq(int256,int256,string)"   $ withMsg 2 (assertEq (AbiIntType 256))
+  , action "assertEq(address,address,string)" $ withMsg 2 (assertEq AbiAddressType)
+  , action "assertEq(bytes32,bytes32,string)" $ withMsg 2 (assertEq (AbiBytesType 32))
+  , action "assertEq(string,string,string)"   $ assertEqMsgDyn AbiStringType
+  , action "assertEq(bytes,bytes,string)"      $ assertEqMsgDyn AbiBytesDynamicType
+  --
+  , action "assertNotEq(bool,bool,string)"       $ withMsg 2 (assertNotEq AbiBoolType)
+  , action "assertNotEq(uint256,uint256,string)" $ withMsg 2 (assertNotEq (AbiUIntType 256))
+  , action "assertNotEq(int256,int256,string)"   $ withMsg 2 (assertNotEq (AbiIntType 256))
+  , action "assertNotEq(address,address,string)" $ withMsg 2 (assertNotEq AbiAddressType)
+  , action "assertNotEq(bytes32,bytes32,string)" $ withMsg 2 (assertNotEq (AbiBytesType 32))
+  , action "assertNotEq(string,string,string)"   $ assertNotEqMsgDyn AbiStringType
+  , action "assertNotEq(bytes,bytes,string)"      $ assertNotEqMsgDyn AbiBytesDynamicType
+  --
+  , action "assertLt(uint256,uint256,string)" $ withMsg 2 (assertLt (AbiUIntType 256))
+  , action "assertLt(int256,int256,string)"   $ withMsg 2 (assertSLt (AbiIntType 256))
+  , action "assertLe(uint256,uint256,string)" $ withMsg 2 (assertLe (AbiUIntType 256))
+  , action "assertLe(int256,int256,string)"   $ withMsg 2 (assertSLe (AbiIntType 256))
+  , action "assertGt(uint256,uint256,string)" $ withMsg 2 (assertGt (AbiUIntType 256))
+  , action "assertGt(int256,int256,string)"   $ withMsg 2 (assertSGt (AbiIntType 256))
+  , action "assertGe(uint256,uint256,string)" $ withMsg 2 (assertGe (AbiUIntType 256))
+  , action "assertGe(int256,int256,string)"   $ withMsg 2 (assertSGe (AbiIntType 256))
+  --
+  , action "assertApproxEqAbs(uint256,uint256,uint256,string)" $ withMsg 3 assertApproxEqAbsUint
+  , action "assertApproxEqAbs(int256,int256,uint256,string)"   $ withMsg 3 assertApproxEqAbsInt
+  --
+  , action "assertApproxEqRel(uint256,uint256,uint256,string)" $ withMsg 3 assertApproxEqRelUint
+  , action "assertApproxEqRel(int256,int256,uint256,string)"   $ withMsg 3 assertApproxEqRelInt
   --
   , action "toString(address)" $ toStringCheat AbiAddressType
   , action "toString(bool)"    $ toStringCheat AbiBoolType
@@ -2270,17 +2305,38 @@ cheatActions = Map.fromList
       BS8.pack (show a) <> " !~= " <> BS8.pack (show b) <>
       " (max delta: " <> BS8.pack (show maxPercentDelta) <>
       ", real delta: " <> BS8.pack realDelta <> ")"
-    genAssert comp exprComp invComp name abitype sig input = do
-      case decodeBuf [abitype, abitype] input of
-        (CAbi [a, b],"") | a `comp` b -> doStop
-        (CAbi [a, b],"")-> revertErr a b invComp
-        (SAbi [ew1, ew2],"") -> case (Expr.simplify (Expr.iszero $ exprComp ew1 ew2)) of
+    genAssert = genAssertN []
+    -- as genAssert, but ignores `extra` trailing ABI args (foundry's `err`-string
+    -- overloads). Used directly only for the string-operand variants; static
+    -- operands instead strip the trailing arg upstream via withMsg so they keep
+    -- the symbolic comparison path (decodeBuf yields no SAbi once a dynamic type
+    -- like the string is present in the signature).
+    genAssertN extra comp exprComp invComp name abitype sig input = do
+      case decodeBuf ([abitype, abitype] ++ extra) input of
+        (CAbi (a:b:_),"") | a `comp` b -> doStop
+        (CAbi (a:b:_),"")-> revertErr a b invComp
+        (SAbi (ew1:ew2:_),"") -> case (Expr.simplify (Expr.iszero $ exprComp ew1 ew2)) of
           Lit 0 -> doStop
           Lit _ -> revertErr ew1 ew2 invComp
           ew -> branch (?conf).maxDepth ew $ \case
             False -> doStop
             True -> revertErr ew1 ew2 invComp
         abivals -> vmError (BadCheatCode (paramDecodeErr abitype name abivals) sig)
+    -- Keep only the first n 32-byte head words of the calldata, dropping the
+    -- trailing (dynamic) `err` string so the operand-only handlers can decode
+    -- normally and still produce SAbi for symbolic operands.
+    keepHeadWords n input =
+      foldr (\i acc -> let off = Lit (fromIntegral (i * 32 :: Int))
+                       in writeWord off (readWord off input) acc)
+            mempty [0 .. n - 1]
+    -- Run a no-message handler after stripping the trailing `err` string.
+    withMsg n handler sig input = handler sig (keepHeadWords n input)
+    -- Message variants whose OPERANDS are dynamic (string, bytes): they can't be
+    -- sliced, so decode [op, op, string] and compare the first two operands
+    -- concretely (dynamic operands have no symbolic path), ignoring the trailing
+    -- `err` string. Matches the concrete-only behaviour of assertEq(string,string).
+    assertEqMsgDyn    op = genAssertN [AbiStringType] (==) Expr.eq "!=" "assertEq" op
+    assertNotEqMsgDyn op = genAssertN [AbiStringType] (/=) (\a b -> Expr.iszero $ Expr.eq a b) "==" "assertNotEq" op
     assertEq =    genAssert (==) Expr.eq "!=" "assertEq"
     assertNotEq = genAssert (/=) (\a b -> Expr.iszero $ Expr.eq a b) "==" "assertNotEq"
     assertLt =    genAssert (<)  Expr.lt ">=" "assertLt"

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2295,9 +2295,14 @@ cheatActions = Map.fromList
       BS8.pack (show a) <> " " <> comp <> " " <> BS8.pack (show b)
     -- 1e18 (100% in foundry's 18-decimal fixed point) as Integer and W256
     scale1e18 :: Integer
-    scale1e18 = 1000000000000000000
+    scale1e18 = 10^(18::Int)
     scale1e18W :: W256
-    scale1e18W = 1000000000000000000
+    scale1e18W = 10^(18::Int)
+    -- largest absDelta for which (absDelta * 1e18) does not overflow 256 bits.
+    -- Used by the symbolic relative-equality path to detect when the truncating
+    -- Expr.mul would produce a wrong result.
+    maxSafeRelDelta :: W256
+    maxSafeRelDelta = (maxBound :: W256) `Prelude.div` scale1e18W
     -- shared failure message for the relative-equality assertions; realDelta is
     -- already rendered (a scaled integer, or the literal "undefined")
     relFailMsg :: Show a => a -> a -> Word256 -> String -> ByteString
@@ -2427,10 +2432,24 @@ cheatActions = Map.fromList
                else if percentDelta <= toInteger maxPercentDelta then doStop
                else frameRevert $ relFailMsg a b maxPercentDelta (show percentDelta)
         (SAbi [ew1, ew2, ew3],"") ->
-          -- percentDelta = (max(a,b) - min(a,b)) * 1e18 / b; check <= maxPercentDelta
-          let absDelta = Expr.sub (Expr.max ew1 ew2) (Expr.min ew1 ew2)
+          -- Sound symbolic encoding. percentDelta = |a-b| * 1e18 / b, and the
+          -- assertion passes iff percentDelta <= maxPercentDelta. hevm's Expr has
+          -- no full-precision div, so Expr.mul truncates mod 2^256 and the result
+          -- is only trustworthy when (absDelta * 1e18) cannot overflow, i.e.
+          -- absDelta <= maxSafeRelDelta. We therefore PASS only when we can prove
+          -- the assertion holds; in every other case (overflow possible, or
+          -- b == 0 && a /= 0) we fail. This can produce false positives but never
+          -- an unsound pass. b == 0 && a == 0 is treated as equal (pass).
+          let absDelta     = Expr.sub (Expr.max ew1 ew2) (Expr.min ew1 ew2)
               percentDelta = Expr.div (Expr.mul absDelta (Lit scale1e18W)) ew2
-          in case Expr.simplify (Expr.iszero $ Expr.leq percentDelta ew3) of
+              bZero        = Expr.iszero ew2
+              aNotZero     = Expr.iszero (Expr.iszero ew1)
+              overflow     = Expr.gt absDelta (Lit maxSafeRelDelta)
+              pdExceeds    = Expr.gt percentDelta ew3
+              -- fail iff (b == 0 && a /= 0) || (b /= 0 && (overflow || pd > max))
+              failCond     = Expr.or (Expr.and bZero aNotZero)
+                                     (Expr.and (Expr.iszero bZero) (Expr.or overflow pdExceeds))
+          in case Expr.simplify failCond of
             Lit 0 -> doStop
             Lit _ -> frameRevert "assertion failed: assertApproxEqRel (symbolic)"
             ew -> branch (?conf).maxDepth ew $ \case
@@ -2461,16 +2480,14 @@ cheatActions = Map.fromList
                   then frameRevert "assertion failed: overflow in delta calculation"
                   else if percentDelta <= toInteger maxPercentDelta then doStop
                   else frameRevert $ relFailMsg a b maxPercentDelta (show percentDelta)
-        (SAbi [ew1, ew2, ew3],"") ->
-          -- best-effort symbolic handling (same-sign approximation, see assertApproxEqAbs)
-          let absDelta = Expr.sub (Expr.max ew1 ew2) (Expr.min ew1 ew2)
-              percentDelta = Expr.div (Expr.mul absDelta (Lit scale1e18W)) ew2
-          in case Expr.simplify (Expr.iszero $ Expr.leq percentDelta ew3) of
-            Lit 0 -> doStop
-            Lit _ -> frameRevert "assertion failed: assertApproxEqRel (symbolic)"
-            ew -> branch (?conf).maxDepth ew $ \case
-              False -> doStop
-              True -> frameRevert "assertion failed: assertApproxEqRel (symbolic)"
+        (SAbi [_, _, _],"") ->
+          -- A sound symbolic encoding for signed operands would need full-precision
+          -- signed abs and a |b| denominator (||a|-|b|| / |a|+|b| over the reference
+          -- |b|), which hevm's Expr language cannot express without an unsound,
+          -- overflow-prone Expr.mul/Expr.div. Rather than risk a false pass we
+          -- conservatively report failure for symbolic int256 operands. This may
+          -- be a false positive but is never an unsound pass.
+          frameRevert "assertion failed: assertApproxEqRel (symbolic int256 operands not supported)"
         abivals -> vmError (BadCheatCode ("assertApproxEqRel(int256,int256,uint256) parameter decoding failed: " <> show abivals) sig)
     toStringCheat abitype sig input = do
       case decodeBuf [abitype] input of

--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -2208,6 +2208,9 @@ cheatActions = Map.fromList
   , action "assertApproxEqAbs(uint256,uint256,uint256)" $ assertApproxEqAbsUint
   , action "assertApproxEqAbs(int256,int256,uint256)"   $ assertApproxEqAbsInt
   --
+  , action "assertApproxEqRel(uint256,uint256,uint256)" $ assertApproxEqRelUint
+  , action "assertApproxEqRel(int256,int256,uint256)"   $ assertApproxEqRelInt
+  --
   , action "toString(address)" $ toStringCheat AbiAddressType
   , action "toString(bool)"    $ toStringCheat AbiBoolType
   , action "toString(uint256)" $ toStringCheat (AbiUIntType 256)
@@ -2255,6 +2258,18 @@ cheatActions = Map.fromList
       ")  parameter decoding failed. Error: " <> show abivals
     revertErr a b comp = frameRevert $ "assertion failed: " <>
       BS8.pack (show a) <> " " <> comp <> " " <> BS8.pack (show b)
+    -- 1e18 (100% in foundry's 18-decimal fixed point) as Integer and W256
+    scale1e18 :: Integer
+    scale1e18 = 1000000000000000000
+    scale1e18W :: W256
+    scale1e18W = 1000000000000000000
+    -- shared failure message for the relative-equality assertions; realDelta is
+    -- already rendered (a scaled integer, or the literal "undefined")
+    relFailMsg :: Show a => a -> a -> Word256 -> String -> ByteString
+    relFailMsg a b maxPercentDelta realDelta = "assertion failed: " <>
+      BS8.pack (show a) <> " !~= " <> BS8.pack (show b) <>
+      " (max delta: " <> BS8.pack (show maxPercentDelta) <>
+      ", real delta: " <> BS8.pack realDelta <> ")"
     genAssert comp exprComp invComp name abitype sig input = do
       case decodeBuf [abitype, abitype] input of
         (CAbi [a, b],"") | a `comp` b -> doStop
@@ -2331,6 +2346,76 @@ cheatActions = Map.fromList
               False -> doStop
               True -> frameRevert "assertion failed: assertApproxEqAbs (symbolic)"
         abivals -> vmError (BadCheatCode ("assertApproxEqAbs(int256,int256,uint256) parameter decoding failed: " <> show abivals) sig)
+    -- | assertApproxEqRel for uint256: passes when the relative difference in
+    -- percents is <= maxPercentDelta. maxPercentDelta is an 18-decimal fixed
+    -- point number where 1e18 == 100%. The denominator is the second argument
+    -- (the reference value), matching foundry/forge-std semantics:
+    --   percentDelta = |a - b| * 1e18 / b
+    -- Special cases (mirroring the native foundry cheatcode):
+    --   * b == 0 && a == 0 -> pass (treated as equal)
+    --   * b == 0 && a /= 0 -> fail with "real delta: undefined"
+    --   * if the U512 intermediate doesn't fit in uint256 -> "overflow in delta calculation"
+    assertApproxEqRelUint sig input = do
+      case decodeBuf [AbiUIntType 256, AbiUIntType 256, AbiUIntType 256] input of
+        (CAbi [AbiUInt _ a, AbiUInt _ b, AbiUInt _ maxPercentDelta],"")
+          | b == 0 ->
+            if a == 0 then doStop
+            else frameRevert $ relFailMsg a b maxPercentDelta "undefined"
+          | otherwise ->
+            let absDelta = if a > b then a - b else b - a
+                -- compute in Integer to avoid the intermediate overflow that
+                -- foundry sidesteps by widening to U512
+                percentDelta = (toInteger absDelta * scale1e18) `Prelude.div` toInteger b
+            in if percentDelta > toInteger (maxBound :: Word256)
+               then frameRevert "assertion failed: overflow in delta calculation"
+               else if percentDelta <= toInteger maxPercentDelta then doStop
+               else frameRevert $ relFailMsg a b maxPercentDelta (show percentDelta)
+        (SAbi [ew1, ew2, ew3],"") ->
+          -- percentDelta = (max(a,b) - min(a,b)) * 1e18 / b; check <= maxPercentDelta
+          let absDelta = Expr.sub (Expr.max ew1 ew2) (Expr.min ew1 ew2)
+              percentDelta = Expr.div (Expr.mul absDelta (Lit scale1e18W)) ew2
+          in case Expr.simplify (Expr.iszero $ Expr.leq percentDelta ew3) of
+            Lit 0 -> doStop
+            Lit _ -> frameRevert "assertion failed: assertApproxEqRel (symbolic)"
+            ew -> branch (?conf).maxDepth ew $ \case
+              False -> doStop
+              True -> frameRevert "assertion failed: assertApproxEqRel (symbolic)"
+        abivals -> vmError (BadCheatCode ("assertApproxEqRel(uint256,uint256,uint256) parameter decoding failed: " <> show abivals) sig)
+    -- | assertApproxEqRel for int256. Same as the uint version but the absolute
+    -- delta accounts for signs (same sign: ||a|-|b||, opposite: |a|+|b|) and the
+    -- denominator is |b|.
+    assertApproxEqRelInt sig input = do
+      case decodeBuf [AbiIntType 256, AbiIntType 256, AbiUIntType 256] input of
+        (CAbi [AbiInt _ a, AbiInt _ b, AbiUInt _ maxPercentDelta],"") ->
+          let -- fromIntegral Int256->Word256 reinterprets bits; for minBound this gives 2^255 which is correct
+              absI x = if x == minBound then fromIntegral (maxBound :: Int256) + 1
+                        else fromIntegral (abs x) :: Word256
+              absA = absI a
+              absB = absI b
+              sameSign = (a >= 0 && b >= 0) || (a < 0 && b < 0)
+              absDelta = if sameSign
+                         then if absA > absB then absA - absB else absB - absA
+                         else absA + absB
+          in if b == 0
+             then if a == 0 then doStop
+                  else frameRevert $ relFailMsg a b maxPercentDelta "undefined"
+             else
+               let percentDelta = (toInteger absDelta * scale1e18) `Prelude.div` toInteger absB
+               in if percentDelta > toInteger (maxBound :: Word256)
+                  then frameRevert "assertion failed: overflow in delta calculation"
+                  else if percentDelta <= toInteger maxPercentDelta then doStop
+                  else frameRevert $ relFailMsg a b maxPercentDelta (show percentDelta)
+        (SAbi [ew1, ew2, ew3],"") ->
+          -- best-effort symbolic handling (same-sign approximation, see assertApproxEqAbs)
+          let absDelta = Expr.sub (Expr.max ew1 ew2) (Expr.min ew1 ew2)
+              percentDelta = Expr.div (Expr.mul absDelta (Lit scale1e18W)) ew2
+          in case Expr.simplify (Expr.iszero $ Expr.leq percentDelta ew3) of
+            Lit 0 -> doStop
+            Lit _ -> frameRevert "assertion failed: assertApproxEqRel (symbolic)"
+            ew -> branch (?conf).maxDepth ew $ \case
+              False -> doStop
+              True -> frameRevert "assertion failed: assertApproxEqRel (symbolic)"
+        abivals -> vmError (BadCheatCode ("assertApproxEqRel(int256,int256,uint256) parameter decoding failed: " <> show abivals) sig)
     toStringCheat abitype sig input = do
       case decodeBuf [abitype] input of
         (CAbi [val],"") -> frameReturn $ AbiTuple $ V.fromList [AbiString $ Char8.pack $ show val]

--- a/test/EVM/Test/FoundryTests.hs
+++ b/test/EVM/Test/FoundryTests.hs
@@ -149,6 +149,7 @@ tests = testGroup "Foundry tests"
               -- concrete-only tests: all branches revert, hence (False, False)
               [ ("prove_approx_eq_rel_uint_exceeds_delta", (False, False))
               , ("prove_approx_eq_rel_uint_b_zero_neq", (False, False))
+              , ("prove_approx_eq_rel_uint_overflow_delta", (False, False))
               , ("prove_approx_eq_rel_int_exceeds_delta", (False, False))
               , ("prove_approx_eq_rel_int_b_zero_neq", (False, False))
               -- symbolic: not all branches revert
@@ -156,6 +157,14 @@ tests = testGroup "Foundry tests"
               ]
         forM_ cases $ \(method, expected) -> do
           executeSingleMethod testFile method >>= assertEqualM (unpack method) expected
+    , test "AssertMsg-Pass" $ do
+        let testFile = "test/contracts/pass/assertMsg.sol"
+        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+    , test "AssertMsg-Fail" $ do
+        -- every message/bytes overload is violated; all concrete, so all branches
+        -- revert -> (False, False)
+        let testFile = "test/contracts/fail/assertMsg.sol"
+        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (False, False)
     , test "Panic-Source-Location" $ do
         -- Regression test for #895: panic in a called contract should not show "<source not found>"
         let testFile = "test/contracts/fail/assertPanic.sol"

--- a/test/EVM/Test/FoundryTests.hs
+++ b/test/EVM/Test/FoundryTests.hs
@@ -140,6 +140,22 @@ tests = testGroup "Foundry tests"
               ]
         forM_ cases $ \(method, expected) -> do
           executeSingleMethod testFile method >>= assertEqualM (unpack method) expected
+    , test "AssertApproxEqRel-Pass" $ do
+        let testFile = "test/contracts/pass/assertApproxEqRel.sol"
+        executeAllMethodsWithPrefix testFile "prove" >>= assertEqualM "test result" (True, True)
+    , test "AssertApproxEqRel-Fail" $ do
+        let testFile = "test/contracts/fail/assertApproxEqRel.sol"
+        let cases =
+              -- concrete-only tests: all branches revert, hence (False, False)
+              [ ("prove_approx_eq_rel_uint_exceeds_delta", (False, False))
+              , ("prove_approx_eq_rel_uint_b_zero_neq", (False, False))
+              , ("prove_approx_eq_rel_int_exceeds_delta", (False, False))
+              , ("prove_approx_eq_rel_int_b_zero_neq", (False, False))
+              -- symbolic: not all branches revert
+              , ("prove_approx_eq_rel_uint_symbolic_fail", (False, True))
+              ]
+        forM_ cases $ \(method, expected) -> do
+          executeSingleMethod testFile method >>= assertEqualM (unpack method) expected
     , test "Panic-Source-Location" $ do
         -- Regression test for #895: panic in a called contract should not show "<source not found>"
         let testFile = "test/contracts/fail/assertPanic.sol"

--- a/test/contracts/fail/assertApproxEqRel.sol
+++ b/test/contracts/fail/assertApproxEqRel.sol
@@ -15,6 +15,13 @@ contract AssertApproxEqRelFailTest is Test {
         assertApproxEqRel(uint256(1), uint256(0), 0);
     }
 
+    function prove_approx_eq_rel_uint_overflow_delta() public pure {
+        // huge difference: absDelta ~ 2^256, denom = 1, so percentDelta ~ 2^256 * 1e18
+        // does not fit in uint256 -> "overflow in delta calculation" -> should fail
+        // even with the maximum tolerance.
+        assertApproxEqRel(type(uint256).max, uint256(1), type(uint256).max);
+    }
+
     // --- int256 failures ---
 
     function prove_approx_eq_rel_int_exceeds_delta() public pure {

--- a/test/contracts/fail/assertApproxEqRel.sol
+++ b/test/contracts/fail/assertApproxEqRel.sol
@@ -1,0 +1,36 @@
+import "forge-std/Test.sol";
+
+contract AssertApproxEqRelFailTest is Test {
+    // percentDelta = |a - b| * 1e18 / b  (denominator is the second argument)
+
+    // --- uint256 failures ---
+
+    function prove_approx_eq_rel_uint_exceeds_delta() public pure {
+        // pd = |111-100| * 1e18 / 100 = 1.1e17 (11%), max 10% -> should fail
+        assertApproxEqRel(uint256(111), uint256(100), 1e17);
+    }
+
+    function prove_approx_eq_rel_uint_b_zero_neq() public pure {
+        // b == 0 but a != 0 -> real delta undefined -> should fail
+        assertApproxEqRel(uint256(1), uint256(0), 0);
+    }
+
+    // --- int256 failures ---
+
+    function prove_approx_eq_rel_int_exceeds_delta() public pure {
+        // opposite signs: absDelta = |−6| + |5| = 11, denom = |5| = 5, pd = 2.2e18 (220%), max 100% -> fail
+        assertApproxEqRel(int256(-6), int256(5), 1e18);
+    }
+
+    function prove_approx_eq_rel_int_b_zero_neq() public pure {
+        // b == 0 but a != 0 -> should fail
+        assertApproxEqRel(int256(5), int256(0), 0);
+    }
+
+    // --- symbolic failure ---
+
+    function prove_approx_eq_rel_uint_symbolic_fail(uint256 a) public pure {
+        // a vs 100 with 0% tolerance means a must be 100, but a is unconstrained -> should fail
+        assertApproxEqRel(a, uint256(100), 0);
+    }
+}

--- a/test/contracts/fail/assertMsg.sol
+++ b/test/contracts/fail/assertMsg.sol
@@ -1,0 +1,105 @@
+import "forge-std/Test.sol";
+
+// Each method violates one of the new message-bearing (`...,string`) assert
+// overloads, or one of the new bytes overloads. forge-std only forwards to the
+// `vm` cheatcode on the failing branch, so a violation is what actually drives
+// hevm's handler (withMsg / keepHeadWords / assertEqMsgDyn). A broken decode
+// would surface as a BadCheatCode error instead of a clean assertion failure.
+contract AssertMsgFailTest is Test {
+    // --- assertEq(...,string): static operands (withMsg) ---
+
+    function prove_eq_bool_msg() public pure {
+        assertEq(true, false, "bool eq");
+    }
+
+    function prove_eq_uint_msg() public pure {
+        assertEq(uint256(1), uint256(2), "uint eq");
+    }
+
+    function prove_eq_int_msg() public pure {
+        assertEq(int256(-1), int256(2), "int eq");
+    }
+
+    function prove_eq_addr_msg() public pure {
+        assertEq(address(uint160(1)), address(uint160(2)), "addr eq");
+    }
+
+    function prove_eq_bytes32_msg() public pure {
+        assertEq(bytes32(uint256(1)), bytes32(uint256(2)), "bytes32 eq");
+    }
+
+    // --- assertEq(...,string): dynamic operands (assertEqMsgDyn) ---
+
+    function prove_eq_string_msg() public pure {
+        assertEq(string("a"), string("b"), "string eq");
+    }
+
+    function prove_eq_bytes_msg() public pure {
+        assertEq(bytes("a"), bytes("b"), "bytes eq");
+    }
+
+    // --- assertNotEq(...,string) ---
+
+    function prove_neq_uint_msg() public pure {
+        assertNotEq(uint256(1), uint256(1), "uint neq");
+    }
+
+    function prove_neq_string_msg() public pure {
+        assertNotEq(string("a"), string("a"), "string neq");
+    }
+
+    function prove_neq_bytes_msg() public pure {
+        assertNotEq(bytes("a"), bytes("a"), "bytes neq");
+    }
+
+    // --- assert{Lt,Le,Gt,Ge}(...,string) ---
+
+    function prove_lt_uint_msg() public pure {
+        assertLt(uint256(2), uint256(1), "uint lt");
+    }
+
+    function prove_lt_int_msg() public pure {
+        assertLt(int256(2), int256(-1), "int lt");
+    }
+
+    function prove_le_uint_msg() public pure {
+        assertLe(uint256(2), uint256(1), "uint le");
+    }
+
+    function prove_gt_uint_msg() public pure {
+        assertGt(uint256(1), uint256(2), "uint gt");
+    }
+
+    function prove_gt_int_msg() public pure {
+        assertGt(int256(-1), int256(2), "int gt");
+    }
+
+    function prove_ge_uint_msg() public pure {
+        assertGe(uint256(1), uint256(2), "uint ge");
+    }
+
+    // --- assertApproxEq{Abs,Rel}(...,string) (vm called unconditionally) ---
+
+    function prove_approx_abs_uint_msg() public pure {
+        assertApproxEqAbs(uint256(10), uint256(1), 0, "abs");
+    }
+
+    function prove_approx_rel_uint_msg() public pure {
+        // pd = |2-1| * 1e18 / 1 = 1e18 (100%) > 0 -> fail
+        assertApproxEqRel(uint256(2), uint256(1), 0, "rel");
+    }
+
+    function prove_approx_rel_int_msg() public pure {
+        assertApproxEqRel(int256(2), int256(1), 0, "rel int");
+    }
+
+    // --- new bytes overloads without a message ---
+
+    function prove_eq_bytes() public pure {
+        assertEq(bytes("a"), bytes("b"));
+    }
+
+    function prove_neq_bytes() public pure {
+        assertNotEq(bytes("a"), bytes("a"));
+    }
+}

--- a/test/contracts/pass/assertApproxEqRel.sol
+++ b/test/contracts/pass/assertApproxEqRel.sol
@@ -1,0 +1,70 @@
+import "forge-std/Test.sol";
+
+contract AssertApproxEqRelTest is Test {
+    // maxPercentDelta is an 18-decimal fixed point number where 1e18 == 100%.
+    // percentDelta = |a - b| * 1e18 / b  (denominator is the second argument)
+
+    // --- uint256 concrete tests ---
+
+    function prove_approx_eq_rel_uint_exact() public pure {
+        // pd = 0
+        assertApproxEqRel(uint256(100), uint256(100), 0);
+    }
+
+    function prove_approx_eq_rel_uint_within_delta() public pure {
+        // pd = |105-100| * 1e18 / 100 = 5e16 (5%), max 10%
+        assertApproxEqRel(uint256(105), uint256(100), 1e17);
+    }
+
+    function prove_approx_eq_rel_uint_at_boundary() public pure {
+        // pd = |110-100| * 1e18 / 100 = 1e17 (10%), max 10% -> inclusive pass
+        assertApproxEqRel(uint256(110), uint256(100), 1e17);
+    }
+
+    function prove_approx_eq_rel_uint_both_zero() public pure {
+        // b == 0 && a == 0 -> treated as equal
+        assertApproxEqRel(uint256(0), uint256(0), 0);
+    }
+
+    function prove_approx_eq_rel_uint_full_delta() public pure {
+        // pd = |2-1| * 1e18 / 1 = 1e18 (100%), max 100%
+        assertApproxEqRel(uint256(2), uint256(1), 1e18);
+    }
+
+    function prove_approx_eq_rel_uint_large_values() public pure {
+        // no intermediate overflow despite huge magnitudes (computed in wider precision)
+        assertApproxEqRel(type(uint256).max, type(uint256).max, 0);
+    }
+
+    // --- int256 concrete tests ---
+
+    function prove_approx_eq_rel_int_exact() public pure {
+        assertApproxEqRel(int256(-100), int256(-100), 0);
+    }
+
+    function prove_approx_eq_rel_int_same_sign() public pure {
+        // same sign: absDelta = |100-95| = 5, denom = |−100| = 100, pd = 5e16 (5%)
+        assertApproxEqRel(int256(-95), int256(-100), 1e17);
+    }
+
+    function prove_approx_eq_rel_int_opposite_signs() public pure {
+        // opposite signs: absDelta = |−5| + |5| = 10, denom = |5| = 5, pd = 2e18 (200%)
+        assertApproxEqRel(int256(-5), int256(5), 2e18);
+    }
+
+    function prove_approx_eq_rel_int_both_zero() public pure {
+        assertApproxEqRel(int256(0), int256(0), 0);
+    }
+
+    // --- uint256 symbolic tests ---
+
+    function prove_approx_eq_rel_uint_symbolic(uint256 a) public pure {
+        // any value is within 0% of itself (and 0 ~= 0 holds when b == 0)
+        assertApproxEqRel(a, a, 0);
+    }
+
+    function prove_approx_eq_rel_uint_symbolic_maxdelta(uint256 a) public pure {
+        // a vs a is always within any tolerance
+        assertApproxEqRel(a, a, type(uint256).max);
+    }
+}

--- a/test/contracts/pass/assertApproxEqRel.sol
+++ b/test/contracts/pass/assertApproxEqRel.sol
@@ -36,6 +36,19 @@ contract AssertApproxEqRelTest is Test {
         assertApproxEqRel(type(uint256).max, type(uint256).max, 0);
     }
 
+    function prove_approx_eq_rel_uint_intermediate_overflow_ok() public pure {
+        // absDelta = 2^200, so absDelta * 1e18 (~2^260) overflows uint256, but the
+        // true percentDelta = 2^200 * 1e18 / 2^200 = 1e18 (100%) still fits and is
+        // within tolerance. Exercises the wide-precision path on the pass side.
+        assertApproxEqRel(uint256(2)**201, uint256(2)**200, 1e18);
+    }
+
+    function prove_approx_eq_rel_uint_intermediate_overflow_within() public pure {
+        // absDelta = 2^200 (mul overflows uint256), denom = 2^205, so
+        // percentDelta = 2^200 * 1e18 / 2^205 = 1e18 / 32 = 3.125e16 (~3.125%) <= 10%.
+        assertApproxEqRel(uint256(2)**205 + uint256(2)**200, uint256(2)**205, 1e17);
+    }
+
     // --- int256 concrete tests ---
 
     function prove_approx_eq_rel_int_exact() public pure {

--- a/test/contracts/pass/assertMsg.sol
+++ b/test/contracts/pass/assertMsg.sol
@@ -1,0 +1,92 @@
+import "forge-std/Test.sol";
+
+// Passing counterparts of the new message-bearing and bytes assert overloads.
+// For most overloads forge-std short-circuits on the passing branch and never
+// reaches the cheatcode, so these mainly guard against compile/behaviour
+// regressions; the assertApproxEq{Abs,Rel}(...,string) overloads forward to the
+// cheatcode unconditionally and therefore exercise hevm's handler here too.
+contract AssertMsgPassTest is Test {
+    function prove_eq_bool_msg() public pure {
+        assertEq(true, true, "bool eq");
+    }
+
+    function prove_eq_uint_msg() public pure {
+        assertEq(uint256(1), uint256(1), "uint eq");
+    }
+
+    function prove_eq_int_msg() public pure {
+        assertEq(int256(-1), int256(-1), "int eq");
+    }
+
+    function prove_eq_addr_msg() public pure {
+        assertEq(address(uint160(1)), address(uint160(1)), "addr eq");
+    }
+
+    function prove_eq_bytes32_msg() public pure {
+        assertEq(bytes32(uint256(1)), bytes32(uint256(1)), "bytes32 eq");
+    }
+
+    function prove_eq_string_msg() public pure {
+        assertEq(string("a"), string("a"), "string eq");
+    }
+
+    function prove_eq_bytes_msg() public pure {
+        assertEq(bytes("a"), bytes("a"), "bytes eq");
+    }
+
+    function prove_neq_uint_msg() public pure {
+        assertNotEq(uint256(1), uint256(2), "uint neq");
+    }
+
+    function prove_neq_string_msg() public pure {
+        assertNotEq(string("a"), string("b"), "string neq");
+    }
+
+    function prove_neq_bytes_msg() public pure {
+        assertNotEq(bytes("a"), bytes("b"), "bytes neq");
+    }
+
+    function prove_lt_uint_msg() public pure {
+        assertLt(uint256(1), uint256(2), "uint lt");
+    }
+
+    function prove_lt_int_msg() public pure {
+        assertLt(int256(-1), int256(2), "int lt");
+    }
+
+    function prove_le_uint_msg() public pure {
+        assertLe(uint256(1), uint256(1), "uint le");
+    }
+
+    function prove_gt_uint_msg() public pure {
+        assertGt(uint256(2), uint256(1), "uint gt");
+    }
+
+    function prove_gt_int_msg() public pure {
+        assertGt(int256(2), int256(-1), "int gt");
+    }
+
+    function prove_ge_uint_msg() public pure {
+        assertGe(uint256(1), uint256(1), "uint ge");
+    }
+
+    function prove_approx_abs_uint_msg() public pure {
+        assertApproxEqAbs(uint256(10), uint256(10), 0, "abs");
+    }
+
+    function prove_approx_rel_uint_msg() public pure {
+        assertApproxEqRel(uint256(105), uint256(100), 1e17, "rel");
+    }
+
+    function prove_approx_rel_int_msg() public pure {
+        assertApproxEqRel(int256(-95), int256(-100), 1e17, "rel int");
+    }
+
+    function prove_eq_bytes() public pure {
+        assertEq(bytes("a"), bytes("a"));
+    }
+
+    function prove_neq_bytes() public pure {
+        assertNotEq(bytes("a"), bytes("b"));
+    }
+}


### PR DESCRIPTION
Implement foundry's assertApproxEqRel as a native hevm cheatcode, mirroring the existing assertApproxEqAbs. The relative percent delta is computed as |a - b| * 1e18 / b (denominator is the second/reference argument; 1e18 == 100%), and the assertion passes when percentDelta <= maxPercentDelta.

Matches foundry's native cheatcode semantics:
- int256 delta accounts for signs (same sign: ||a|-|b||, opposite: |a|+|b|), denominator is |b|
- b == 0 && a == 0 -> pass; b == 0 && a != 0 -> fail with "real delta: undefined"
- concrete path computes in arbitrary-precision Integer to avoid the intermediate overflow foundry sidesteps with U512
- best-effort symbolic path

Adds pass/fail test contracts and FoundryTests entries.

## Description

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [ ] updated the changelog
