### PR TITLE
Fix copyslice in case the copy is exactly ONE byte.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   options.
 - We now abort VM run on a failed `assume`.
 - Removed SHA256 from the Expr since it was not being used
+- When doing CopySlice of exactly one concrete byte, we now correctly simplify
 
 ## [0.57.0] - 2026-01-08
 

--- a/src/EVM/Expr.hs
+++ b/src/EVM/Expr.hs
@@ -586,7 +586,7 @@ copySlice a@(Lit srcOffset) b@(Lit dstOffset) c@(Lit size) d@(ConcreteBuf src) e
 -- concrete indices & abstract src (may produce a concrete result if we are
 -- copying from a concrete region of src)
 copySlice s@(Lit srcOffset) d@(Lit dstOffset) sz@(Lit size) src ds@(ConcreteBuf dst)
-  | dstOffset < maxBytes, size < maxBytes, srcOffset + (size-1) > srcOffset = let
+  | dstOffset < maxBytes, size < maxBytes, srcOffset + (size-1) >= srcOffset = let
     hd = padRight (unsafeInto dstOffset) $ BS.take (unsafeInto dstOffset) dst
     sl = [readByte (Lit i) src | i <- [srcOffset .. srcOffset + (size - 1)]]
     tl = BS.drop (unsafeInto dstOffset + unsafeInto size) dst

--- a/test/EVM/Expr/ExprTests.hs
+++ b/test/EVM/Expr/ExprTests.hs
@@ -105,6 +105,22 @@ copySliceTests = testGroup "CopySlice tests"
         let simpl = Expr.simplify e
         let expected = ConcreteBuf $ BS.pack [0x00, 0xff, 0x00, 0xff]
         assertEqual "" expected simpl
+  , testCase "copyslice-single-byte-concretizes" $ do
+        -- Regression for issue #1066. A size-1 CopySlice whose read range is
+        -- fully covered by a concrete WriteWord must concretize, even when an
+        -- unrelated (out-of-range) symbolic write sits underneath it.
+        let w = Lit 0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
+            src = WriteWord (Lit 0x20) w (WriteWord (Lit 0x80) (Var "x") (ConcreteBuf ""))
+            e = CopySlice (Lit 0x20) (Lit 0x0) (Lit 0x1) src (ConcreteBuf "")
+        assertEqual "size-1 copy must concretize to the 1st byte, dropping the out-of-range symbolic write"
+          (ConcreteBuf (BS.pack [0xab])) (Expr.simplify e)
+  , testCase "copyslice-single-byte-value" $ do
+        -- Same as above, but no symbolic write this time
+        let w = Lit 0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
+            src = WriteWord (Lit 0x20) w (ConcreteBuf "")
+            e = CopySlice (Lit 0x3f) (Lit 0x0) (Lit 0x1) src (ConcreteBuf "")
+        assertEqual "size-1 copy must read the correct (last) byte"
+          (ConcreteBuf (BS.pack [0x89])) (Expr.simplify e)
   ]
 
 memoryTests :: TestTree


### PR DESCRIPTION
## Description

OOps, the exactly-one-byte copy was not concretized because of an overly-eager wraparound check.

The only thing `>=` (current) adds over `>` (previous) is the case when `srcOffset + (size-1) == srcOffset`. I.e. when size == 1. In that case the copy range is `[srcOffset .. srcOffset]`, i.e one element, no wrap.

Fixes  https://github.com/argotorg/hevm/issues/1066

## Checklist

- [x] tested locally
- [x] added automated tests
- [ ] updated the docs
- [x] updated the changelog
