### PR TITLE
Fix pranked CREATE2 address preimage

### DIFF
--- a/src/EVM.hs
+++ b/src/EVM.hs
@@ -1070,7 +1070,7 @@ exec1 conf = do
                       touchAddress from'
 
                       let (cost, gas') = costOfCreate fees availableGas xSize True
-                      newAddr <- create2Address self xSalt initCode
+                      newAddr <- create2Address from' xSalt initCode
                       _ <- accessAccountForGas newAddr
                       burn' cost $
                         create from' this xSize gas' xValue xs newAddr (ConcreteBuf initCode)

--- a/test/EVM/SymExec/SymExecTests.hs
+++ b/test/EVM/SymExec/SymExecTests.hs
@@ -761,6 +761,40 @@ cheatCodeTests = testGroup "Cheatcode tests via symbolic execution"
           |]
       result <- verifyUserAsserts c (Just $ Sig "f()" [])
       expectNoCexNoPartial result
+  , testCase "vm.prank-create2" $ do
+      Just c <- solcRuntime "C"
+          [i|
+            interface Vm {
+              function prank(address) external;
+            }
+            contract Owned {
+              address public owner;
+              constructor() {
+                owner = msg.sender;
+              }
+            }
+            contract C {
+              function f() external {
+                Vm vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+                bytes32 salt = bytes32(uint256(1));
+                address usr = address(1312);
+                vm.prank(usr);
+                Owned target = new Owned{salt: salt}();
+                address expected = address(uint160(uint256(keccak256(abi.encodePacked(
+                  bytes1(0xff),
+                  usr,
+                  salt,
+                  keccak256(type(Owned).creationCode)
+                )))));
+
+                assert(target.owner() == usr);
+                assert(address(target) == expected);
+              }
+            }
+          |]
+      result <- verifyUserAsserts c (Just $ Sig "f()" [])
+      expectNoCexNoPartial result
   , testCase "vm.prank underflow" $ do
       Just c <- solcRuntime "C"
           [i|


### PR DESCRIPTION
## Summary

- Use the pranked deployment source when deriving CREATE2 addresses.
- Add a regression test for `vm.prank` followed by `new ...{salt: ...}()`.

## Root cause

The CREATE2 path applied `overrideCaller` to the constructor caller/deployment source, but still derived the CREATE2 address from `self`. That made the deployed address disagree with the pranked deployer semantics already used by CREATE.

## Validation

- `git diff --check`
- `solc --bin` on the added Solidity regression fixture