### PR TITLE
[PoC] Abstract symbolic multiplication (abst_evm_bvmul) for vault-style verification

### DIFF
--- a/hevm.cabal
+++ b/hevm.cabal
@@ -125,6 +125,8 @@ library
     EVM.CheatsTH,
     EVM.SMT.Types,
     EVM.SMT.SMTLIB,
+    EVM.SMT.AbstractBase,
+    EVM.SMT.AbstractLemmas,
     Paths_hevm
   autogen-modules:
     Paths_hevm

--- a/src/EVM/SMT.hs
+++ b/src/EVM/SMT.hs
@@ -145,7 +145,8 @@ assertPropsAbstract conf ps = do
   base <- if not conf.simp then mkBase False ps
           else mkBase True (decompose conf ps)
   shiftBounds <- divModEncoding (exprToSMTWith AbstractDivMod) ps
-  pure $ base <> SMT2 (SMTScript shiftBounds) mempty mempty
+  mulLemmas <- mulEncoding (exprToSMTWith AbstractDivMod) ps
+  pure $ base <> SMT2 (SMTScript (shiftBounds <> mulLemmas)) mempty mempty
 
 -- Note: we need a version that does NOT call simplify,
 -- because we make use of it to verify the correctness of our simplification
@@ -455,7 +456,12 @@ exprToSMTWith divEnc = \case
 
   Add a b -> op2 "bvadd" a b
   Sub a b -> op2 "bvsub" a b
-  Mul a b -> op2 "bvmul" a b
+  Mul a b -> case (a, b) of
+    -- only genuinely symbolic products are abstracted; a concrete factor
+    -- (0/1/power-of-two/constant) is handled natively / by the simplifier
+    (Lit _, _) -> op2 "bvmul" a b
+    (_, Lit _) -> op2 "bvmul" a b
+    _          -> mulOp a b
   Exp a b -> case a of
     Lit 0 -> do
       benc <- exprToSMT b
@@ -633,6 +639,12 @@ exprToSMTWith divEnc = \case
     divModOp concreteOp abstractOp a b = case divEnc of
       ConcreteDivMod -> op2CheckZero concreteOp a b
       AbstractDivMod -> op2 abstractOp a b
+    -- symbolic*symbolic multiplication: native under ConcreteDivMod, an
+    -- uninterpreted function under AbstractDivMod (no zero guard needed).
+    mulOp :: Expr x -> Expr y -> Err Builder
+    mulOp a b = case divEnc of
+      ConcreteDivMod -> op2 "bvmul" a b
+      AbstractDivMod -> op2 "abst_evm_bvmul" a b
 
 sp :: Builder -> Builder -> Builder
 a `sp` b = a <> " " <> b

--- a/src/EVM/SMT/AbstractBase.hs
+++ b/src/EVM/SMT/AbstractBase.hs
@@ -1,0 +1,297 @@
+{- |
+   Module: EVM.SMT.AbstractBase
+   Description: Shared vocabulary for the abstract arithmetic encoding.
+
+   This is the base layer both 'EVM.SMT.AbstractLemmas' (the lemma catalogue) and
+   'EVM.SMT.DivModEncoding' (the orchestration + div/mod ground truth) build on. It
+   holds, with no dependency on either of them:
+
+   * the SMT-LIB builder primitives ('sp', 'zero', 'mulNoOverflow', 'wordAsBV', …)
+     and signed helpers ('smtAbsolute', 'signedFromUnsignedDiv', …);
+   * the div/mod operation taxonomy ('DivModKind' and friends);
+   * the term collectors ('collectDivMods', 'collectMuls', 'collectConstMuls') and
+     shape matchers ('asMul', 'asConstMul');
+   * the abstract-term /saturation/ ('saturate'), which closes the set of div/mul
+     terms the lemmas range over (synthetic divisions, nested-division collapse,
+     div-mul link products) into an 'AbstractCtx'.
+
+   Keeping this separate breaks the import cycle: @DivModEncoding@ imports
+   @AbstractLemmas@, so the primitives the lemmas need cannot live in
+   @DivModEncoding@.
+-}
+module EVM.SMT.AbstractBase
+  ( -- * Encoder alias
+    Enc
+    -- * UF declarations
+  , divModAbstractDecls
+    -- * SMT-LIB builder primitives
+  , sp
+  , zero
+  , one
+  , maxU128
+  , mulNoOverflow
+  , wordAsBV
+    -- * Div/mod taxonomy
+  , DivModKind(..)
+  , DivModOp
+  , AbstractKey(..)
+  , isDiv
+  , isSigned
+  , abstFnName
+  , concFnName
+  , abstractKey
+    -- * Collectors and shape matchers
+  , collectDivMods
+  , collectMuls
+  , collectConstMuls
+  , hasAbstractMul
+  , asMul
+  , asConstMul
+    -- * Signed reconstruction helpers
+  , smtZeroGuard
+  , smtAbsolute
+  , smtNeg
+  , smtSameSign
+  , smtIsNonNeg
+  , signedFromUnsignedDiv
+  , signedFromUnsignedMod
+    -- * Abstract-term saturation
+  , AbstractCtx(..)
+  , saturate
+  ) where
+
+import Data.Containers.ListUtils (nubOrd)
+import Data.Text.Lazy.Builder
+import qualified Data.Text.Lazy.Builder.Int
+
+import EVM.SMT.Types
+import EVM.Traversals
+import EVM.Types (Prop(..), EType(EWord), Err, W256, Expr, Expr(Lit))
+import EVM.Types qualified as T
+
+-- | The expression-to-SMT encoder threaded through every emitter.
+type Enc = Expr EWord -> Err Builder
+
+-- | Uninterpreted function declarations for abstract div/mod.
+divModAbstractDecls :: [SMTEntry]
+divModAbstractDecls =
+  [ SMTComment "abstract division/modulo (uninterpreted functions)"
+  , SMTCommand "(declare-fun abst_evm_bvsdiv ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
+  , SMTCommand "(declare-fun abst_evm_bvsrem ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
+  , SMTCommand "(declare-fun abst_evm_bvudiv ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
+  , SMTCommand "(declare-fun abst_evm_bvurem ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
+  , SMTComment "abstract multiplication (kept fully uninterpreted: no ground truth)"
+  , SMTCommand "(declare-fun abst_evm_bvmul ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
+  ]
+
+-- | Local helper for trivial SMT constructs
+sp :: Builder -> Builder -> Builder
+a `sp` b = a <> " " <> b
+
+zero :: Builder
+zero = "(_ bv0 256)"
+
+one :: Builder
+one = "(_ bv1 256)"
+
+-- | Maximum value representable in 128 unsigned bits (2^128 - 1).
+maxU128 :: Builder
+maxU128 = "(_ bv340282366920938463463374607431768211455 256)"
+
+-- | A /sufficient/ condition for x*y not to overflow 256 bits: both operands
+-- fit in 128 bits, so their product fits in 256 (since (2^128-1)^2 < 2^256).
+--
+-- We deliberately use this cheap sufficient condition rather than the exact
+-- no-overflow predicate @extract 511 256 (bvmul (zext x) (zext y)) = 0@. The
+-- exact form forces the solver to bit-blast a full 512-bit multiply for every
+-- lemma instance, which is the dominant cost and makes queries with large
+-- operands (~2^100) time out. Two comparisons against a constant are
+-- essentially free by contrast.
+--
+-- This is the same width-budget idea Halmos uses. It is SOUND: when the guard
+-- holds there is genuinely no overflow, so any lemma it gates remains valid.
+-- The cost is completeness — a product of operands above 2^128 that happens not
+-- to overflow will not receive the lemma. Callers bound operands (e.g. a
+-- Solidity @require(x < 2**128)@) so the guard discharges cheaply.
+mulNoOverflow :: Builder -> Builder -> Builder
+mulNoOverflow x y =
+  "(and (bvule " <> x <> " " <> maxU128 <> ") (bvule " <> y <> " " <> maxU128 <> "))"
+
+wordAsBV :: forall a. Integral a => a -> Builder
+wordAsBV w = "(_ bv" <> Data.Text.Lazy.Builder.Int.decimal w <> " 256)"
+
+-- | The four EVM division/modulo operations. The @S@-variants are signed
+-- (SDiv/SMod), the @U@-variants unsigned (Div/Mod). Signed and unsigned ops
+-- are kept in separate groups so the signed absolute-value/sign-reconstruction
+-- machinery is never applied to unsigned operands (and vice versa).
+data DivModKind = IsSDiv | IsSMod | IsUDiv | IsUMod
+  deriving (Eq, Ord)
+
+type DivModOp = (DivModKind, Expr EWord, Expr EWord)
+
+data AbstractKey = AbstractKey (Expr EWord) (Expr EWord) DivModKind
+  deriving (Eq, Ord)
+
+isDiv :: DivModKind -> Bool
+isDiv IsSDiv = True
+isDiv IsUDiv = True
+isDiv _      = False
+
+isSigned :: DivModKind -> Bool
+isSigned IsSDiv = True
+isSigned IsSMod = True
+isSigned _      = False
+
+-- | Name of the uninterpreted function standing in for this op.
+abstFnName :: DivModKind -> Builder
+abstFnName IsSDiv = "abst_evm_bvsdiv"
+abstFnName IsSMod = "abst_evm_bvsrem"
+abstFnName IsUDiv = "abst_evm_bvudiv"
+abstFnName IsUMod = "abst_evm_bvurem"
+
+-- | Name of the concrete SMT-LIB op refined against in phase two.
+concFnName :: DivModKind -> Builder
+concFnName IsSDiv = "bvsdiv"
+concFnName IsSMod = "bvsrem"
+concFnName IsUDiv = "bvudiv"
+concFnName IsUMod = "bvurem"
+
+abstractKey :: DivModOp -> AbstractKey
+abstractKey (kind, a, b) = AbstractKey a b kind
+
+-- | Collect all div/mod operations from an expression.
+collectDivMods :: Expr a -> [DivModOp]
+collectDivMods = \case
+  T.SDiv a b -> [(IsSDiv, a, b)]
+  T.SMod a b -> [(IsSMod, a, b)]
+  T.Div  a b -> [(IsUDiv, a, b)]
+  T.Mod  a b -> [(IsUMod, a, b)]
+  _          -> []
+
+-- | Collect symbolic*symbolic multiplications (neither operand a literal).
+-- Concrete factors (incl. 0/1/power-of-two) are handled natively by the
+-- simplifier, so only genuinely symbolic products are abstracted.
+collectMuls :: Expr a -> [(Expr EWord, Expr EWord)]
+collectMuls = \case
+  T.Mul a b | notLit a, notLit b -> [(a, b)]
+  _ -> []
+
+-- | Collect multiplications by a literal constant, @(c, x)@ for @c*x@ (either
+-- operand order), excluding the trivial constants 0 and 1. These stay native
+-- @bvmul@ (the value is concrete), but a symbolic operand times a large
+-- constant is still costly to bit-blast and compare; const-mul monotonicity
+-- lets the solver order such products without doing so.
+collectConstMuls :: Expr a -> [(W256, Expr EWord)]
+collectConstMuls = \case
+  T.Mul (Lit c) x | notLit x, c /= 0, c /= 1 -> [(c, x)]
+  T.Mul x (Lit c) | notLit x, c /= 0, c /= 1 -> [(c, x)]
+  _ -> []
+
+-- | True if any prop contains a symbolic*symbolic multiplication, i.e. the
+-- multiplication abstraction is in play. Because abst_evm_bvmul is left
+-- uninterpreted (no ground truth), a satisfying model may assign it values
+-- inconsistent with real multiplication, so a counterexample cannot be
+-- trusted; callers must downgrade SAT results to Unknown to stay SOUND.
+hasAbstractMul :: [Prop] -> Bool
+hasAbstractMul props = not $ null $ concatMap (foldProp collectMuls []) props
+
+-- | Recognise an abstract symbolic*symbolic product.
+asMul :: Expr EWord -> Maybe (Expr EWord, Expr EWord)
+asMul (T.Mul x y) | notLit x, notLit y = Just (x, y)
+asMul _ = Nothing
+
+-- | Recognise multiplication by a non-trivial literal constant: c*x or x*c.
+asConstMul :: Expr EWord -> Maybe (W256, Expr EWord)
+asConstMul (T.Mul (Lit c) x) | notLit x, c /= 0, c /= 1 = Just (c, x)
+asConstMul (T.Mul x (Lit c)) | notLit x, c /= 0, c /= 1 = Just (c, x)
+asConstMul _ = Nothing
+
+notLit :: Expr a -> Bool
+notLit (Lit _) = False
+notLit _       = True
+
+-- | (ite (= divisor 0) 0 result)
+smtZeroGuard :: Builder -> Builder -> Builder
+smtZeroGuard divisor nonZeroResult =
+  "(ite (=" `sp` divisor `sp` zero <> ")" `sp` zero `sp` nonZeroResult <> ")"
+
+-- | |x| as SMT: ite(x >= 0, x, 0 - x).
+smtAbsolute :: Builder -> Builder
+smtAbsolute x = "(ite (bvsge" `sp` x `sp` zero <> ")" `sp` x `sp` "(bvsub" `sp` zero `sp` x <> "))"
+
+-- | -x as SMT.
+smtNeg :: Builder -> Builder
+smtNeg x = "(bvsub" `sp` zero `sp` x <> ")"
+
+-- | True if a and b have the same sign
+smtSameSign :: Builder -> Builder -> Builder
+smtSameSign a b = "(=" `sp` "(bvslt" `sp` a `sp` zero <> ")" `sp` "(bvslt" `sp` b `sp` zero <> "))"
+
+-- | x >= 0.
+smtIsNonNeg :: Builder -> Builder
+smtIsNonNeg x = "(bvsge" `sp` x `sp` zero <> ")"
+
+-- | sdiv(a,b) = ITE(b = 0,              0,
+--               ITE(sign(a) = sign(b),  udiv(|a|,|b|),
+--                                      -udiv(|a|,|b|)))
+signedFromUnsignedDiv :: Builder -> Builder -> Builder -> Builder
+signedFromUnsignedDiv aenc benc udivResult =
+  smtZeroGuard benc $
+  "(ite" `sp` (smtSameSign aenc benc) `sp`
+    udivResult `sp` (smtNeg udivResult) <> ")"
+
+-- | smod(a,b) = ITE(b = 0,   0,
+--               ITE(a ≥ 0,   urem(|a|,|b|),
+--                           -urem(|a|,|b|)))
+signedFromUnsignedMod :: Builder -> Builder -> Builder -> Builder
+signedFromUnsignedMod aenc benc uremResult =
+  smtZeroGuard benc $
+  "(ite" `sp` (smtIsNonNeg aenc) `sp`
+    uremResult `sp` (smtNeg uremResult) <> ")"
+
+-- | The saturated set of abstract arithmetic terms a property mentions, closed
+-- under the synthetic terms the lemmas need to fire. Built once by 'saturate';
+-- the lemma catalogue ('EVM.SMT.AbstractLemmas') ranges over these fields.
+data AbstractCtx = AbstractCtx
+  { acUDivs     :: [(Expr EWord, Expr EWord)]
+    -- ^ Unsigned divisions, saturated: the raw @(a,b)@ for @a/b@ found in the
+    -- props, plus synthetic divisions and nested-division collapses (see below).
+  , acMuls      :: [(Expr EWord, Expr EWord)]
+    -- ^ Symbolic*symbolic products, saturated with the div-mul link products
+    -- @(a/b)*b@ introduced by the link lemma.
+  , acConstMuls :: [(W256, Expr EWord)]
+    -- ^ Products @c*x@ by a non-trivial literal constant.
+  }
+
+-- | Close the set of div/mul terms the lemmas range over.
+--
+-- Beyond the raw products and divisions a prop mentions, three synthetic
+-- families are added so single-level lemmas can bridge multi-level code (all
+-- SOUND — each synthetic term is an exact EVM operation that some lemma below
+-- then equates to its closed form):
+--
+--   * /synthetic divisions/: when an abstract product @a*b@ reuses a factor that
+--     is a divisor elsewhere, add @(a*b)/factor@ — lets mulDiv-bound and
+--     div-monotonicity bridge cross-divisor round-trips.
+--   * /nested-division collapse/: a nested constant division @(A/c1)/c2@ also
+--     contributes a single @A/(c1*c2)@, so the single-divide lemmas match code
+--     that splits precision across two divides.
+--   * /div-mul link products/: every division @a/b@ contributes the product
+--     @(a/b)*b@ that the link lemma bounds by @a@.
+saturate :: [Prop] -> AbstractCtx
+saturate props =
+  let udivs = [ (a, b) | (IsUDiv, a, b) <- nubOrd $ concatMap (foldProp collectDivMods []) props ]
+      muls  = nubOrd $ concatMap (foldProp collectMuls []) props
+      constMuls = nubOrd $ concatMap (foldProp collectConstMuls []) props
+      divisors  = nubOrd [ b | (_, b) <- udivs ]
+      synthDivs = nubOrd $ [ (T.Mul a b, b) | (a, b) <- muls, b `elem` divisors ]
+                        <> [ (T.Mul a b, a) | (a, b) <- muls, a `elem` divisors ]
+      collapsedDivs = nubOrd
+        [ (innerA, Lit (c1 * c2))
+        | (a, b) <- udivs <> synthDivs, Lit c2 <- [b]
+        , T.Div innerA (Lit c1) <- [a]
+        , c1 /= 0, c2 /= 0, toInteger c1 * toInteger c2 < 2 ^ (256 :: Int) ]
+      udivsAll  = nubOrd (udivs <> synthDivs <> collapsedDivs)
+      linkMuls  = [ (T.Div a b, b) | (a, b) <- udivsAll ]
+      allMuls   = nubOrd (muls <> linkMuls)
+  in AbstractCtx { acUDivs = udivsAll, acMuls = allMuls, acConstMuls = constMuls }

--- a/src/EVM/SMT/AbstractLemmas.hs
+++ b/src/EVM/SMT/AbstractLemmas.hs
@@ -1,0 +1,275 @@
+{- |
+   Module: EVM.SMT.AbstractLemmas
+   Description: The catalogue of sound algebraic lemmas for abstract arithmetic.
+
+   This is the review surface. Multiplication is kept fully uninterpreted (no
+   ground truth, so the solver never bit-blasts a symbolic product); we add only
+   /sound/ algebraic facts about @abst_evm_bvmul@/@abst_evm_bvudiv@. Each lemma
+   appears in three aligned places, under a shared banner:
+
+   1. a 'LemmaInst' constructor (its arguments),
+   2. a clause in 'collectLemmas' (when it fires — the trigger), and
+   3. a clause in 'emitLemma' (the SMT it emits + why it is sound).
+
+   To audit soundness, read 'emitLemma': every emitted assertion is true of
+   ordinary multiplication/division, so anything the solver derives from them
+   holds for the real operations too. To add a lemma, add a constructor, a
+   'collectLemmas' clause, and an 'emitLemma' clause — GHC's exhaustiveness
+   checker forces the third once you add the first.
+
+   The emission order in 'collectLemmas' is family-by-family and is preserved
+   from the original monolithic encoder, so the generated query is unchanged.
+-}
+module EVM.SMT.AbstractLemmas
+  ( LemmaInst(..)
+  , collectLemmas
+  , emitLemma
+  ) where
+
+import Data.Containers.ListUtils (nubOrd)
+
+import EVM.SMT.AbstractBase
+import EVM.SMT.Types (SMTEntry(..))
+import EVM.Types (EType(EWord), Err, W256, Expr, Expr(Lit))
+import EVM.Types qualified as T
+
+-- | A single firing of a lemma family, carrying the sub-terms it matched.
+-- Field meanings are documented at the corresponding 'emitLemma' clause.
+data LemmaInst
+  = Comm          (Expr EWord) (Expr EWord)                            -- ^ a*b = b*a
+  | Identity      (Expr EWord) (Expr EWord)                            -- ^ x*0, 0*y, x*1, 1*y
+  | DivMulLink    (Expr EWord) (Expr EWord)                            -- ^ (a/b)*b <= a
+  | MulMono       (Expr EWord) (Expr EWord) (Expr EWord)               -- ^ x<=y => x*z<=y*z
+  | DivMono       (Expr EWord) (Expr EWord) (Expr EWord)               -- ^ x<=y => x/z<=y/z
+  | DivisorMono   (Expr EWord) (Expr EWord) (Expr EWord)               -- ^ y1<=y2 => x/y2<=x/y1
+  | MulDivBound   (Expr EWord) (Expr EWord) (Expr EWord) (Expr EWord)  -- ^ (x*y)/z <= x or y
+  | ConstMulMono  W256 (Expr EWord) (Expr EWord)                       -- ^ x<=y => c*x<=c*y
+  | ConstCancel   (Expr EWord) W256 W256 (Expr EWord)                  -- ^ (c1*x)/c2 == (c1/c2)*x
+  | NestedDiv     (Expr EWord) W256 W256                               -- ^ (A/c1)/c2 == A/(c1*c2)
+  | FracReduce    (Expr EWord) W256 W256 (Expr EWord)                  -- ^ (c1*x)/c2 == x/(c2/c1)
+  | CeilDivCancel (Expr EWord) W256 W256 (Expr EWord)                  -- ^ ceilDiv(c1*x,c2) inner divide
+  | Telescope     (Expr EWord) (Expr EWord) W256 W256                  -- ^ (a*b)/c - (a*(b-k))/c == a*(k/c)
+  deriving (Eq, Ord)
+
+-- | Every lemma instance triggered by the saturated term set, in the order the
+-- assertions are emitted. One clause per family; see 'emitLemma' for the math.
+collectLemmas :: AbstractCtx -> [LemmaInst]
+collectLemmas ctx =
+     -- commutativity + 0/1 identities over every product
+     [ Comm a b            | (a, b) <- ctx.acMuls ]
+  <> [ Identity a b        | (a, b) <- ctx.acMuls ]
+     -- the div<->mul link, one per division
+  <> [ DivMulLink a b      | (a, b) <- ctx.acUDivs ]
+     -- monotonicities over shared-operand pairs
+  <> [ MulMono x y z       | (x, y, z) <- sharedPairs (bothOrders (ctx.acMuls)) ]
+  <> [ DivMono x y z       | (x, y, z) <- sharedPairs (ctx.acUDivs) ]
+  <> [ DivisorMono y1 y2 x | (y1, y2, x) <- divisorPairs (ctx.acUDivs) ]
+     -- product-over-divisor bound, for divisions whose dividend is a product
+  <> [ MulDivBound a x y b | (a, b) <- ctx.acUDivs, Just (x, y) <- [asMul a] ]
+     -- const-mul monotonicity over const-products sharing the same constant
+  <> [ ConstMulMono c x y  | (c, x) <- ctx.acConstMuls, (c', y) <- ctx.acConstMuls, c == c', x /= y ]
+     -- constant cancellation / fraction reduction over constant divisions
+  <> [ ConstCancel a c1 c2 x
+     | (a, b) <- ctx.acUDivs, Just (c1, x) <- [asConstMul a]
+     , Lit c2 <- [b], c2 /= 0, c1 `mod` c2 == 0 ]
+  <> [ NestedDiv innerA c1 c2
+     | (a, b) <- ctx.acUDivs, Lit c2 <- [b]
+     , T.Div innerA (Lit c1) <- [a]
+     , c1 /= 0, c2 /= 0, toInteger c1 * toInteger c2 < 2 ^ (256 :: Int) ]
+  <> [ FracReduce a c1 c2 x
+     | (a, b) <- ctx.acUDivs, Just (c1, x) <- [asConstMul a]
+     , Lit c2 <- [b], c2 /= 0, c1 /= 0, c2 `mod` c1 == 0, c2 /= c1 ]
+  <> [ CeilDivCancel a c1 c2 x
+     | (a, b) <- ctx.acUDivs, T.Sub inner (Lit 1) <- [a]
+     , Just (c1, x) <- [asConstMul inner]
+     , Lit c2 <- [b], c2 /= 0, c1 `mod` c2 == 0 ]
+     -- scaled-product telescoping (the only cross-product lemma)
+  <> [ Telescope a b k c | (a, b, k, c) <- telescopes ]
+  where
+    telescopes = nubOrd
+      [ (a, b, k, c)
+      | (sd, Lit c) <- ctx.acUDivs, c /= 0
+      , Just (f1, f2) <- [asMul sd]
+      , (a, T.Sub b (Lit k)) <- [(f1, f2), (f2, f1)]
+      , k /= 0, k `mod` c == 0
+      , any (`elem` ctx.acUDivs) [ (T.Mul a b, Lit c), (T.Mul b a, Lit c) ] ]
+
+-- | Emit the SMT assertion(s) for a single lemma instance. Each clause is the
+-- sound fact, with its no-overflow / divisor guard where one is required.
+emitLemma :: Enc -> LemmaInst -> Err [SMTEntry]
+
+-- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so lemma
+-- terms match the props regardless of the simplifier's operand order.
+emitLemma enc (Comm a b) = do
+  aenc <- enc a; benc <- enc b
+  let m1 = "(abst_evm_bvmul" `sp` aenc `sp` benc <> ")"
+      m2 = "(abst_evm_bvmul" `sp` benc `sp` aenc <> ")"
+  pure [ SMTCommand $ "(assert (=" `sp` m1 `sp` m2 <> "))" ]
+
+-- sound identities pinning the otherwise-free UF on 0/1 operands:
+--   x*0 = 0, 0*y = 0, x*1 = x, 1*y = y
+emitLemma enc (Identity a b) = do
+  aenc <- enc a; benc <- enc b
+  let m = "(abst_evm_bvmul" `sp` aenc `sp` benc <> ")"
+  pure [ SMTCommand $ "(assert (=> (=" `sp` aenc `sp` zero <> ") (=" `sp` m `sp` zero  <> ")))"
+       , SMTCommand $ "(assert (=> (=" `sp` benc `sp` zero <> ") (=" `sp` m `sp` zero  <> ")))"
+       , SMTCommand $ "(assert (=> (=" `sp` aenc `sp` one  <> ") (=" `sp` m `sp` benc  <> ")))"
+       , SMTCommand $ "(assert (=> (=" `sp` benc `sp` one  <> ") (=" `sp` m `sp` aenc  <> ")))"
+       ]
+
+-- div<->mul link (sound unconditionally): quotient*divisor <= dividend, i.e.
+--   abst_evm_bvmul(abst_evm_bvudiv(a,b), b) <= a.
+-- (a/b)*b <= a < 2^256 can never overflow, so no guard. This links the div and
+-- mul abstractions and chains nested divisions.
+emitLemma enc (DivMulLink a b) = do
+  aenc <- enc a; benc <- enc b
+  let q  = "(abst_evm_bvudiv" `sp` aenc `sp` benc <> ")"
+      qb = "(abst_evm_bvmul" `sp` q `sp` benc <> ")"
+  pure [ SMTCommand $ "(assert (bvule" `sp` qb `sp` aenc <> "))" ]
+
+-- mul monotonicity (guarded by no-overflow, hence sound): if neither x*z nor
+-- y*z overflows then x <= y => x*z <= y*z. The guard is bound-free; bounding
+-- operands (e.g. a Solidity require) keeps it cheap to discharge.
+emitLemma enc (MulMono x y z) = do
+  xenc <- enc x; yenc <- enc y; zenc <- enc z
+  let mxz = "(abst_evm_bvmul" `sp` xenc `sp` zenc <> ")"
+      myz = "(abst_evm_bvmul" `sp` yenc `sp` zenc <> ")"
+  pure [ SMTCommand $ "(assert (=> (and" `sp` mulNoOverflow xenc zenc `sp` mulNoOverflow yenc zenc
+         <> " (bvule" `sp` xenc `sp` yenc <> ")) (bvule" `sp` mxz `sp` myz <> ")))" ]
+
+-- div monotonicity in the dividend (sound unconditionally): for a common
+-- divisor z, x <= y => floor(x/z) <= floor(y/z).
+emitLemma enc (DivMono x y z) = do
+  xenc <- enc x; yenc <- enc y; zenc <- enc z
+  let dxz = "(abst_evm_bvudiv" `sp` xenc `sp` zenc <> ")"
+      dyz = "(abst_evm_bvudiv" `sp` yenc `sp` zenc <> ")"
+  pure [ SMTCommand $ "(assert (=> (bvule" `sp` xenc `sp` yenc <> ") (bvule" `sp` dxz `sp` dyz <> ")))" ]
+
+-- div anti-monotonicity in the divisor (sound for nonzero divisors): a bigger
+-- divisor yields a smaller-or-equal quotient.
+--   y1 <= y2 && y1 != 0  =>  x/y2 <= x/y1
+emitLemma enc (DivisorMono y1 y2 x) = do
+  y1e <- enc y1; y2e <- enc y2; xe <- enc x
+  let dxy1 = "(abst_evm_bvudiv" `sp` xe `sp` y1e <> ")"
+      dxy2 = "(abst_evm_bvudiv" `sp` xe `sp` y2e <> ")"
+  pure [ SMTCommand $ "(assert (=> (and (distinct" `sp` y1e `sp` zero <> ")"
+         <> " (bvule" `sp` y1e `sp` y2e <> ")) (bvule" `sp` dxy2 `sp` dxy1 <> ")))" ]
+
+-- mulDiv bound (sound under no-overflow of x*z): if one factor is <= the
+-- divisor then dividing the product by it cannot exceed the other factor.
+--   y <= z  =>  (x*y)/z <= x       x <= z  =>  (x*y)/z <= y
+-- `a` is the original product expr, so the div term matches the prop exactly.
+emitLemma enc (MulDivBound a x y z) = do
+  ae <- enc a; xe <- enc x; ye <- enc y; ze <- enc z
+  let dv = "(abst_evm_bvudiv" `sp` ae `sp` ze <> ")"
+  pure [ SMTCommand $ "(assert (=> (and (bvule" `sp` ye `sp` ze <> ")" `sp` mulNoOverflow xe ze
+           <> ") (bvule" `sp` dv `sp` xe <> ")))"
+       , SMTCommand $ "(assert (=> (and (bvule" `sp` xe `sp` ze <> ")" `sp` mulNoOverflow ye ze
+           <> ") (bvule" `sp` dv `sp` ye <> ")))" ]
+
+-- const-mul monotonicity (sound, no-overflow guarded): for a fixed literal
+-- constant c, x <= y => c*x <= c*y. Because c is concrete we compute the exact
+-- no-overflow bound floor((2^256-1)/c) at encode time, so the guard is a single
+-- comparison against a constant. c*x stays a native bvmul; this lemma just lets
+-- the solver order two such products without bit-blasting the multiply.
+emitLemma enc (ConstMulMono c x y) = do
+  xe <- enc x; ye <- enc y
+  let cbv  = wordAsBV c
+      cx   = "(bvmul" `sp` cbv `sp` xe <> ")"
+      cy   = "(bvmul" `sp` cbv `sp` ye <> ")"
+      bnd  = wordAsBV ((maxBound :: W256) `div` c)  -- largest x with c*x < 2^256
+  pure [ SMTCommand $ "(assert (=> (and (bvule" `sp` xe `sp` bnd <> ") (bvule" `sp` ye `sp` bnd <> ")"
+         <> " (bvule" `sp` xe `sp` ye <> ")) (bvule" `sp` cx `sp` cy <> ")))" ]
+
+-- const cancellation (sound, no-overflow guarded): a product c1*x divided by a
+-- literal c2 that divides c1 collapses to (c1/c2)*x. The multiply by a constant
+-- stays a native bvmul but the divide is abstracted, so without this the
+-- precision-scaling wrapper c1*x/c2 (e.g. amount*1e18/1e6 in _getUsdcValue) is
+-- not provably its closed form. `a` is the dividend (c1*x); c2 | c1 makes c1/c2
+-- exact, and the bound floor((2^256-1)/c1) is computed at encode time.
+emitLemma enc (ConstCancel a c1 c2 x) = do
+  ae <- enc a; xe <- enc x
+  let c2bv = wordAsBV c2
+      k    = c1 `div` c2                 -- exact, since c2 | c1
+      rhs  = if k == 1 then xe else "(bvmul" `sp` wordAsBV k `sp` xe <> ")"
+      dv   = "(abst_evm_bvudiv" `sp` ae `sp` c2bv <> ")"
+      bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
+  pure [ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` rhs <> ")))" ]
+
+-- nested-division collapse (sound, floor identity): (A/c1)/c2 == A/(c1*c2) for
+-- literal c1,c2 with c1*c2 < 2^256. Lets the solver simplify chained constant
+-- divisions such as x*rate/1e9/1e18 to x*rate/1e27. No operand bound needed.
+emitLemma enc (NestedDiv innerA c1 c2) = do
+  ae <- enc innerA
+  let inner     = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c1 <> ")"
+      outer     = "(abst_evm_bvudiv" `sp` inner `sp` wordAsBV c2 <> ")"
+      collapsed = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV (c1 * c2) <> ")"
+  pure [ SMTCommand $ "(assert (=" `sp` outer `sp` collapsed <> "))" ]
+
+-- fraction-reduce (sound, no-overflow guarded): a product c1*x divided by a
+-- literal c2 that c1 divides collapses to x/(c2/c1). The mirror of const-cancel:
+-- const-cancel needs c2 | c1 (multiply by large, divide by small); this needs
+-- c1 | c2 (multiply by small, divide by large, e.g. x*1e6/1e18 == x/1e12 — the
+-- convert-to-usdc precision step). Under the guard c1*x is exact and
+-- floor(c1*x / (c1*k)) = floor(x/k). `a` is the dividend (c1*x).
+emitLemma enc (FracReduce a c1 c2 x) = do
+  ae <- enc a; xe <- enc x
+  let k    = c2 `div` c1                 -- exact and >= 2, since c1 | c2 and c2 /= c1
+      dv   = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c2 <> ")"   -- (c1*x)/c2
+      rhs  = "(abst_evm_bvudiv" `sp` xe `sp` wordAsBV k <> ")"    -- x/(c2/c1)
+      bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
+  pure [ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` rhs <> ")))" ]
+
+-- ceilDiv-cancel (sound, guarded): pins the abstracted divide inside
+-- OpenZeppelin's Math.ceilDiv(c1*x, c2) = (c1*x - 1)/c2 + 1 (the c1*x != 0
+-- branch). `a` is the (c1*x - 1) dividend. When c2 | c1, write c1 = c2*m: then
+-- c1*x = c2*(m*x), so floor((c2*m*x - 1)/c2) = m*x - 1 (for m*x >= 1). Adding the
+-- ceilDiv's +1 gives m*x = (c1/c2)*x exactly. Guarded by x >= 1 (the ceilDiv ITE
+-- handles x==0) and the encode-time no-overflow bound floor((2^256-1)/c1).
+emitLemma enc (CeilDivCancel a c1 c2 x) = do
+  ae <- enc a; xe <- enc x
+  let m    = c1 `div` c2                 -- exact, since c2 | c1
+      mx   = if m == 1 then xe else "(bvmul" `sp` wordAsBV m `sp` xe <> ")"
+      dv   = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c2 <> ")"   -- (c1*x - 1)/c2
+      rhs  = "(bvsub" `sp` mx `sp` one <> ")"                     -- (c1/c2)*x - 1
+      bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
+  pure [ SMTCommand $ "(assert (=> (and (bvuge" `sp` xe `sp` one <> ")"
+         <> " (bvule" `sp` xe `sp` bnd <> ")) (=" `sp` dv `sp` rhs <> ")))" ]
+
+-- scaled-product telescoping (sound, no-overflow guarded). For products sharing
+-- factor a whose other factors differ by a literal k with c | k:
+--   floor(a*b/c) == floor(a*(b-k)/c) + a*(k/c).
+-- Sound because a*b = a*(b-k) + a*k and a*k is an exact multiple of c, so
+-- removing it shifts the floor by exactly a*(k/c). The only lemma pinning the
+-- EXACT difference of two distinct abstract products; discharges value-change
+-- accounting like susds*rate/1e27 - susds == susds*(rate-1e27)/1e27. Guarded by
+-- no-overflow on a*b and b >= k (so b-k is a true difference, no wraparound).
+emitLemma enc (Telescope a b k c) = do
+  ae <- enc a; be <- enc b
+  let m       = k `div` c                       -- exact, since c | k
+      cbv     = wordAsBV c
+      full    = "(abst_evm_bvmul" `sp` ae `sp` be <> ")"
+      stepped = "(abst_evm_bvmul" `sp` ae `sp` ("(bvsub" `sp` be `sp` wordAsBV k <> ")") <> ")"
+      dFull   = "(abst_evm_bvudiv" `sp` full `sp` cbv <> ")"
+      dStep   = "(abst_evm_bvudiv" `sp` stepped `sp` cbv <> ")"
+      coeff   = if m == 1 then ae else "(bvmul" `sp` wordAsBV m `sp` ae <> ")"
+      rhs     = "(bvadd" `sp` dStep `sp` coeff <> ")"
+  pure [ SMTCommand $ "(assert (=> (and" `sp` mulNoOverflow ae be
+         <> " (bvuge" `sp` be `sp` wordAsBV k <> ")) (=" `sp` dFull `sp` rhs <> ")))" ]
+
+-- | Include both operand orders of each product. Multiplication is commutative
+-- (and we assert that), but the simplifier/solc may order a product's operands
+-- either way; considering both ensures monotonicity is found regardless of
+-- ordering. Only used for the (commutative) mul lemmas.
+bothOrders :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord)]
+bothOrders xs = nubOrd (xs <> [ (b, a) | (a, b) <- xs ])
+
+-- | Ordered pairs (x, y, z) where (x,z) and (y,z) both occur (shared 2nd
+-- operand): products by a common factor, or divisions by a common divisor.
+sharedPairs :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord, Expr EWord)]
+sharedPairs xs = [ (x, y, z) | (x, z) <- xs, (y, z') <- xs, z == z', x /= y ]
+
+-- | Ordered pairs (y1, y2, x) where (x,y1) and (x,y2) both occur (shared 1st
+-- operand): divisions of the same dividend by different divisors.
+divisorPairs :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord, Expr EWord)]
+divisorPairs xs = [ (y1, y2, x) | (x, y1) <- xs, (x', y2) <- xs, x == x', y1 /= y2 ]

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -1,4 +1,12 @@
-{- | Abstract div/mobsolud encoding for two-phase SMT solving. -}
+{- | Abstract div/mod encoding for two-phase SMT solving.
+
+   Orchestration layer. The shared vocabulary (primitives, collectors,
+   'saturate') lives in "EVM.SMT.AbstractBase"; the multiplication lemma
+   catalogue lives in "EVM.SMT.AbstractLemmas". This module wires them together
+   ('mulEncoding') and holds the div/mod /ground-truth/ encoding — the phase that
+   refines the abstract uninterpreted functions against real bvudiv/bvsdiv using
+   absolute values, shift bounds, and congruence.
+-}
 module EVM.SMT.DivModEncoding
   ( divModGroundTruth
   , divModEncoding
@@ -11,114 +19,32 @@ import Data.Bits (countTrailingZeros)
 import Data.Containers.ListUtils (nubOrd)
 import Data.List (groupBy, sortBy)
 import Data.Ord (comparing)
-import Data.Text.Lazy.Builder
-import qualified Data.Text.Lazy.Builder.Int
+import Data.Text.Lazy.Builder (Builder, fromString)
+
+import EVM.SMT.AbstractBase
+import EVM.SMT.AbstractLemmas (collectLemmas, emitLemma)
 import EVM.SMT.Types
-import EVM.Traversals
-import EVM.Types (Prop(..), EType(EWord), Err, W256, Expr, Expr(Lit), Expr(SHL))
-import EVM.Types qualified as T
+import EVM.Traversals (foldProp)
+import EVM.Types (Prop, EType(EWord), Err, W256, Expr, Expr(Lit), Expr(SHL))
 
--- | Uninterpreted function declarations for abstract div/mod.
-divModAbstractDecls :: [SMTEntry]
-divModAbstractDecls =
-  [ SMTComment "abstract division/modulo (uninterpreted functions)"
-  , SMTCommand "(declare-fun abst_evm_bvsdiv ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
-  , SMTCommand "(declare-fun abst_evm_bvsrem ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
-  , SMTCommand "(declare-fun abst_evm_bvudiv ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
-  , SMTCommand "(declare-fun abst_evm_bvurem ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
-  , SMTComment "abstract multiplication (kept fully uninterpreted: no ground truth)"
-  , SMTCommand "(declare-fun abst_evm_bvmul ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
-  ]
-
--- | Local helper for trivial SMT constructs
-sp :: Builder -> Builder -> Builder
-a `sp` b = a <> " " <> b
-
-zero :: Builder
-zero = "(_ bv0 256)"
-
-one :: Builder
-one = "(_ bv1 256)"
-
--- | Maximum value representable in 128 unsigned bits (2^128 - 1).
-maxU128 :: Builder
-maxU128 = "(_ bv340282366920938463463374607431768211455 256)"
-
--- | A /sufficient/ condition for x*y not to overflow 256 bits: both operands
--- fit in 128 bits, so their product fits in 256 (since (2^128-1)^2 < 2^256).
---
--- We deliberately use this cheap sufficient condition rather than the exact
--- no-overflow predicate @extract 511 256 (bvmul (zext x) (zext y)) = 0@. The
--- exact form forces the solver to bit-blast a full 512-bit multiply for every
--- lemma instance, which is the dominant cost and makes queries with large
--- operands (~2^100) time out. Two comparisons against a constant are
--- essentially free by contrast.
---
--- This is the same width-budget idea Halmos uses. It is SOUND: when the guard
--- holds there is genuinely no overflow, so any lemma it gates remains valid.
--- The cost is completeness — a product of operands above 2^128 that happens not
--- to overflow will not receive the lemma. Callers bound operands (e.g. a
--- Solidity @require(x < 2**128)@) so the guard discharges cheaply.
-mulNoOverflow :: Builder -> Builder -> Builder
-mulNoOverflow x y =
-  "(and (bvule " <> x <> " " <> maxU128 <> ") (bvule " <> y <> " " <> maxU128 <> "))"
-
-wordAsBV :: forall a. Integral a => a -> Builder
-wordAsBV w = "(_ bv" <> Data.Text.Lazy.Builder.Int.decimal w <> " 256)"
-
--- | The four EVM division/modulo operations. The @S@-variants are signed
--- (SDiv/SMod), the @U@-variants unsigned (Div/Mod). Signed and unsigned ops
--- are kept in separate groups so the signed absolute-value/sign-reconstruction
--- machinery is never applied to unsigned operands (and vice versa).
-data DivModKind = IsSDiv | IsSMod | IsUDiv | IsUMod
-  deriving (Eq, Ord)
-
-type DivModOp = (DivModKind, Expr EWord, Expr EWord)
-
-data AbstractKey = AbstractKey (Expr EWord) (Expr EWord) DivModKind
-  deriving (Eq, Ord)
-
-isDiv :: DivModKind -> Bool
-isDiv IsSDiv = True
-isDiv IsUDiv = True
-isDiv _      = False
-
-isSigned :: DivModKind -> Bool
-isSigned IsSDiv = True
-isSigned IsSMod = True
-isSigned _      = False
-
--- | Name of the uninterpreted function standing in for this op.
-abstFnName :: DivModKind -> Builder
-abstFnName IsSDiv = "abst_evm_bvsdiv"
-abstFnName IsSMod = "abst_evm_bvsrem"
-abstFnName IsUDiv = "abst_evm_bvudiv"
-abstFnName IsUMod = "abst_evm_bvurem"
-
--- | Name of the concrete SMT-LIB op refined against in phase two.
-concFnName :: DivModKind -> Builder
-concFnName IsSDiv = "bvsdiv"
-concFnName IsSMod = "bvsrem"
-concFnName IsUDiv = "bvudiv"
-concFnName IsUMod = "bvurem"
-
--- | Collect all div/mod operations from an expression.
-collectDivMods :: Expr a -> [DivModOp]
-collectDivMods = \case
-  T.SDiv a b -> [(IsSDiv, a, b)]
-  T.SMod a b -> [(IsSMod, a, b)]
-  T.Div  a b -> [(IsUDiv, a, b)]
-  T.Mod  a b -> [(IsUMod, a, b)]
-  _          -> []
-
-abstractKey :: DivModOp -> AbstractKey
-abstractKey (kind, a, b) = AbstractKey a b kind
+-- | Lemmas for abstract multiplication. Multiplication is kept fully
+-- uninterpreted (no ground truth, so the solver never bit-blasts a symbolic
+-- product); we add only the sound algebraic facts catalogued in
+-- "EVM.SMT.AbstractLemmas". 'saturate' closes the term set the lemmas range
+-- over; 'collectLemmas' picks the instances; 'emitLemma' renders each to SMT.
+mulEncoding :: Enc -> [Prop] -> Err [SMTEntry]
+mulEncoding enc props = do
+  let ctx = saturate props
+  if null ctx.acUDivs && null ctx.acMuls && null ctx.acConstMuls then pure []
+  else do
+    lemmas <- concat <$> mapM (emitLemma enc) (collectLemmas ctx)
+    pure $ (SMTComment "multiplication abstraction lemmas") : lemmas
 
 -- | Declare the magnitude variables and the unsigned result variable for a
 -- group. For signed ops the magnitudes are the absolute values |a|, |b|; for
 -- unsigned ops the operands are already non-negative, so the magnitude is the
 -- operand itself (|x| = x).
-declareAbsolute :: (Expr EWord -> Err Builder) -> DivModKind -> Int -> Expr EWord -> Expr EWord -> Builder -> Err ([SMTEntry], (Builder, Builder))
+declareAbsolute :: Enc -> DivModKind -> Int -> Expr EWord -> Expr EWord -> Builder -> Err ([SMTEntry], (Builder, Builder))
 declareAbsolute enc kind groupIdx firstA firstB unsignedResult = do
   aenc <- enc firstA
   benc <- enc firstB
@@ -138,7 +64,7 @@ declareAbsolute enc kind groupIdx firstA firstB unsignedResult = do
 -- | Assert "abstract div/mod(a,b)" = result derived from the unsigned result
 -- variable. Signed ops reconstruct the sign from |a|/|b|; unsigned ops need
 -- only the EVM divide-by-zero guard, since the unsigned result is the answer.
-assertAbstEqResult :: (Expr EWord -> Err Builder) -> Builder -> DivModOp -> Err SMTEntry
+assertAbstEqResult :: Enc -> Builder -> DivModOp -> Err SMTEntry
 assertAbstEqResult enc unsignedResult (kind, a, b) = do
   aenc <- enc a
   benc <- enc b
@@ -153,7 +79,7 @@ assertAbstEqResult enc unsignedResult (kind, a, b) = do
 -- | Ground-truth axioms: for each sdiv/smod op, assert that the abstract
 -- uninterpreted function equals the real bvsdiv/bvsrem.
 -- e.g. (assert (= (abst_evm_bvsdiv a b) (bvsdiv a b)))
-divModGroundTruth :: (Expr EWord -> Err Builder) -> [Prop] -> Err [SMTEntry]
+divModGroundTruth :: Enc -> [Prop] -> Err [SMTEntry]
 divModGroundTruth enc props = do
   let allDivMods = nubOrd $ concatMap (foldProp collectDivMods []) props
   if null allDivMods then pure []
@@ -174,346 +100,8 @@ divModGroundTruth enc props = do
           concrete = if isSigned kind then native else smtZeroGuard benc native
       pure $ SMTCommand $ "(assert (=" `sp` abstract `sp` concrete <> "))"
 
--- | Collect symbolic*symbolic multiplications (neither operand a literal).
--- Concrete factors (incl. 0/1/power-of-two) are handled natively by the
--- simplifier, so only genuinely symbolic products are abstracted.
-collectMuls :: Expr a -> [(Expr EWord, Expr EWord)]
-collectMuls = \case
-  T.Mul a b | notLit a, notLit b -> [(a, b)]
-  _ -> []
-  where
-    notLit (Lit _) = False
-    notLit _       = True
-
--- | Collect multiplications by a literal constant, @(c, x)@ for @c*x@ (either
--- operand order), excluding the trivial constants 0 and 1. These stay native
--- @bvmul@ (the value is concrete), but a symbolic operand times a large
--- constant is still costly to bit-blast and compare; const-mul monotonicity
--- (see 'mkConstMulMono') lets the solver order such products without doing so.
-collectConstMuls :: Expr a -> [(W256, Expr EWord)]
-collectConstMuls = \case
-  T.Mul (Lit c) x | notLit x, c /= 0, c /= 1 -> [(c, x)]
-  T.Mul x (Lit c) | notLit x, c /= 0, c /= 1 -> [(c, x)]
-  _ -> []
-  where
-    notLit (Lit _) = False
-    notLit _       = True
-
--- | True if any prop contains a symbolic*symbolic multiplication, i.e. the
--- multiplication abstraction is in play. Because abst_evm_bvmul is left
--- uninterpreted (no ground truth), a satisfying model may assign it values
--- inconsistent with real multiplication, so a counterexample cannot be
--- trusted; callers must downgrade SAT results to Unknown to stay SOUND.
-hasAbstractMul :: [Prop] -> Bool
-hasAbstractMul props = not $ null $ concatMap (foldProp collectMuls []) props
-
--- | Lemmas for abstract multiplication. Multiplication is kept fully
--- uninterpreted (no ground truth, so the solver never bit-blasts a symbolic
--- product); we add only sound algebraic facts. Commutativity is free because
--- the simplifier canonically orders Mul operands, so abst_evm_bvmul(a,b) and
--- abst_evm_bvmul(b,a) are the same term.
---
--- Step 1 lemma (sound unconditionally): quotient*divisor <= dividend, i.e.
---   abst_evm_bvmul(abst_evm_bvudiv(X,Y), Y) <= X
--- The product (X/Y)*Y <= X < 2^256 can never overflow, so no guard is needed.
--- This is what links the div and mul abstractions and chains nested divisions.
-mulEncoding :: (Expr EWord -> Err Builder) -> [Prop] -> Err [SMTEntry]
-mulEncoding enc props = do
-  let udivs = [ (a, b) | (IsUDiv, a, b) <- nubOrd $ concatMap (foldProp collectDivMods []) props ]
-      muls  = nubOrd $ concatMap (foldProp collectMuls []) props
-      constMuls = nubOrd $ concatMap (foldProp collectConstMuls []) props
-      -- Cancellation: when an abstract product a*b has a factor that is reused
-      -- as a divisor elsewhere, synthesize the exact division (a*b)/factor.
-      -- Adding it to the div set lets the existing lemmas bridge nested
-      -- divisions: mulDiv-bound gives (a*b)/b <= a, and div-monotonicity carries
-      -- that bound across a shared divisor. This is what proves cross-divisor
-      -- round-trips like convertToAssetValue(convertToShares(x)) <= x (the
-      -- stateless core of inflation-attack safety), which single-level lemmas
-      -- cannot. The synthetic terms are exact EVM divisions, so this is SOUND.
-      divisors  = nubOrd [ b | (_, b) <- udivs ]
-      synthDivs = nubOrd $ [ (T.Mul a b, b) | (a, b) <- muls, b `elem` divisors ]
-                        <> [ (T.Mul a b, a) | (a, b) <- muls, a `elem` divisors ]
-      -- Collapse a nested constant division (A/c1)/c2 into a synthetic single divide
-      -- A/(c1*c2), and add it to the div set. Sound because nested-div-collapse below
-      -- asserts the two forms equal, so the synthetic divide is exact. This lets the
-      -- single-divide lemmas (telescoping, const-cancel, fraction-reduce) match code
-      -- that splits precision across two divides — e.g. _getSUsdsValue's x*rate/1e9/1e18,
-      -- whose collapsed x*rate/1e27 is what those lemmas key on.
-      collapsedDivs = nubOrd
-        [ (innerA, Lit (c1 * c2))
-        | (a, b) <- udivs <> synthDivs, Lit c2 <- [b]
-        , T.Div innerA (Lit c1) <- [a]
-        , c1 /= 0, c2 /= 0, toInteger c1 * toInteger c2 < 2 ^ (256 :: Int) ]
-      udivsAll  = nubOrd (udivs <> synthDivs <> collapsedDivs)
-      -- products the div-link lemma introduces, e.g. (a/b)*b
-      linkMuls = [ (T.Div a b, b) | (a, b) <- udivsAll ]
-      allMuls  = nubOrd (muls <> linkMuls)
-      -- divisions whose dividend is an abstract product: (x*y)/z
-      mulDivs = [ (a, x, y, b) | (a, b) <- udivsAll, Just (x, y) <- [asMul a] ]
-      -- pairs of const-muls sharing the same constant: (c, x, y) for c*x, c*y
-      constMulPairs = [ (c, x, y) | (c, x) <- constMuls, (c', y) <- constMuls, c == c', x /= y ]
-      -- const cancellation: a product c1*x divided by a literal c2 that divides
-      -- c1 collapses to (c1/c2)*x. (a, c1, c2, x): a is the dividend (c1*x). The
-      -- same-constant case (c1==c2) gives just x; the general case (c2 | c1)
-      -- covers lossless precision scaling like x*1e18/1e6 == x*1e12.
-      constCancels = [ (a, c1, c2, x)
-                     | (a, b) <- udivsAll, Just (c1, x) <- [asConstMul a]
-                     , Lit c2 <- [b], c2 /= 0, c1 `mod` c2 == 0 ]
-      -- nested-division collapse: (A/c1)/c2 == A/(c1*c2) for literals c1,c2 whose
-      -- product fits in 256 bits. A floor identity (sound unconditionally). E.g.
-      -- x*rate/1e9/1e18 == x*rate/1e27.
-      nestedDivs = [ (innerA, c1, c2)
-                   | (a, b) <- udivsAll, Lit c2 <- [b]
-                   , T.Div innerA (Lit c1) <- [a]
-                   , c1 /= 0, c2 /= 0, toInteger c1 * toInteger c2 < 2 ^ (256 :: Int) ]
-      -- fraction-reduce: a product c1*x divided by a literal c2 that c1 divides
-      -- collapses to x/(c2/c1). The mirror of const-cancel (c2 | c1); this is the
-      -- c1 | c2 case (multiply by small, divide by large) such as x*1e6/1e18 ==
-      -- x/1e12 (precision scaling DOWN, the convert-to-usdc direction). Excludes
-      -- c1==c2, which const-cancel already covers (collapsing to x).
-      fracReduces = [ (a, c1, c2, x)
-                    | (a, b) <- udivsAll, Just (c1, x) <- [asConstMul a]
-                    , Lit c2 <- [b], c2 /= 0, c1 /= 0
-                    , c2 `mod` c1 == 0, c2 /= c1 ]
-      -- ceilDiv-cancel: OpenZeppelin Math.ceilDiv(c1*x, c2) is
-      -- (c1*x == 0) ? 0 : (c1*x - 1)/c2 + 1, so the abstracted divide is over the
-      -- (c1*x - 1) dividend. When c2 | c1 the product c1*x is always a multiple of
-      -- c2, hence ceil == floor and the whole ceilDiv collapses to (c1/c2)*x. We
-      -- pin the inner divide: (a, c1, c2, x) with a == (c1*x) - 1.
-      ceilDivCancels = [ (a, c1, c2, x)
-                       | (a, b) <- udivsAll, T.Sub inner (Lit 1) <- [a]
-                       , Just (c1, x) <- [asConstMul inner]
-                       , Lit c2 <- [b], c2 /= 0, c1 `mod` c2 == 0 ]
-      -- scaled-product telescoping (sound, no-overflow guarded): two abstract
-      -- products sharing a factor a, whose other factors differ by a literal k that
-      -- the common divisor c divides, have an EXACT quotient difference:
-      -- (a*b)/c - (a*(b-k))/c == a*(k/c). This is the only lemma that relates two
-      -- DISTINCT abstract products, so it discharges value-change accounting
-      -- identities such as susds*rate/1e27 - susds == susds*(rate-1e27)/1e27 (rate
-      -- and rate-1e27 give unrelated abst_evm_bvmul terms otherwise). (a, b, k, c):
-      -- full product a*b, stepped product a*(b-k), divisor c, with c | k.
-      telescopes = nubOrd
-        [ (a, b, k, c)
-        | (sd, Lit c) <- udivsAll, c /= 0
-        , Just (f1, f2) <- [asMul sd]
-        , (a, T.Sub b (Lit k)) <- [(f1, f2), (f2, f1)]
-        , k /= 0, k `mod` c == 0
-        , any (`elem` udivsAll) [ (T.Mul a b, Lit c), (T.Mul b a, Lit c) ] ]
-  if null udivs && null muls && null constMuls then pure []
-  else do
-    comm    <- mapM mkComm allMuls
-    links   <- mapM mkDivMulLink udivsAll
-    zeroOne <- concat <$> mapM mkMulIdentities allMuls
-    mulMono <- concat <$> mapM mkMulMono (sharedPairs (bothOrders allMuls))
-    divMono <- concat <$> mapM mkDivMono (sharedPairs udivsAll)
-    divDivisorMono <- concat <$> mapM mkDivisorMono (divisorPairs udivsAll)
-    mulDivB <- concat <$> mapM mkMulDivBound mulDivs
-    constMulMono <- mapM mkConstMulMono constMulPairs
-    constCancel <- mapM mkConstCancel constCancels
-    nestedDiv <- mapM mkNestedDiv nestedDivs
-    fracReduce <- mapM mkFracReduce fracReduces
-    ceilDivCancel <- mapM mkCeilDivCancel ceilDivCancels
-    telescope <- mapM mkTelescope telescopes
-    pure $ (SMTComment "multiplication abstraction lemmas")
-           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel <> nestedDiv <> fracReduce <> ceilDivCancel <> telescope)
-  where
-    -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
-    -- lemma terms match the props regardless of the simplifier's operand order.
-    mkComm (a, b) = do
-      aenc <- enc a; benc <- enc b
-      let m1 = "(abst_evm_bvmul" `sp` aenc `sp` benc <> ")"
-          m2 = "(abst_evm_bvmul" `sp` benc `sp` aenc <> ")"
-      pure $ SMTCommand $ "(assert (=" `sp` m1 `sp` m2 <> "))"
-    -- Include both operand orders of each product. Multiplication is
-    -- commutative (and we assert that), but the simplifier/solc may order a
-    -- product's operands either way; considering both ensures monotonicity is
-    -- found regardless of ordering. Only used for the (commutative) mul lemmas,
-    -- never for the order-sensitive division lemmas.
-    bothOrders :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord)]
-    bothOrders xs = nubOrd (xs <> [ (b, a) | (a, b) <- xs ])
-
-    -- ordered pairs (x, y, z) where (x,z) and (y,z) both occur (shared 2nd operand)
-    sharedPairs :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord, Expr EWord)]
-    sharedPairs xs = [ (x, y, z) | (x, z) <- xs, (y, z') <- xs, z == z', x /= y ]
-
-    -- ordered pairs (y1, y2, x) where (x,y1) and (x,y2) both occur (shared 1st
-    -- operand): divisions of the same dividend by different divisors.
-    divisorPairs :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord, Expr EWord)]
-    divisorPairs xs = [ (y1, y2, x) | (x, y1) <- xs, (x', y2) <- xs, x == x', y1 /= y2 ]
-
-    -- div anti-monotonicity in the divisor (sound for nonzero divisors): a
-    -- bigger divisor yields a smaller-or-equal quotient.
-    --   y1 <= y2 && y1 != 0  =>  x/y2 <= x/y1
-    mkDivisorMono (y1, y2, x) = do
-      y1e <- enc y1; y2e <- enc y2; xe <- enc x
-      let dxy1 = "(abst_evm_bvudiv" `sp` xe `sp` y1e <> ")"
-          dxy2 = "(abst_evm_bvudiv" `sp` xe `sp` y2e <> ")"
-      pure [ SMTCommand $ "(assert (=> (and (distinct" `sp` y1e `sp` zero <> ")"
-             <> " (bvule" `sp` y1e `sp` y2e <> ")) (bvule" `sp` dxy2 `sp` dxy1 <> ")))" ]
-
-    -- mul monotonicity (guarded by no-overflow, hence sound): if neither x*z
-    -- nor y*z overflows then x <= y  =>  x*z <= y*z. The guard is bound-free;
-    -- bounding operands (e.g. a Solidity require) keeps it cheap to discharge.
-    mkMulMono (x, y, z) = do
-      xenc <- enc x; yenc <- enc y; zenc <- enc z
-      let mxz = "(abst_evm_bvmul" `sp` xenc `sp` zenc <> ")"
-          myz = "(abst_evm_bvmul" `sp` yenc `sp` zenc <> ")"
-      -- forward: x <= y  =>  x*z <= y*z
-      pure [ SMTCommand $ "(assert (=> (and" `sp` mulNoOverflow xenc zenc `sp` mulNoOverflow yenc zenc
-             <> " (bvule" `sp` xenc `sp` yenc <> ")) (bvule" `sp` mxz `sp` myz <> ")))" ]
-
-    -- const-mul monotonicity (sound, no-overflow guarded): for a fixed literal
-    -- constant c, x <= y  =>  c*x <= c*y. Because c is concrete we compute the
-    -- exact no-overflow bound floor((2^256-1)/c) at encode time, so the guard is
-    -- a single comparison against a constant (cheap) rather than a 512-bit
-    -- multiply. c*x stays a native bvmul; this lemma simply lets the solver
-    -- order two such products without bit-blasting the multiply.
-    mkConstMulMono (c, x, y) = do
-      xe <- enc x; ye <- enc y
-      let cbv  = wordAsBV c
-          cx   = "(bvmul" `sp` cbv `sp` xe <> ")"
-          cy   = "(bvmul" `sp` cbv `sp` ye <> ")"
-          bnd  = wordAsBV ((maxBound :: W256) `div` c)  -- largest x with c*x < 2^256
-      pure $ SMTCommand $ "(assert (=> (and (bvule" `sp` xe `sp` bnd <> ") (bvule" `sp` ye `sp` bnd <> ")"
-             <> " (bvule" `sp` xe `sp` ye <> ")) (bvule" `sp` cx `sp` cy <> ")))"
-
-    -- const cancellation (sound, no-overflow guarded): a product c1*x divided by
-    -- a literal c2 that divides c1 collapses to (c1/c2)*x. The multiply by a
-    -- constant stays a native bvmul but the divide is abstracted (uninterpreted),
-    -- so without this the precision-scaling wrapper c1*x/c2 (e.g. amount*1e18/1e18
-    -- in _getUsdsValue, or amount*1e18/1e6 in _getUsdcValue) is not provably its
-    -- closed form. `a` is the dividend expr (c1*x) so the abst_evm_bvudiv term
-    -- matches the prop exactly; c2 | c1 makes c1/c2 exact, and the no-overflow
-    -- bound floor((2^256-1)/c1) is computed at encode time (one comparison).
-    mkConstCancel (a, c1, c2, x) = do
-      ae <- enc a; xe <- enc x
-      let c2bv = wordAsBV c2
-          k    = c1 `div` c2                 -- exact, since c2 | c1
-          rhs  = if k == 1 then xe else "(bvmul" `sp` wordAsBV k `sp` xe <> ")"
-          dv   = "(abst_evm_bvudiv" `sp` ae `sp` c2bv <> ")"
-          bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
-      pure $ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` rhs <> ")))"
-
-    -- nested-division collapse (sound, floor identity): (A/c1)/c2 == A/(c1*c2) for
-    -- literal c1,c2 with c1*c2 < 2^256. Lets the solver simplify chained constant
-    -- divisions such as x*rate/1e9/1e18 to x*rate/1e27. No operand bound needed.
-    mkNestedDiv (innerA, c1, c2) = do
-      ae <- enc innerA
-      let inner    = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c1 <> ")"
-          outer    = "(abst_evm_bvudiv" `sp` inner `sp` wordAsBV c2 <> ")"
-          collapsed = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV (c1 * c2) <> ")"
-      pure $ SMTCommand $ "(assert (=" `sp` outer `sp` collapsed <> "))"
-
-    -- fraction-reduce (sound, no-overflow guarded): a product c1*x divided by a
-    -- literal c2 that c1 divides collapses to x/(c2/c1). The mirror of const
-    -- cancellation: const-cancel needs c2 | c1 (multiply by large, divide by
-    -- small, e.g. x*1e18/1e6 == x*1e12); this needs c1 | c2 (multiply by small,
-    -- divide by large, e.g. x*1e6/1e18 == x/1e12 — the convert-to-usdc precision
-    -- step). Sound because, under the no-overflow guard, c1*x is exact and
-    -- floor(c1*x / (c1*k)) = floor(x/k). `a` is the dividend (c1*x) so the
-    -- abst_evm_bvudiv term matches the prop; c1 | c2 makes c2/c1 exact and the
-    -- bound floor((2^256-1)/c1) is computed at encode time (one comparison).
-    mkFracReduce (a, c1, c2, x) = do
-      ae <- enc a; xe <- enc x
-      let k    = c2 `div` c1                 -- exact and >= 2, since c1 | c2 and c2 /= c1
-          dv   = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c2 <> ")"   -- (c1*x)/c2
-          rhs  = "(abst_evm_bvudiv" `sp` xe `sp` wordAsBV k <> ")"    -- x/(c2/c1)
-          bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
-      pure $ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` rhs <> ")))"
-
-    -- ceilDiv-cancel (sound, guarded): pins the abstracted divide inside
-    -- OpenZeppelin's Math.ceilDiv(c1*x, c2) = (c1*x - 1)/c2 + 1 (the c1*x != 0
-    -- branch). `a` is the (c1*x - 1) dividend. When c2 | c1, write c1 = c2*m: then
-    -- c1*x = c2*(m*x), so floor((c2*m*x - 1)/c2) = m*x - 1 (for m*x >= 1). Adding
-    -- the ceilDiv's +1 gives m*x = (c1/c2)*x exactly. Guarded by x >= 1 (the ceilDiv
-    -- ITE handles x==0 on its own branch) and the encode-time no-overflow bound
-    -- floor((2^256-1)/c1). This is the ceilDiv sibling of const-cancel; it
-    -- discharges the round-up swap-out closed forms (e.g. previewSwapExactOut
-    -- usds->usdc == amountOut*1e12).
-    mkCeilDivCancel (a, c1, c2, x) = do
-      ae <- enc a; xe <- enc x
-      let m    = c1 `div` c2                 -- exact, since c2 | c1
-          mx   = if m == 1 then xe else "(bvmul" `sp` wordAsBV m `sp` xe <> ")"
-          dv   = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c2 <> ")"   -- (c1*x - 1)/c2
-          rhs  = "(bvsub" `sp` mx `sp` one <> ")"                     -- (c1/c2)*x - 1
-          bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
-      pure $ SMTCommand $ "(assert (=> (and (bvuge" `sp` xe `sp` one <> ")"
-             <> " (bvule" `sp` xe `sp` bnd <> ")) (=" `sp` dv `sp` rhs <> ")))"
-
-    -- scaled-product telescoping (sound, no-overflow guarded). For products sharing
-    -- factor a whose other factors differ by a literal k with c | k:
-    --   floor(a*b/c) == floor(a*(b-k)/c) + a*(k/c).
-    -- Sound because a*b = a*(b-k) + a*k and a*k is an exact multiple of c (c | k), so
-    -- removing it shifts the floor by exactly a*(k/c). This is the only lemma pinning
-    -- the EXACT difference of two distinct abstract products; it discharges
-    -- value-change accounting like susds*rate/1e27 - susds == susds*(rate-1e27)/1e27.
-    -- Guarded by no-overflow on a*b (so a*(b-k), a*k all fit) and b >= k (so b-k is a
-    -- true difference, no wraparound).
-    mkTelescope (a, b, k, c) = do
-      ae <- enc a; be <- enc b
-      let m       = k `div` c                       -- exact, since c | k
-          cbv     = wordAsBV c
-          full    = "(abst_evm_bvmul" `sp` ae `sp` be <> ")"
-          stepped = "(abst_evm_bvmul" `sp` ae `sp` ("(bvsub" `sp` be `sp` wordAsBV k <> ")") <> ")"
-          dFull   = "(abst_evm_bvudiv" `sp` full `sp` cbv <> ")"
-          dStep   = "(abst_evm_bvudiv" `sp` stepped `sp` cbv <> ")"
-          coeff   = if m == 1 then ae else "(bvmul" `sp` wordAsBV m `sp` ae <> ")"
-          rhs     = "(bvadd" `sp` dStep `sp` coeff <> ")"
-      pure $ SMTCommand $ "(assert (=> (and" `sp` mulNoOverflow ae be
-             <> " (bvuge" `sp` be `sp` wordAsBV k <> ")) (=" `sp` dFull `sp` rhs <> ")))"
-
-    -- recognise multiplication by a non-trivial literal constant: c*x or x*c.
-    asConstMul :: Expr EWord -> Maybe (W256, Expr EWord)
-    asConstMul (T.Mul (Lit c) x) | notLit x, c /= 0, c /= 1 = Just (c, x)
-    asConstMul (T.Mul x (Lit c)) | notLit x, c /= 0, c /= 1 = Just (c, x)
-    asConstMul _ = Nothing
-
-    -- div monotonicity in the dividend (sound unconditionally): for a common
-    -- divisor z, x <= y  =>  floor(x/z) <= floor(y/z).
-    mkDivMono (x, y, z) = do
-      xenc <- enc x; yenc <- enc y; zenc <- enc z
-      let dxz = "(abst_evm_bvudiv" `sp` xenc `sp` zenc <> ")"
-          dyz = "(abst_evm_bvudiv" `sp` yenc `sp` zenc <> ")"
-      pure [ SMTCommand $ "(assert (=> (bvule" `sp` xenc `sp` yenc <> ") (bvule" `sp` dxz `sp` dyz <> ")))" ]
-    -- recognise an abstract symbolic*symbolic product
-    asMul :: Expr EWord -> Maybe (Expr EWord, Expr EWord)
-    asMul (T.Mul x y) | notLit x, notLit y = Just (x, y)
-    asMul _ = Nothing
-    notLit (Lit _) = False
-    notLit _       = True
-
-    -- mulDiv bound (sound under no-overflow of x*z): if one factor is <= the
-    -- divisor then dividing the product by it cannot exceed the other factor.
-    --   y <= z  =>  (x*y)/z <= x       x <= z  =>  (x*y)/z <= y
-    -- `a` is the original product expr, so the div term matches the prop exactly.
-    mkMulDivBound (a, x, y, z) = do
-      ae <- enc a; xe <- enc x; ye <- enc y; ze <- enc z
-      let dv = "(abst_evm_bvudiv" `sp` ae `sp` ze <> ")"
-      pure [ SMTCommand $ "(assert (=> (and (bvule" `sp` ye `sp` ze <> ")" `sp` mulNoOverflow xe ze
-               <> ") (bvule" `sp` dv `sp` xe <> ")))"
-           , SMTCommand $ "(assert (=> (and (bvule" `sp` xe `sp` ze <> ")" `sp` mulNoOverflow ye ze
-               <> ") (bvule" `sp` dv `sp` ye <> ")))" ]
-    -- quotient*divisor <= dividend
-    mkDivMulLink (a, b) = do
-      aenc <- enc a
-      benc <- enc b
-      let q  = "(abst_evm_bvudiv" `sp` aenc `sp` benc <> ")"
-          qb = "(abst_evm_bvmul" `sp` q `sp` benc <> ")"
-      pure $ SMTCommand $ "(assert (bvule" `sp` qb `sp` aenc <> "))"
-    -- sound identities pinning the otherwise-free UF on 0/1 operands:
-    --   x*0 = 0, 0*y = 0, x*1 = x, 1*y = y
-    mkMulIdentities (a, b) = do
-      aenc <- enc a
-      benc <- enc b
-      let m = "(abst_evm_bvmul" `sp` aenc `sp` benc <> ")"
-      pure [ SMTCommand $ "(assert (=> (=" `sp` aenc `sp` zero <> ") (=" `sp` m `sp` zero  <> ")))"
-           , SMTCommand $ "(assert (=> (=" `sp` benc `sp` zero <> ") (=" `sp` m `sp` zero  <> ")))"
-           , SMTCommand $ "(assert (=> (=" `sp` aenc `sp` one  <> ") (=" `sp` m `sp` benc  <> ")))"
-           , SMTCommand $ "(assert (=> (=" `sp` benc `sp` one  <> ") (=" `sp` m `sp` aenc  <> ")))"
-           ]
-
 -- | Encode div/mod operations using abs values, shift-bounds, and congruence (no bvudiv).
-divModEncoding :: (Expr EWord -> Err Builder) -> [Prop] -> Err [SMTEntry]
+divModEncoding :: Enc -> [Prop] -> Err [SMTEntry]
 divModEncoding enc props = do
   let allDivMods = nubOrd $ concatMap (foldProp collectDivMods []) props
   if null allDivMods then pure []
@@ -583,42 +171,3 @@ mkCongruenceLinks indexedGroups =
       in [ SMTCommand $ "(assert (=> "
             <> "(and (=" `sp` absoluteAi `sp` absoluteAj <> ") (=" `sp` abosluteBi `sp` absoluteBj <> "))"
             <> "(=" `sp` absoluteResI `sp` absoluteRedJ <> ")))" ]
-
--- | (ite (= divisor 0) 0 result)
-smtZeroGuard :: Builder -> Builder -> Builder
-smtZeroGuard divisor nonZeroResult =
-  "(ite (=" `sp` divisor `sp` zero <> ")" `sp` zero `sp` nonZeroResult <> ")"
-
--- | |x| as SMT: ite(x >= 0, x, 0 - x).
-smtAbsolute :: Builder -> Builder
-smtAbsolute x = "(ite (bvsge" `sp` x `sp` zero <> ")" `sp` x `sp` "(bvsub" `sp` zero `sp` x <> "))"
-
--- | -x as SMT.
-smtNeg :: Builder -> Builder
-smtNeg x = "(bvsub" `sp` zero `sp` x <> ")"
-
--- | True if a and b have the same sign
-smtSameSign :: Builder -> Builder -> Builder
-smtSameSign a b = "(=" `sp` "(bvslt" `sp` a `sp` zero <> ")" `sp` "(bvslt" `sp` b `sp` zero <> "))"
-
--- | x >= 0.
-smtIsNonNeg :: Builder -> Builder
-smtIsNonNeg x = "(bvsge" `sp` x `sp` zero <> ")"
-
--- | sdiv(a,b) = ITE(b = 0,              0,
---               ITE(sign(a) = sign(b),  udiv(|a|,|b|),
---                                      -udiv(|a|,|b|)))
-signedFromUnsignedDiv :: Builder -> Builder -> Builder -> Builder
-signedFromUnsignedDiv aenc benc udivResult =
-  smtZeroGuard benc $
-  "(ite" `sp` (smtSameSign aenc benc) `sp`
-    udivResult `sp` (smtNeg udivResult) <> ")"
-
--- | smod(a,b) = ITE(b = 0,   0,
---               ITE(a ≥ 0,   urem(|a|,|b|),
---                           -urem(|a|,|b|)))
-signedFromUnsignedMod :: Builder -> Builder -> Builder -> Builder
-signedFromUnsignedMod aenc benc uremResult =
-  smtZeroGuard benc $
-  "(ite" `sp` (smtIsNonNeg aenc) `sp`
-    uremResult `sp` (smtNeg uremResult) <> ")"

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -223,21 +223,33 @@ mulEncoding enc props = do
   let udivs = [ (a, b) | (IsUDiv, a, b) <- nubOrd $ concatMap (foldProp collectDivMods []) props ]
       muls  = nubOrd $ concatMap (foldProp collectMuls []) props
       constMuls = nubOrd $ concatMap (foldProp collectConstMuls []) props
+      -- Cancellation: when an abstract product a*b has a factor that is reused
+      -- as a divisor elsewhere, synthesize the exact division (a*b)/factor.
+      -- Adding it to the div set lets the existing lemmas bridge nested
+      -- divisions: mulDiv-bound gives (a*b)/b <= a, and div-monotonicity carries
+      -- that bound across a shared divisor. This is what proves cross-divisor
+      -- round-trips like convertToAssetValue(convertToShares(x)) <= x (the
+      -- stateless core of inflation-attack safety), which single-level lemmas
+      -- cannot. The synthetic terms are exact EVM divisions, so this is SOUND.
+      divisors  = nubOrd [ b | (_, b) <- udivs ]
+      synthDivs = nubOrd $ [ (T.Mul a b, b) | (a, b) <- muls, b `elem` divisors ]
+                        <> [ (T.Mul a b, a) | (a, b) <- muls, a `elem` divisors ]
+      udivsAll  = nubOrd (udivs <> synthDivs)
       -- products the div-link lemma introduces, e.g. (a/b)*b
-      linkMuls = [ (T.Div a b, b) | (a, b) <- udivs ]
+      linkMuls = [ (T.Div a b, b) | (a, b) <- udivsAll ]
       allMuls  = nubOrd (muls <> linkMuls)
       -- divisions whose dividend is an abstract product: (x*y)/z
-      mulDivs = [ (a, x, y, b) | (a, b) <- udivs, Just (x, y) <- [asMul a] ]
+      mulDivs = [ (a, x, y, b) | (a, b) <- udivsAll, Just (x, y) <- [asMul a] ]
       -- pairs of const-muls sharing the same constant: (c, x, y) for c*x, c*y
       constMulPairs = [ (c, x, y) | (c, x) <- constMuls, (c', y) <- constMuls, c == c', x /= y ]
   if null udivs && null muls && null constMuls then pure []
   else do
     comm    <- mapM mkComm allMuls
-    links   <- mapM mkDivMulLink udivs
+    links   <- mapM mkDivMulLink udivsAll
     zeroOne <- concat <$> mapM mkMulIdentities allMuls
     mulMono <- concat <$> mapM mkMulMono (sharedPairs (bothOrders allMuls))
-    divMono <- concat <$> mapM mkDivMono (sharedPairs udivs)
-    divDivisorMono <- concat <$> mapM mkDivisorMono (divisorPairs udivs)
+    divMono <- concat <$> mapM mkDivMono (sharedPairs udivsAll)
+    divDivisorMono <- concat <$> mapM mkDivisorMono (divisorPairs udivsAll)
     mulDivB <- concat <$> mapM mkMulDivBound mulDivs
     constMulMono <- mapM mkConstMulMono constMulPairs
     pure $ (SMTComment "multiplication abstraction lemmas")

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -241,9 +241,20 @@ mulEncoding enc props = do
       mulDivs = [ (a, x, y, b) | (a, b) <- udivsAll, Just (x, y) <- [asMul a] ]
       -- pairs of const-muls sharing the same constant: (c, x, y) for c*x, c*y
       constMulPairs = [ (c, x, y) | (c, x) <- constMuls, (c', y) <- constMuls, c == c', x /= y ]
-      -- const cancellation: divisions (c*x)/c by the SAME literal constant c.
-      -- (a, c, x): a is the division's dividend (c*x), divided by Lit c.
-      constCancels = [ (a, c, x) | (a, b) <- udivsAll, Just (c, x) <- [asConstMul a], b == Lit c ]
+      -- const cancellation: a product c1*x divided by a literal c2 that divides
+      -- c1 collapses to (c1/c2)*x. (a, c1, c2, x): a is the dividend (c1*x). The
+      -- same-constant case (c1==c2) gives just x; the general case (c2 | c1)
+      -- covers lossless precision scaling like x*1e18/1e6 == x*1e12.
+      constCancels = [ (a, c1, c2, x)
+                     | (a, b) <- udivsAll, Just (c1, x) <- [asConstMul a]
+                     , Lit c2 <- [b], c2 /= 0, c1 `mod` c2 == 0 ]
+      -- nested-division collapse: (A/c1)/c2 == A/(c1*c2) for literals c1,c2 whose
+      -- product fits in 256 bits. A floor identity (sound unconditionally). E.g.
+      -- x*rate/1e9/1e18 == x*rate/1e27.
+      nestedDivs = [ (innerA, c1, c2)
+                   | (a, b) <- udivsAll, Lit c2 <- [b]
+                   , T.Div innerA (Lit c1) <- [a]
+                   , c1 /= 0, c2 /= 0, toInteger c1 * toInteger c2 < 2 ^ (256 :: Int) ]
   if null udivs && null muls && null constMuls then pure []
   else do
     comm    <- mapM mkComm allMuls
@@ -255,8 +266,9 @@ mulEncoding enc props = do
     mulDivB <- concat <$> mapM mkMulDivBound mulDivs
     constMulMono <- mapM mkConstMulMono constMulPairs
     constCancel <- mapM mkConstCancel constCancels
+    nestedDiv <- mapM mkNestedDiv nestedDivs
     pure $ (SMTComment "multiplication abstraction lemmas")
-           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel)
+           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel <> nestedDiv)
   where
     -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
     -- lemma terms match the props regardless of the simplifier's operand order.
@@ -318,20 +330,32 @@ mulEncoding enc props = do
       pure $ SMTCommand $ "(assert (=> (and (bvule" `sp` xe `sp` bnd <> ") (bvule" `sp` ye `sp` bnd <> ")"
              <> " (bvule" `sp` xe `sp` ye <> ")) (bvule" `sp` cx `sp` cy <> ")))"
 
-    -- const cancellation (sound, no-overflow guarded): dividing a product by the
-    -- same literal constant it was multiplied by is the identity, (c*x)/c == x.
-    -- The multiply by a constant stays a native bvmul but the divide is
-    -- abstracted (uninterpreted), so without this the wrapper c*x/c that appears
-    -- in precision scaling (e.g. amount * 1e18 / 1e18 in _getUsdsValue) is not
-    -- provably the identity. `a` is the dividend expr (c*x) so the abst_evm_bvudiv
-    -- term matches the prop exactly; the exact no-overflow bound floor((2^256-1)/c)
-    -- is computed at encode time, so the guard is a single constant comparison.
-    mkConstCancel (a, c, x) = do
+    -- const cancellation (sound, no-overflow guarded): a product c1*x divided by
+    -- a literal c2 that divides c1 collapses to (c1/c2)*x. The multiply by a
+    -- constant stays a native bvmul but the divide is abstracted (uninterpreted),
+    -- so without this the precision-scaling wrapper c1*x/c2 (e.g. amount*1e18/1e18
+    -- in _getUsdsValue, or amount*1e18/1e6 in _getUsdcValue) is not provably its
+    -- closed form. `a` is the dividend expr (c1*x) so the abst_evm_bvudiv term
+    -- matches the prop exactly; c2 | c1 makes c1/c2 exact, and the no-overflow
+    -- bound floor((2^256-1)/c1) is computed at encode time (one comparison).
+    mkConstCancel (a, c1, c2, x) = do
       ae <- enc a; xe <- enc x
-      let cbv = wordAsBV c
-          dv  = "(abst_evm_bvudiv" `sp` ae `sp` cbv <> ")"
-          bnd = wordAsBV ((maxBound :: W256) `div` c)  -- largest x with c*x < 2^256
-      pure $ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` xe <> ")))"
+      let c2bv = wordAsBV c2
+          k    = c1 `div` c2                 -- exact, since c2 | c1
+          rhs  = if k == 1 then xe else "(bvmul" `sp` wordAsBV k `sp` xe <> ")"
+          dv   = "(abst_evm_bvudiv" `sp` ae `sp` c2bv <> ")"
+          bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
+      pure $ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` rhs <> ")))"
+
+    -- nested-division collapse (sound, floor identity): (A/c1)/c2 == A/(c1*c2) for
+    -- literal c1,c2 with c1*c2 < 2^256. Lets the solver simplify chained constant
+    -- divisions such as x*rate/1e9/1e18 to x*rate/1e27. No operand bound needed.
+    mkNestedDiv (innerA, c1, c2) = do
+      ae <- enc innerA
+      let inner    = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c1 <> ")"
+          outer    = "(abst_evm_bvudiv" `sp` inner `sp` wordAsBV c2 <> ")"
+          collapsed = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV (c1 * c2) <> ")"
+      pure $ SMTCommand $ "(assert (=" `sp` outer `sp` collapsed <> "))"
 
     -- recognise multiplication by a non-trivial literal constant: c*x or x*c.
     asConstMul :: Expr EWord -> Maybe (W256, Expr EWord)

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -40,13 +40,29 @@ zero = "(_ bv0 256)"
 one :: Builder
 one = "(_ bv1 256)"
 
--- | True iff x*y does not overflow 256 bits (high half of the 512-bit product
--- is zero). This is bound-free: it does NOT bake in any particular width
--- limit. Callers (e.g. a Solidity `require(x < 2**128)`) are responsible for
--- bounding operands so that this predicate is cheap for the solver to discharge.
+-- | Maximum value representable in 128 unsigned bits (2^128 - 1).
+maxU128 :: Builder
+maxU128 = "(_ bv340282366920938463463374607431768211455 256)"
+
+-- | A /sufficient/ condition for x*y not to overflow 256 bits: both operands
+-- fit in 128 bits, so their product fits in 256 (since (2^128-1)^2 < 2^256).
+--
+-- We deliberately use this cheap sufficient condition rather than the exact
+-- no-overflow predicate @extract 511 256 (bvmul (zext x) (zext y)) = 0@. The
+-- exact form forces the solver to bit-blast a full 512-bit multiply for every
+-- lemma instance, which is the dominant cost and makes realistic vault queries
+-- (operands ~2^100, e.g. token amounts up to 1e30) time out. Two comparisons
+-- against a constant are essentially free by contrast.
+--
+-- This is the same width-budget idea Halmos uses. It is SOUND: when the guard
+-- holds there is genuinely no overflow, so any lemma it gates remains valid.
+-- The cost is completeness — a product of operands above 2^128 that happens not
+-- to overflow will not receive the lemma. All realistic token amounts, share
+-- counts and conversion rates are far below 2^128, so this is not a limitation
+-- in practice.
 mulNoOverflow :: Builder -> Builder -> Builder
 mulNoOverflow x y =
-  "(= ((_ extract 511 256) (bvmul ((_ zero_extend 256) " <> x <> ") ((_ zero_extend 256) " <> y <> "))) " <> zero <> ")"
+  "(and (bvule " <> x <> " " <> maxU128 <> ") (bvule " <> y <> " " <> maxU128 <> "))"
 
 wordAsBV :: forall a. Integral a => a -> Builder
 wordAsBV w = "(_ bv" <> Data.Text.Lazy.Builder.Int.decimal w <> " 256)"
@@ -170,6 +186,20 @@ collectMuls = \case
     notLit (Lit _) = False
     notLit _       = True
 
+-- | Collect multiplications by a literal constant, @(c, x)@ for @c*x@ (either
+-- operand order), excluding the trivial constants 0 and 1. These stay native
+-- @bvmul@ (the value is concrete), but a symbolic operand times a large
+-- constant is still costly to bit-blast and compare; const-mul monotonicity
+-- (see 'mkConstMulMono') lets the solver order such products without doing so.
+collectConstMuls :: Expr a -> [(W256, Expr EWord)]
+collectConstMuls = \case
+  T.Mul (Lit c) x | notLit x, c /= 0, c /= 1 -> [(c, x)]
+  T.Mul x (Lit c) | notLit x, c /= 0, c /= 1 -> [(c, x)]
+  _ -> []
+  where
+    notLit (Lit _) = False
+    notLit _       = True
+
 -- | True if any prop contains a symbolic*symbolic multiplication, i.e. the
 -- multiplication abstraction is in play. Because abst_evm_bvmul is left
 -- uninterpreted (no ground truth), a satisfying model may assign it values
@@ -192,12 +222,15 @@ mulEncoding :: (Expr EWord -> Err Builder) -> [Prop] -> Err [SMTEntry]
 mulEncoding enc props = do
   let udivs = [ (a, b) | (IsUDiv, a, b) <- nubOrd $ concatMap (foldProp collectDivMods []) props ]
       muls  = nubOrd $ concatMap (foldProp collectMuls []) props
+      constMuls = nubOrd $ concatMap (foldProp collectConstMuls []) props
       -- products the div-link lemma introduces, e.g. (a/b)*b
       linkMuls = [ (T.Div a b, b) | (a, b) <- udivs ]
       allMuls  = nubOrd (muls <> linkMuls)
       -- divisions whose dividend is an abstract product: (x*y)/z
       mulDivs = [ (a, x, y, b) | (a, b) <- udivs, Just (x, y) <- [asMul a] ]
-  if null udivs && null muls then pure []
+      -- pairs of const-muls sharing the same constant: (c, x, y) for c*x, c*y
+      constMulPairs = [ (c, x, y) | (c, x) <- constMuls, (c', y) <- constMuls, c == c', x /= y ]
+  if null udivs && null muls && null constMuls then pure []
   else do
     comm    <- mapM mkComm allMuls
     links   <- mapM mkDivMulLink udivs
@@ -206,8 +239,9 @@ mulEncoding enc props = do
     divMono <- concat <$> mapM mkDivMono (sharedPairs udivs)
     divDivisorMono <- concat <$> mapM mkDivisorMono (divisorPairs udivs)
     mulDivB <- concat <$> mapM mkMulDivBound mulDivs
+    constMulMono <- mapM mkConstMulMono constMulPairs
     pure $ (SMTComment "multiplication abstraction lemmas")
-           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB)
+           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono)
   where
     -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
     -- lemma terms match the props regardless of the simplifier's operand order.
@@ -253,6 +287,21 @@ mulEncoding enc props = do
       -- forward: x <= y  =>  x*z <= y*z
       pure [ SMTCommand $ "(assert (=> (and" `sp` mulNoOverflow xenc zenc `sp` mulNoOverflow yenc zenc
              <> " (bvule" `sp` xenc `sp` yenc <> ")) (bvule" `sp` mxz `sp` myz <> ")))" ]
+
+    -- const-mul monotonicity (sound, no-overflow guarded): for a fixed literal
+    -- constant c, x <= y  =>  c*x <= c*y. Because c is concrete we compute the
+    -- exact no-overflow bound floor((2^256-1)/c) at encode time, so the guard is
+    -- a single comparison against a constant (cheap) rather than a 512-bit
+    -- multiply. c*x stays a native bvmul; this lemma simply lets the solver
+    -- order two such products without bit-blasting the multiply.
+    mkConstMulMono (c, x, y) = do
+      xe <- enc x; ye <- enc y
+      let cbv  = wordAsBV c
+          cx   = "(bvmul" `sp` cbv `sp` xe <> ")"
+          cy   = "(bvmul" `sp` cbv `sp` ye <> ")"
+          bnd  = wordAsBV ((maxBound :: W256) `div` c)  -- largest x with c*x < 2^256
+      pure $ SMTCommand $ "(assert (=> (and (bvule" `sp` xe `sp` bnd <> ") (bvule" `sp` ye `sp` bnd <> ")"
+             <> " (bvule" `sp` xe `sp` ye <> ")) (bvule" `sp` cx `sp` cy <> ")))"
 
     -- div monotonicity in the dividend (sound unconditionally): for a common
     -- divisor z, x <= y  =>  floor(x/z) <= floor(y/z).

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -195,6 +195,8 @@ mulEncoding enc props = do
       -- products the div-link lemma introduces, e.g. (a/b)*b
       linkMuls = [ (T.Div a b, b) | (a, b) <- udivs ]
       allMuls  = nubOrd (muls <> linkMuls)
+      -- divisions whose dividend is an abstract product: (x*y)/z
+      mulDivs = [ (a, x, y, b) | (a, b) <- udivs, Just (x, y) <- [asMul a] ]
   if null udivs && null muls then pure []
   else do
     comm    <- mapM mkComm allMuls
@@ -202,8 +204,10 @@ mulEncoding enc props = do
     zeroOne <- concat <$> mapM mkMulIdentities allMuls
     mulMono <- concat <$> mapM mkMulMono (sharedPairs allMuls)
     divMono <- concat <$> mapM mkDivMono (sharedPairs udivs)
+    divDivisorMono <- concat <$> mapM mkDivisorMono (divisorPairs udivs)
+    mulDivB <- concat <$> mapM mkMulDivBound mulDivs
     pure $ (SMTComment "multiplication abstraction lemmas")
-           : (comm <> zeroOne <> links <> mulMono <> divMono)
+           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB)
   where
     -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
     -- lemma terms match the props regardless of the simplifier's operand order.
@@ -216,6 +220,21 @@ mulEncoding enc props = do
     sharedPairs :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord, Expr EWord)]
     sharedPairs xs = [ (x, y, z) | (x, z) <- xs, (y, z') <- xs, z == z', x /= y ]
 
+    -- ordered pairs (y1, y2, x) where (x,y1) and (x,y2) both occur (shared 1st
+    -- operand): divisions of the same dividend by different divisors.
+    divisorPairs :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord, Expr EWord)]
+    divisorPairs xs = [ (y1, y2, x) | (x, y1) <- xs, (x', y2) <- xs, x == x', y1 /= y2 ]
+
+    -- div anti-monotonicity in the divisor (sound for nonzero divisors): a
+    -- bigger divisor yields a smaller-or-equal quotient.
+    --   y1 <= y2 && y1 != 0  =>  x/y2 <= x/y1
+    mkDivisorMono (y1, y2, x) = do
+      y1e <- enc y1; y2e <- enc y2; xe <- enc x
+      let dxy1 = "(abst_evm_bvudiv" `sp` xe `sp` y1e <> ")"
+          dxy2 = "(abst_evm_bvudiv" `sp` xe `sp` y2e <> ")"
+      pure [ SMTCommand $ "(assert (=> (and (distinct" `sp` y1e `sp` zero <> ")"
+             <> " (bvule" `sp` y1e `sp` y2e <> ")) (bvule" `sp` dxy2 `sp` dxy1 <> ")))" ]
+
     -- mul monotonicity (guarded by no-overflow, hence sound): if neither x*z
     -- nor y*z overflows then x <= y  =>  x*z <= y*z. The guard is bound-free;
     -- bounding operands (e.g. a Solidity require) keeps it cheap to discharge.
@@ -223,6 +242,7 @@ mulEncoding enc props = do
       xenc <- enc x; yenc <- enc y; zenc <- enc z
       let mxz = "(abst_evm_bvmul" `sp` xenc `sp` zenc <> ")"
           myz = "(abst_evm_bvmul" `sp` yenc `sp` zenc <> ")"
+      -- forward: x <= y  =>  x*z <= y*z
       pure [ SMTCommand $ "(assert (=> (and" `sp` mulNoOverflow xenc zenc `sp` mulNoOverflow yenc zenc
              <> " (bvule" `sp` xenc `sp` yenc <> ")) (bvule" `sp` mxz `sp` myz <> ")))" ]
 
@@ -233,6 +253,24 @@ mulEncoding enc props = do
       let dxz = "(abst_evm_bvudiv" `sp` xenc `sp` zenc <> ")"
           dyz = "(abst_evm_bvudiv" `sp` yenc `sp` zenc <> ")"
       pure [ SMTCommand $ "(assert (=> (bvule" `sp` xenc `sp` yenc <> ") (bvule" `sp` dxz `sp` dyz <> ")))" ]
+    -- recognise an abstract symbolic*symbolic product
+    asMul :: Expr EWord -> Maybe (Expr EWord, Expr EWord)
+    asMul (T.Mul x y) | notLit x, notLit y = Just (x, y)
+    asMul _ = Nothing
+    notLit (Lit _) = False
+    notLit _       = True
+
+    -- mulDiv bound (sound under no-overflow of x*z): if one factor is <= the
+    -- divisor then dividing the product by it cannot exceed the other factor.
+    --   y <= z  =>  (x*y)/z <= x       x <= z  =>  (x*y)/z <= y
+    -- `a` is the original product expr, so the div term matches the prop exactly.
+    mkMulDivBound (a, x, y, z) = do
+      ae <- enc a; xe <- enc x; ye <- enc y; ze <- enc z
+      let dv = "(abst_evm_bvudiv" `sp` ae `sp` ze <> ")"
+      pure [ SMTCommand $ "(assert (=> (and (bvule" `sp` ye `sp` ze <> ")" `sp` mulNoOverflow xe ze
+               <> ") (bvule" `sp` dv `sp` xe <> ")))"
+           , SMTCommand $ "(assert (=> (and (bvule" `sp` xe `sp` ze <> ")" `sp` mulNoOverflow ye ze
+               <> ") (bvule" `sp` dv `sp` ye <> ")))" ]
     -- quotient*divisor <= dividend
     mkDivMulLink (a, b) = do
       aenc <- enc a

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -50,16 +50,15 @@ maxU128 = "(_ bv340282366920938463463374607431768211455 256)"
 -- We deliberately use this cheap sufficient condition rather than the exact
 -- no-overflow predicate @extract 511 256 (bvmul (zext x) (zext y)) = 0@. The
 -- exact form forces the solver to bit-blast a full 512-bit multiply for every
--- lemma instance, which is the dominant cost and makes realistic vault queries
--- (operands ~2^100, e.g. token amounts up to 1e30) time out. Two comparisons
--- against a constant are essentially free by contrast.
+-- lemma instance, which is the dominant cost and makes queries with large
+-- operands (~2^100) time out. Two comparisons against a constant are
+-- essentially free by contrast.
 --
 -- This is the same width-budget idea Halmos uses. It is SOUND: when the guard
 -- holds there is genuinely no overflow, so any lemma it gates remains valid.
 -- The cost is completeness — a product of operands above 2^128 that happens not
--- to overflow will not receive the lemma. All realistic token amounts, share
--- counts and conversion rates are far below 2^128, so this is not a limitation
--- in practice.
+-- to overflow will not receive the lemma. Callers bound operands (e.g. a
+-- Solidity @require(x < 2**128)@) so the guard discharges cheaply.
 mulNoOverflow :: Builder -> Builder -> Builder
 mulNoOverflow x y =
   "(and (bvule " <> x <> " " <> maxU128 <> ") (bvule " <> y <> " " <> maxU128 <> "))"

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -241,6 +241,9 @@ mulEncoding enc props = do
       mulDivs = [ (a, x, y, b) | (a, b) <- udivsAll, Just (x, y) <- [asMul a] ]
       -- pairs of const-muls sharing the same constant: (c, x, y) for c*x, c*y
       constMulPairs = [ (c, x, y) | (c, x) <- constMuls, (c', y) <- constMuls, c == c', x /= y ]
+      -- const cancellation: divisions (c*x)/c by the SAME literal constant c.
+      -- (a, c, x): a is the division's dividend (c*x), divided by Lit c.
+      constCancels = [ (a, c, x) | (a, b) <- udivsAll, Just (c, x) <- [asConstMul a], b == Lit c ]
   if null udivs && null muls && null constMuls then pure []
   else do
     comm    <- mapM mkComm allMuls
@@ -251,8 +254,9 @@ mulEncoding enc props = do
     divDivisorMono <- concat <$> mapM mkDivisorMono (divisorPairs udivsAll)
     mulDivB <- concat <$> mapM mkMulDivBound mulDivs
     constMulMono <- mapM mkConstMulMono constMulPairs
+    constCancel <- mapM mkConstCancel constCancels
     pure $ (SMTComment "multiplication abstraction lemmas")
-           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono)
+           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel)
   where
     -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
     -- lemma terms match the props regardless of the simplifier's operand order.
@@ -313,6 +317,27 @@ mulEncoding enc props = do
           bnd  = wordAsBV ((maxBound :: W256) `div` c)  -- largest x with c*x < 2^256
       pure $ SMTCommand $ "(assert (=> (and (bvule" `sp` xe `sp` bnd <> ") (bvule" `sp` ye `sp` bnd <> ")"
              <> " (bvule" `sp` xe `sp` ye <> ")) (bvule" `sp` cx `sp` cy <> ")))"
+
+    -- const cancellation (sound, no-overflow guarded): dividing a product by the
+    -- same literal constant it was multiplied by is the identity, (c*x)/c == x.
+    -- The multiply by a constant stays a native bvmul but the divide is
+    -- abstracted (uninterpreted), so without this the wrapper c*x/c that appears
+    -- in precision scaling (e.g. amount * 1e18 / 1e18 in _getUsdsValue) is not
+    -- provably the identity. `a` is the dividend expr (c*x) so the abst_evm_bvudiv
+    -- term matches the prop exactly; the exact no-overflow bound floor((2^256-1)/c)
+    -- is computed at encode time, so the guard is a single constant comparison.
+    mkConstCancel (a, c, x) = do
+      ae <- enc a; xe <- enc x
+      let cbv = wordAsBV c
+          dv  = "(abst_evm_bvudiv" `sp` ae `sp` cbv <> ")"
+          bnd = wordAsBV ((maxBound :: W256) `div` c)  -- largest x with c*x < 2^256
+      pure $ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` xe <> ")))"
+
+    -- recognise multiplication by a non-trivial literal constant: c*x or x*c.
+    asConstMul :: Expr EWord -> Maybe (W256, Expr EWord)
+    asConstMul (T.Mul (Lit c) x) | notLit x, c /= 0, c /= 1 = Just (c, x)
+    asConstMul (T.Mul x (Lit c)) | notLit x, c /= 0, c /= 1 = Just (c, x)
+    asConstMul _ = Nothing
 
     -- div monotonicity in the dividend (sound unconditionally): for a common
     -- divisor z, x <= y  =>  floor(x/z) <= floor(y/z).

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -264,6 +264,15 @@ mulEncoding enc props = do
                     | (a, b) <- udivsAll, Just (c1, x) <- [asConstMul a]
                     , Lit c2 <- [b], c2 /= 0, c1 /= 0
                     , c2 `mod` c1 == 0, c2 /= c1 ]
+      -- ceilDiv-cancel: OpenZeppelin Math.ceilDiv(c1*x, c2) is
+      -- (c1*x == 0) ? 0 : (c1*x - 1)/c2 + 1, so the abstracted divide is over the
+      -- (c1*x - 1) dividend. When c2 | c1 the product c1*x is always a multiple of
+      -- c2, hence ceil == floor and the whole ceilDiv collapses to (c1/c2)*x. We
+      -- pin the inner divide: (a, c1, c2, x) with a == (c1*x) - 1.
+      ceilDivCancels = [ (a, c1, c2, x)
+                       | (a, b) <- udivsAll, T.Sub inner (Lit 1) <- [a]
+                       , Just (c1, x) <- [asConstMul inner]
+                       , Lit c2 <- [b], c2 /= 0, c1 `mod` c2 == 0 ]
   if null udivs && null muls && null constMuls then pure []
   else do
     comm    <- mapM mkComm allMuls
@@ -277,8 +286,9 @@ mulEncoding enc props = do
     constCancel <- mapM mkConstCancel constCancels
     nestedDiv <- mapM mkNestedDiv nestedDivs
     fracReduce <- mapM mkFracReduce fracReduces
+    ceilDivCancel <- mapM mkCeilDivCancel ceilDivCancels
     pure $ (SMTComment "multiplication abstraction lemmas")
-           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel <> nestedDiv <> fracReduce)
+           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel <> nestedDiv <> fracReduce <> ceilDivCancel)
   where
     -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
     -- lemma terms match the props regardless of the simplifier's operand order.
@@ -383,6 +393,25 @@ mulEncoding enc props = do
           rhs  = "(abst_evm_bvudiv" `sp` xe `sp` wordAsBV k <> ")"    -- x/(c2/c1)
           bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
       pure $ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` rhs <> ")))"
+
+    -- ceilDiv-cancel (sound, guarded): pins the abstracted divide inside
+    -- OpenZeppelin's Math.ceilDiv(c1*x, c2) = (c1*x - 1)/c2 + 1 (the c1*x != 0
+    -- branch). `a` is the (c1*x - 1) dividend. When c2 | c1, write c1 = c2*m: then
+    -- c1*x = c2*(m*x), so floor((c2*m*x - 1)/c2) = m*x - 1 (for m*x >= 1). Adding
+    -- the ceilDiv's +1 gives m*x = (c1/c2)*x exactly. Guarded by x >= 1 (the ceilDiv
+    -- ITE handles x==0 on its own branch) and the encode-time no-overflow bound
+    -- floor((2^256-1)/c1). This is the ceilDiv sibling of const-cancel; it
+    -- discharges the round-up swap-out closed forms (e.g. previewSwapExactOut
+    -- usds->usdc == amountOut*1e12).
+    mkCeilDivCancel (a, c1, c2, x) = do
+      ae <- enc a; xe <- enc x
+      let m    = c1 `div` c2                 -- exact, since c2 | c1
+          mx   = if m == 1 then xe else "(bvmul" `sp` wordAsBV m `sp` xe <> ")"
+          dv   = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c2 <> ")"   -- (c1*x - 1)/c2
+          rhs  = "(bvsub" `sp` mx `sp` one <> ")"                     -- (c1/c2)*x - 1
+          bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
+      pure $ SMTCommand $ "(assert (=> (and (bvuge" `sp` xe `sp` one <> ")"
+             <> " (bvule" `sp` xe `sp` bnd <> ")) (=" `sp` dv `sp` rhs <> ")))"
 
     -- recognise multiplication by a non-trivial literal constant: c*x or x*c.
     asConstMul :: Expr EWord -> Maybe (W256, Expr EWord)

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -202,7 +202,7 @@ mulEncoding enc props = do
     comm    <- mapM mkComm allMuls
     links   <- mapM mkDivMulLink udivs
     zeroOne <- concat <$> mapM mkMulIdentities allMuls
-    mulMono <- concat <$> mapM mkMulMono (sharedPairs allMuls)
+    mulMono <- concat <$> mapM mkMulMono (sharedPairs (bothOrders allMuls))
     divMono <- concat <$> mapM mkDivMono (sharedPairs udivs)
     divDivisorMono <- concat <$> mapM mkDivisorMono (divisorPairs udivs)
     mulDivB <- concat <$> mapM mkMulDivBound mulDivs
@@ -216,6 +216,14 @@ mulEncoding enc props = do
       let m1 = "(abst_evm_bvmul" `sp` aenc `sp` benc <> ")"
           m2 = "(abst_evm_bvmul" `sp` benc `sp` aenc <> ")"
       pure $ SMTCommand $ "(assert (=" `sp` m1 `sp` m2 <> "))"
+    -- Include both operand orders of each product. Multiplication is
+    -- commutative (and we assert that), but the simplifier/solc may order a
+    -- product's operands either way; considering both ensures monotonicity is
+    -- found regardless of ordering. Only used for the (commutative) mul lemmas,
+    -- never for the order-sensitive division lemmas.
+    bothOrders :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord)]
+    bothOrders xs = nubOrd (xs <> [ (b, a) | (a, b) <- xs ])
+
     -- ordered pairs (x, y, z) where (x,z) and (y,z) both occur (shared 2nd operand)
     sharedPairs :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord, Expr EWord)]
     sharedPairs xs = [ (x, y, z) | (x, z) <- xs, (y, z') <- xs, z == z', x /= y ]

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -255,6 +255,15 @@ mulEncoding enc props = do
                    | (a, b) <- udivsAll, Lit c2 <- [b]
                    , T.Div innerA (Lit c1) <- [a]
                    , c1 /= 0, c2 /= 0, toInteger c1 * toInteger c2 < 2 ^ (256 :: Int) ]
+      -- fraction-reduce: a product c1*x divided by a literal c2 that c1 divides
+      -- collapses to x/(c2/c1). The mirror of const-cancel (c2 | c1); this is the
+      -- c1 | c2 case (multiply by small, divide by large) such as x*1e6/1e18 ==
+      -- x/1e12 (precision scaling DOWN, the convert-to-usdc direction). Excludes
+      -- c1==c2, which const-cancel already covers (collapsing to x).
+      fracReduces = [ (a, c1, c2, x)
+                    | (a, b) <- udivsAll, Just (c1, x) <- [asConstMul a]
+                    , Lit c2 <- [b], c2 /= 0, c1 /= 0
+                    , c2 `mod` c1 == 0, c2 /= c1 ]
   if null udivs && null muls && null constMuls then pure []
   else do
     comm    <- mapM mkComm allMuls
@@ -267,8 +276,9 @@ mulEncoding enc props = do
     constMulMono <- mapM mkConstMulMono constMulPairs
     constCancel <- mapM mkConstCancel constCancels
     nestedDiv <- mapM mkNestedDiv nestedDivs
+    fracReduce <- mapM mkFracReduce fracReduces
     pure $ (SMTComment "multiplication abstraction lemmas")
-           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel <> nestedDiv)
+           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel <> nestedDiv <> fracReduce)
   where
     -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
     -- lemma terms match the props regardless of the simplifier's operand order.
@@ -356,6 +366,23 @@ mulEncoding enc props = do
           outer    = "(abst_evm_bvudiv" `sp` inner `sp` wordAsBV c2 <> ")"
           collapsed = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV (c1 * c2) <> ")"
       pure $ SMTCommand $ "(assert (=" `sp` outer `sp` collapsed <> "))"
+
+    -- fraction-reduce (sound, no-overflow guarded): a product c1*x divided by a
+    -- literal c2 that c1 divides collapses to x/(c2/c1). The mirror of const
+    -- cancellation: const-cancel needs c2 | c1 (multiply by large, divide by
+    -- small, e.g. x*1e18/1e6 == x*1e12); this needs c1 | c2 (multiply by small,
+    -- divide by large, e.g. x*1e6/1e18 == x/1e12 — the convert-to-usdc precision
+    -- step). Sound because, under the no-overflow guard, c1*x is exact and
+    -- floor(c1*x / (c1*k)) = floor(x/k). `a` is the dividend (c1*x) so the
+    -- abst_evm_bvudiv term matches the prop; c1 | c2 makes c2/c1 exact and the
+    -- bound floor((2^256-1)/c1) is computed at encode time (one comparison).
+    mkFracReduce (a, c1, c2, x) = do
+      ae <- enc a; xe <- enc x
+      let k    = c2 `div` c1                 -- exact and >= 2, since c1 | c2 and c2 /= c1
+          dv   = "(abst_evm_bvudiv" `sp` ae `sp` wordAsBV c2 <> ")"   -- (c1*x)/c2
+          rhs  = "(abst_evm_bvudiv" `sp` xe `sp` wordAsBV k <> ")"    -- x/(c2/c1)
+          bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
+      pure $ SMTCommand $ "(assert (=> (bvule" `sp` xe `sp` bnd <> ") (=" `sp` dv `sp` rhs <> ")))"
 
     -- recognise multiplication by a non-trivial literal constant: c*x or x*c.
     asConstMul :: Expr EWord -> Maybe (W256, Expr EWord)

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -3,6 +3,8 @@ module EVM.SMT.DivModEncoding
   ( divModGroundTruth
   , divModEncoding
   , divModAbstractDecls
+  , mulEncoding
+  , hasAbstractMul
   ) where
 
 import Data.Bits (countTrailingZeros)
@@ -24,6 +26,8 @@ divModAbstractDecls =
   , SMTCommand "(declare-fun abst_evm_bvsrem ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
   , SMTCommand "(declare-fun abst_evm_bvudiv ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
   , SMTCommand "(declare-fun abst_evm_bvurem ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
+  , SMTComment "abstract multiplication (kept fully uninterpreted: no ground truth)"
+  , SMTCommand "(declare-fun abst_evm_bvmul ((_ BitVec 256) (_ BitVec 256)) (_ BitVec 256))"
   ]
 
 -- | Local helper for trivial SMT constructs
@@ -32,6 +36,17 @@ a `sp` b = a <> " " <> b
 
 zero :: Builder
 zero = "(_ bv0 256)"
+
+one :: Builder
+one = "(_ bv1 256)"
+
+-- | True iff x*y does not overflow 256 bits (high half of the 512-bit product
+-- is zero). This is bound-free: it does NOT bake in any particular width
+-- limit. Callers (e.g. a Solidity `require(x < 2**128)`) are responsible for
+-- bounding operands so that this predicate is cheap for the solver to discharge.
+mulNoOverflow :: Builder -> Builder -> Builder
+mulNoOverflow x y =
+  "(= ((_ extract 511 256) (bvmul ((_ zero_extend 256) " <> x <> ") ((_ zero_extend 256) " <> y <> "))) " <> zero <> ")"
 
 wordAsBV :: forall a. Integral a => a -> Builder
 wordAsBV w = "(_ bv" <> Data.Text.Lazy.Builder.Int.decimal w <> " 256)"
@@ -143,6 +158,99 @@ divModGroundTruth enc props = do
           -- signed reconstruction already applies the guard on its side.)
           concrete = if isSigned kind then native else smtZeroGuard benc native
       pure $ SMTCommand $ "(assert (=" `sp` abstract `sp` concrete <> "))"
+
+-- | Collect symbolic*symbolic multiplications (neither operand a literal).
+-- Concrete factors (incl. 0/1/power-of-two) are handled natively by the
+-- simplifier, so only genuinely symbolic products are abstracted.
+collectMuls :: Expr a -> [(Expr EWord, Expr EWord)]
+collectMuls = \case
+  T.Mul a b | notLit a, notLit b -> [(a, b)]
+  _ -> []
+  where
+    notLit (Lit _) = False
+    notLit _       = True
+
+-- | True if any prop contains a symbolic*symbolic multiplication, i.e. the
+-- multiplication abstraction is in play. Because abst_evm_bvmul is left
+-- uninterpreted (no ground truth), a satisfying model may assign it values
+-- inconsistent with real multiplication, so a counterexample cannot be
+-- trusted; callers must downgrade SAT results to Unknown to stay SOUND.
+hasAbstractMul :: [Prop] -> Bool
+hasAbstractMul props = not $ null $ concatMap (foldProp collectMuls []) props
+
+-- | Lemmas for abstract multiplication. Multiplication is kept fully
+-- uninterpreted (no ground truth, so the solver never bit-blasts a symbolic
+-- product); we add only sound algebraic facts. Commutativity is free because
+-- the simplifier canonically orders Mul operands, so abst_evm_bvmul(a,b) and
+-- abst_evm_bvmul(b,a) are the same term.
+--
+-- Step 1 lemma (sound unconditionally): quotient*divisor <= dividend, i.e.
+--   abst_evm_bvmul(abst_evm_bvudiv(X,Y), Y) <= X
+-- The product (X/Y)*Y <= X < 2^256 can never overflow, so no guard is needed.
+-- This is what links the div and mul abstractions and chains nested divisions.
+mulEncoding :: (Expr EWord -> Err Builder) -> [Prop] -> Err [SMTEntry]
+mulEncoding enc props = do
+  let udivs = [ (a, b) | (IsUDiv, a, b) <- nubOrd $ concatMap (foldProp collectDivMods []) props ]
+      muls  = nubOrd $ concatMap (foldProp collectMuls []) props
+      -- products the div-link lemma introduces, e.g. (a/b)*b
+      linkMuls = [ (T.Div a b, b) | (a, b) <- udivs ]
+      allMuls  = nubOrd (muls <> linkMuls)
+  if null udivs && null muls then pure []
+  else do
+    comm    <- mapM mkComm allMuls
+    links   <- mapM mkDivMulLink udivs
+    zeroOne <- concat <$> mapM mkMulIdentities allMuls
+    mulMono <- concat <$> mapM mkMulMono (sharedPairs allMuls)
+    divMono <- concat <$> mapM mkDivMono (sharedPairs udivs)
+    pure $ (SMTComment "multiplication abstraction lemmas")
+           : (comm <> zeroOne <> links <> mulMono <> divMono)
+  where
+    -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
+    -- lemma terms match the props regardless of the simplifier's operand order.
+    mkComm (a, b) = do
+      aenc <- enc a; benc <- enc b
+      let m1 = "(abst_evm_bvmul" `sp` aenc `sp` benc <> ")"
+          m2 = "(abst_evm_bvmul" `sp` benc `sp` aenc <> ")"
+      pure $ SMTCommand $ "(assert (=" `sp` m1 `sp` m2 <> "))"
+    -- ordered pairs (x, y, z) where (x,z) and (y,z) both occur (shared 2nd operand)
+    sharedPairs :: [(Expr EWord, Expr EWord)] -> [(Expr EWord, Expr EWord, Expr EWord)]
+    sharedPairs xs = [ (x, y, z) | (x, z) <- xs, (y, z') <- xs, z == z', x /= y ]
+
+    -- mul monotonicity (guarded by no-overflow, hence sound): if neither x*z
+    -- nor y*z overflows then x <= y  =>  x*z <= y*z. The guard is bound-free;
+    -- bounding operands (e.g. a Solidity require) keeps it cheap to discharge.
+    mkMulMono (x, y, z) = do
+      xenc <- enc x; yenc <- enc y; zenc <- enc z
+      let mxz = "(abst_evm_bvmul" `sp` xenc `sp` zenc <> ")"
+          myz = "(abst_evm_bvmul" `sp` yenc `sp` zenc <> ")"
+      pure [ SMTCommand $ "(assert (=> (and" `sp` mulNoOverflow xenc zenc `sp` mulNoOverflow yenc zenc
+             <> " (bvule" `sp` xenc `sp` yenc <> ")) (bvule" `sp` mxz `sp` myz <> ")))" ]
+
+    -- div monotonicity in the dividend (sound unconditionally): for a common
+    -- divisor z, x <= y  =>  floor(x/z) <= floor(y/z).
+    mkDivMono (x, y, z) = do
+      xenc <- enc x; yenc <- enc y; zenc <- enc z
+      let dxz = "(abst_evm_bvudiv" `sp` xenc `sp` zenc <> ")"
+          dyz = "(abst_evm_bvudiv" `sp` yenc `sp` zenc <> ")"
+      pure [ SMTCommand $ "(assert (=> (bvule" `sp` xenc `sp` yenc <> ") (bvule" `sp` dxz `sp` dyz <> ")))" ]
+    -- quotient*divisor <= dividend
+    mkDivMulLink (a, b) = do
+      aenc <- enc a
+      benc <- enc b
+      let q  = "(abst_evm_bvudiv" `sp` aenc `sp` benc <> ")"
+          qb = "(abst_evm_bvmul" `sp` q `sp` benc <> ")"
+      pure $ SMTCommand $ "(assert (bvule" `sp` qb `sp` aenc <> "))"
+    -- sound identities pinning the otherwise-free UF on 0/1 operands:
+    --   x*0 = 0, 0*y = 0, x*1 = x, 1*y = y
+    mkMulIdentities (a, b) = do
+      aenc <- enc a
+      benc <- enc b
+      let m = "(abst_evm_bvmul" `sp` aenc `sp` benc <> ")"
+      pure [ SMTCommand $ "(assert (=> (=" `sp` aenc `sp` zero <> ") (=" `sp` m `sp` zero  <> ")))"
+           , SMTCommand $ "(assert (=> (=" `sp` benc `sp` zero <> ") (=" `sp` m `sp` zero  <> ")))"
+           , SMTCommand $ "(assert (=> (=" `sp` aenc `sp` one  <> ") (=" `sp` m `sp` benc  <> ")))"
+           , SMTCommand $ "(assert (=> (=" `sp` benc `sp` one  <> ") (=" `sp` m `sp` aenc  <> ")))"
+           ]
 
 -- | Encode div/mod operations using abs values, shift-bounds, and congruence (no bvudiv).
 divModEncoding :: (Expr EWord -> Err Builder) -> [Prop] -> Err [SMTEntry]

--- a/src/EVM/SMT/DivModEncoding.hs
+++ b/src/EVM/SMT/DivModEncoding.hs
@@ -233,7 +233,18 @@ mulEncoding enc props = do
       divisors  = nubOrd [ b | (_, b) <- udivs ]
       synthDivs = nubOrd $ [ (T.Mul a b, b) | (a, b) <- muls, b `elem` divisors ]
                         <> [ (T.Mul a b, a) | (a, b) <- muls, a `elem` divisors ]
-      udivsAll  = nubOrd (udivs <> synthDivs)
+      -- Collapse a nested constant division (A/c1)/c2 into a synthetic single divide
+      -- A/(c1*c2), and add it to the div set. Sound because nested-div-collapse below
+      -- asserts the two forms equal, so the synthetic divide is exact. This lets the
+      -- single-divide lemmas (telescoping, const-cancel, fraction-reduce) match code
+      -- that splits precision across two divides — e.g. _getSUsdsValue's x*rate/1e9/1e18,
+      -- whose collapsed x*rate/1e27 is what those lemmas key on.
+      collapsedDivs = nubOrd
+        [ (innerA, Lit (c1 * c2))
+        | (a, b) <- udivs <> synthDivs, Lit c2 <- [b]
+        , T.Div innerA (Lit c1) <- [a]
+        , c1 /= 0, c2 /= 0, toInteger c1 * toInteger c2 < 2 ^ (256 :: Int) ]
+      udivsAll  = nubOrd (udivs <> synthDivs <> collapsedDivs)
       -- products the div-link lemma introduces, e.g. (a/b)*b
       linkMuls = [ (T.Div a b, b) | (a, b) <- udivsAll ]
       allMuls  = nubOrd (muls <> linkMuls)
@@ -273,6 +284,21 @@ mulEncoding enc props = do
                        | (a, b) <- udivsAll, T.Sub inner (Lit 1) <- [a]
                        , Just (c1, x) <- [asConstMul inner]
                        , Lit c2 <- [b], c2 /= 0, c1 `mod` c2 == 0 ]
+      -- scaled-product telescoping (sound, no-overflow guarded): two abstract
+      -- products sharing a factor a, whose other factors differ by a literal k that
+      -- the common divisor c divides, have an EXACT quotient difference:
+      -- (a*b)/c - (a*(b-k))/c == a*(k/c). This is the only lemma that relates two
+      -- DISTINCT abstract products, so it discharges value-change accounting
+      -- identities such as susds*rate/1e27 - susds == susds*(rate-1e27)/1e27 (rate
+      -- and rate-1e27 give unrelated abst_evm_bvmul terms otherwise). (a, b, k, c):
+      -- full product a*b, stepped product a*(b-k), divisor c, with c | k.
+      telescopes = nubOrd
+        [ (a, b, k, c)
+        | (sd, Lit c) <- udivsAll, c /= 0
+        , Just (f1, f2) <- [asMul sd]
+        , (a, T.Sub b (Lit k)) <- [(f1, f2), (f2, f1)]
+        , k /= 0, k `mod` c == 0
+        , any (`elem` udivsAll) [ (T.Mul a b, Lit c), (T.Mul b a, Lit c) ] ]
   if null udivs && null muls && null constMuls then pure []
   else do
     comm    <- mapM mkComm allMuls
@@ -287,8 +313,9 @@ mulEncoding enc props = do
     nestedDiv <- mapM mkNestedDiv nestedDivs
     fracReduce <- mapM mkFracReduce fracReduces
     ceilDivCancel <- mapM mkCeilDivCancel ceilDivCancels
+    telescope <- mapM mkTelescope telescopes
     pure $ (SMTComment "multiplication abstraction lemmas")
-           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel <> nestedDiv <> fracReduce <> ceilDivCancel)
+           : (comm <> zeroOne <> links <> mulMono <> divMono <> divDivisorMono <> mulDivB <> constMulMono <> constCancel <> nestedDiv <> fracReduce <> ceilDivCancel <> telescope)
   where
     -- commutativity: abst_evm_bvmul(a,b) = abst_evm_bvmul(b,a). Needed so that
     -- lemma terms match the props regardless of the simplifier's operand order.
@@ -412,6 +439,28 @@ mulEncoding enc props = do
           bnd  = wordAsBV ((maxBound :: W256) `div` c1)  -- largest x with c1*x < 2^256
       pure $ SMTCommand $ "(assert (=> (and (bvuge" `sp` xe `sp` one <> ")"
              <> " (bvule" `sp` xe `sp` bnd <> ")) (=" `sp` dv `sp` rhs <> ")))"
+
+    -- scaled-product telescoping (sound, no-overflow guarded). For products sharing
+    -- factor a whose other factors differ by a literal k with c | k:
+    --   floor(a*b/c) == floor(a*(b-k)/c) + a*(k/c).
+    -- Sound because a*b = a*(b-k) + a*k and a*k is an exact multiple of c (c | k), so
+    -- removing it shifts the floor by exactly a*(k/c). This is the only lemma pinning
+    -- the EXACT difference of two distinct abstract products; it discharges
+    -- value-change accounting like susds*rate/1e27 - susds == susds*(rate-1e27)/1e27.
+    -- Guarded by no-overflow on a*b (so a*(b-k), a*k all fit) and b >= k (so b-k is a
+    -- true difference, no wraparound).
+    mkTelescope (a, b, k, c) = do
+      ae <- enc a; be <- enc b
+      let m       = k `div` c                       -- exact, since c | k
+          cbv     = wordAsBV c
+          full    = "(abst_evm_bvmul" `sp` ae `sp` be <> ")"
+          stepped = "(abst_evm_bvmul" `sp` ae `sp` ("(bvsub" `sp` be `sp` wordAsBV k <> ")") <> ")"
+          dFull   = "(abst_evm_bvudiv" `sp` full `sp` cbv <> ")"
+          dStep   = "(abst_evm_bvudiv" `sp` stepped `sp` cbv <> ")"
+          coeff   = if m == 1 then ae else "(bvmul" `sp` wordAsBV m `sp` ae <> ")"
+          rhs     = "(bvadd" `sp` dStep `sp` coeff <> ")"
+      pure $ SMTCommand $ "(assert (=> (and" `sp` mulNoOverflow ae be
+             <> " (bvuge" `sp` be `sp` wordAsBV k <> ")) (=" `sp` dFull `sp` rhs <> ")))"
 
     -- recognise multiplication by a non-trivial literal constant: c*x or x*c.
     asConstMul :: Expr EWord -> Maybe (W256, Expr EWord)

--- a/src/EVM/Solvers.hs
+++ b/src/EVM/Solvers.hs
@@ -142,7 +142,17 @@ checkSatWithProps sg props = do
       else if isLeft refinement then pure $ Error $ getError refinement
       else do
         let x = (getNonError smt2Abstract) <> (SMT2 (SMTScript (getNonError refinement)) mempty mempty)
-        liftIO $ checkSat sg (Just props) (Right x)
+        res <- checkSat sg (Just props) (Right x)
+        -- SOUNDNESS: multiplication is abstracted as an uninterpreted function
+        -- with no ground truth, so a satisfying model may use product values
+        -- that do not match real multiplication. A QED stays sound (the lemmas
+        -- over-approximate real arithmetic), but a counterexample may be
+        -- spurious and must never be reported as a real violation; with nothing
+        -- to validate it against, the only sound output is Unknown.
+        pure $ case res of
+          Cex _ | hasAbstractMul allProps ->
+            Unknown "counterexample unsound under multiplication abstraction (abst_evm_bvmul is uninterpreted)"
+          _ -> res
 
 checkSat :: SolverGroup -> Maybe [Prop] -> Err SMT2 -> IO SMTResult
 checkSat (SolverGroup taskq) props smt2 = do

--- a/test/test.hs
+++ b/test/test.hs
@@ -1332,6 +1332,151 @@ tests = testGroup "hevm"
         (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertBoolM "Expected counterexample" (any isCex res)
     ]
+  , testGroup "Mul-Abstraction"
+    -- Symbolic*symbolic multiplication is abstracted as an uninterpreted
+    -- function (abst_evm_bvmul) with sound lemmas (commutativity, 0/1
+    -- identities, quotient*divisor<=dividend, no-overflow-guarded monotonicity)
+    -- and NO ground truth. This proves vault-style properties native solving
+    -- cannot, while staying SOUND: a QED is a real proof; spurious or
+    -- overflow-dependent results are never reported as bugs (downgraded to
+    -- Unknown). Bounding (e.g. require(x < 2**128)) is supplied in Solidity.
+    [ testAbstractArith "mul-monotone" $ do
+        -- a1 <= a2 => a1*c <= a2*c, under no-overflow (mul-monotonicity lemma)
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_mul_monotone(uint256 a1, uint256 a2, uint256 k) external pure {
+              require(a1 < (1<<128) && a2 < (1<<128) && k < (1<<128));
+              require(a1 <= a2);
+              uint256 p1; uint256 p2;
+              assembly { p1 := mul(a1, k)  p2 := mul(a2, k) }
+              assert(p1 <= p2);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "mul-by-zero" $ do
+        -- x*y == 0 when y == 0 (0-identity lemma; y is symbolic, not folded)
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_mul_zero(uint256 x, uint256 y) external pure {
+              require(y == 0);
+              uint256 p; assembly { p := mul(x, y) }
+              assert(p == 0);
+            }
+          } |]
+        (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "mul-by-one" $ do
+        -- x*y == x when y == 1 (1-identity lemma)
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_mul_one(uint256 x, uint256 y) external pure {
+              require(y == 1);
+              uint256 p; assembly { p := mul(x, y) }
+              assert(p == x);
+            }
+          } |]
+        (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "div-mul-link" $ do
+        -- (x/y)*y <= x for y != 0 (div x mul link lemma; needs commutativity)
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_div_mul_link(uint256 x, uint256 y) external pure {
+              require(y != 0);
+              uint256 q; uint256 p;
+              assembly { q := div(x, y)  p := mul(q, y) }
+              assert(p <= x);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testCase "vault-shares-monotonic" $ do
+        -- ERC-4626: more assets deposited => at least as many shares. Provable
+        -- WITH abstraction, native solving times out (unknown).
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            uint256 public totalAssets;
+            uint256 public totalShares;
+            function prove_shares_monotonic(uint256 a1, uint256 a2) external view {
+              require(totalAssets != 0);
+              require(a1 < (1<<128) && a2 < (1<<128) && totalShares < (1<<128));
+              require(a1 <= a2);
+              uint256 ts = totalShares; uint256 ta = totalAssets;
+              uint256 s1; uint256 s2;
+              assembly { s1 := div(mul(a1, ts), ta)  s2 := div(mul(a2, ts), ta) }
+              assert(s1 <= s2);
+            }
+          } |]
+        let testEnvAbstract = Env { config = testEnv.config { abstractArith = True } }
+        runEnv testEnvAbstract $ do
+          (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          assertEqualM "Must be QED with abstraction" [] res
+        runEnv testEnv $ do
+          (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+          liftIO $ assertBool "Must be unknown natively" (all isUnknown res)
+    , testAbstractArith "mul-overflow-not-unsound" $ do
+        -- SOUNDNESS: unbounded monotonicity is FALSE (raw mul wraps); the
+        -- no-overflow guard must prevent a (bogus) QED -> Unknown, never QED.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_mul_monotone_overflow(uint256 a1, uint256 a2, uint256 k) external pure {
+              require(a1 <= a2);
+              uint256 p1; uint256 p2;
+              assembly { p1 := mul(a1, k)  p2 := mul(a2, k) }
+              assert(p1 <= p2);
+            }
+          } |]
+        (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertBoolM "Must be Unknown, never QED (unsound proof avoided)"
+          (not (any isCex res) && any isUnknown res)
+    , testAbstractArith "roundtrip-spurious-cex-suppressed" $ do
+        -- SOUNDNESS: the cross-divisor round-trip cannot be discharged; the
+        -- uninterpreted mul yields a spurious model that must NOT be reported
+        -- as a counterexample -> Unknown.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            uint256 public totalAssets;
+            uint256 public totalShares;
+            function prove_roundtrip(uint256 assets) external view {
+              require(totalAssets != 0 && totalShares != 0);
+              require(assets < (1<<128) && totalShares < (1<<128) && totalAssets < (1<<128));
+              uint256 ts = totalShares; uint256 ta = totalAssets;
+              uint256 shares; uint256 outv;
+              assembly { shares := div(mul(assets, ts), ta)  outv := div(mul(shares, ta), ts) }
+              assert(outv <= assets);
+            }
+          } |]
+        (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertBoolM "Must be Unknown, never a spurious counterexample"
+          (not (any isCex res) && any isUnknown res)
+    , testAbstractArith "div-cex-preserved" $ do
+        -- No symbolic*symbolic mul => div is exact => a real counterexample is
+        -- still reported (the Cex->Unknown downgrade must be precise).
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_div_cex(uint256 a, uint256 b) external pure {
+              require(b != 0);
+              uint256 q; assembly { q := div(a, b) }
+              assert(q != 0);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertBoolM "Expected counterexample" (any isCex res)
+    , testAbstractArith "constmul-cex-preserved" $ do
+        -- Multiplication by a constant is NOT abstracted, so a real
+        -- counterexample is still reported.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_constmul_cex(uint256 x) external pure {
+              require(x < (1<<128));
+              uint256 p; assembly { p := mul(x, 3) }
+              assert(p != 6);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertBoolM "Expected counterexample" (any isCex res)
+    ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do
         Just c <- solcRuntime "C"

--- a/test/test.hs
+++ b/test/test.hs
@@ -1554,6 +1554,37 @@ tests = testGroup "hevm"
           } |]
         (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertEqualM "Must be QED" [] res
+    , testAbstractArith "const-cancel-scaled" $ do
+        -- generalized const-cancel: (c1*x)/c2 == (c1/c2)*x when c2 | c1.
+        -- (x*1e18)/1e6 == x*1e12 — discharges lossless precision scaling between
+        -- different decimals (e.g. _getUsdcValue).
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_const_cancel_scaled(uint256 x) external pure {
+              require(x < (1<<80));
+              uint256 y; uint256 z;
+              assembly { y := div(mul(x, 1000000000000000000), 1000000)  z := mul(x, 1000000000000) }
+              assert(y == z);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "nested-div-collapse" $ do
+        -- (A/c1)/c2 == A/(c1*c2) for literals c1,c2 (floor identity). With A a
+        -- symbolic product the divisions are abstracted, so the lemma is what
+        -- collapses chained constant divisions like x*rate/1e9/1e18 to x*rate/1e27.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_nested_div_collapse(uint256 a, uint256 b) external pure {
+              uint256 lhs; uint256 rhs;
+              assembly { let p := mul(a, b)
+                lhs := div(div(p, 1000000000), 1000000000000000000)
+                rhs := div(p, 1000000000000000000000000000) }
+              assert(lhs == rhs);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
     ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -1430,10 +1430,14 @@ tests = testGroup "hevm"
         (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertBoolM "Must be Unknown, never QED (unsound proof avoided)"
           (not (any isCex res) && any isUnknown res)
-    , testAbstractArith "roundtrip-spurious-cex-suppressed" $ do
-        -- SOUNDNESS: the cross-divisor round-trip cannot be discharged; the
-        -- uninterpreted mul yields a spurious model that must NOT be reported
-        -- as a counterexample -> Unknown.
+    , testAbstractArith "roundtrip-no-inflation" $ do
+        -- The cross-divisor round-trip convertToAssetValue(convertToShares(x)),
+        -- i.e. ((x*ts)/ta)*ta/ts <= x, is the stateless core of inflation-attack
+        -- safety: converting a value to shares and back never yields more than
+        -- you started with. It needs two nested divisions to be related, which
+        -- the cancellation synthesis (the synthetic (x*ts)/ts term plus div
+        -- monotonicity) discharges. SOUND: shares*ta <= x*ts (div-mul-link), so
+        -- floor(shares*ta/ts) <= floor(x*ts/ts) = x.
         Just c <- solcRuntime "C" [i|
           contract C {
             uint256 public totalAssets;
@@ -1447,9 +1451,8 @@ tests = testGroup "hevm"
               assert(outv <= assets);
             }
           } |]
-        (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
-        assertBoolM "Must be Unknown, never a spurious counterexample"
-          (not (any isCex res) && any isUnknown res)
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
     , testAbstractArith "div-cex-preserved" $ do
         -- No symbolic*symbolic mul => div is exact => a real counterexample is
         -- still reported (the Cex->Unknown downgrade must be precise).

--- a/test/test.hs
+++ b/test/test.hs
@@ -1451,7 +1451,8 @@ tests = testGroup "hevm"
               assert(outv <= assets);
             }
           } |]
-        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        -- z3 closes the nested cross-divisor round-trip reliably here.
+        (_, res) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertEqualM "Must be QED" [] res
     , testAbstractArith "div-cex-preserved" $ do
         -- No symbolic*symbolic mul => div is exact => a real counterexample is
@@ -1537,7 +1538,9 @@ tests = testGroup "hevm"
               assert(a1 <= a2);
             }
           } |]
-        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        -- z3 discharges the large-constant (1e27) multiply that bitwuzla
+        -- struggles with here; both are sound, this is purely a capability pick.
+        (_, res) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertEqualM "Must be QED" [] res
     ]
   , testGroup "max-iterations"

--- a/test/test.hs
+++ b/test/test.hs
@@ -1453,33 +1453,6 @@ tests = testGroup "hevm"
           } |]
         (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertEqualM "Must be QED" [] res
-    , testAbstractArith "roundtrip-checked-realcode" $ do
-        -- Same round-trip on real-code-shaped Solidity: ordinary checked
-        -- arithmetic (so each `*` carries the 0.8 overflow guard div(mul(a,b),a))
-        -- and the conversions are real functions that read storage, called as in
-        -- the contract. Confirms the cancellation synthesis survives the extra
-        -- overflow-guard divisions, i.e. the property proves on the code as
-        -- written, not only on raw assembly ops.
-        Just c <- solcRuntime "C" [i|
-          contract C {
-            uint256 public totalShares;
-            uint256 public totalAssets;
-            function convertToShares(uint256 assetValue) public view returns (uint256) {
-              if (totalAssets != 0) return assetValue * totalShares / totalAssets;
-              return assetValue;
-            }
-            function convertToAssetValue(uint256 numShares) public view returns (uint256) {
-              if (totalShares != 0) return numShares * totalAssets / totalShares;
-              return numShares;
-            }
-            function prove_roundtrip(uint256 x) external view {
-              require(totalShares != 0 && totalAssets != 0);
-              require(x < (1<<128) && totalShares < (1<<128) && totalAssets < (1<<128));
-              assert(convertToAssetValue(convertToShares(x)) <= x);
-            }
-          } |]
-        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
-        assertEqualM "Must be QED" [] res
     , testAbstractArith "div-cex-preserved" $ do
         -- No symbolic*symbolic mul => div is exact => a real counterexample is
         -- still reported (the Cex->Unknown downgrade must be precise).
@@ -1550,7 +1523,6 @@ tests = testGroup "hevm"
         -- by a large literal (1e27), which stays a native bvmul; const-mul
         -- monotonicity lets the solver order the two dividends without
         -- bit-blasting that multiply, which is otherwise the bottleneck.
-        -- Mirrors spark-psm convertToAssets(sUSDS): value * 1e9 * 1e18 / rate.
         Just c <- solcRuntime "C" [i|
           contract C {
             function prove_constmul_div_monotone(uint256 v1, uint256 v2, uint256 rate) external pure {

--- a/test/test.hs
+++ b/test/test.hs
@@ -1476,6 +1476,45 @@ tests = testGroup "hevm"
           } |]
         (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertBoolM "Expected counterexample" (any isCex res)
+    , testAbstractArith "div-divisor-monotone" $ do
+        -- a bigger divisor yields a smaller-or-equal quotient (div anti-monotonicity)
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_divisor_monotone(uint256 amt, uint256 p1, uint256 p2) external pure {
+              require(p1 != 0 && p2 != 0);
+              require(p1 <= p2);
+              uint256 q1; uint256 q2;
+              assembly { q1 := div(amt, p1)  q2 := div(amt, p2) }
+              assert(q2 <= q1);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "muldiv-fee-cap" $ do
+        -- a fee of feeBps/10000 never exceeds the principal (mulDiv bound)
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_fee_le(uint256 amount, uint256 feeBps) external pure {
+              require(amount < (1<<128) && feeBps <= 10000);
+              uint256 fee; assembly { fee := div(mul(amount, feeBps), 10000) }
+              assert(fee <= amount);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "muldiv-fee-uncapped-not-unsound" $ do
+        -- SOUNDNESS: without the feeBps <= 100% bound the property is false; the
+        -- mulDiv guard must not fire, so this must NOT be proved.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_fee_uncapped(uint256 amount, uint256 feeBps) external pure {
+              require(amount < (1<<128));
+              uint256 fee; assembly { fee := div(mul(amount, feeBps), 10000) }
+              assert(fee <= amount);
+            }
+          } |]
+        (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertBoolM "Must be Unknown, never QED" (not (any isCex res) && any isUnknown res)
     ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -1651,6 +1651,41 @@ tests = testGroup "hevm"
           } |]
         (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertBoolM "Wrong closed form must not be QED" (not (null res))
+    , testAbstractArith "scaled-product-telescope" $ do
+        -- scaled-product telescoping: a*b/c - a*(b-k)/c == a*(k/c) when c | k (here
+        -- c == k == 1e27, so the coefficient is a). This is the ONLY lemma that
+        -- relates two DISTINCT abstract products (a*b and a*(b-1e27), both
+        -- symbolic*symbolic), so it discharges value-change accounting identities
+        -- like s*rate/1e27 - s == s*(rate-1e27)/1e27 (the third assertion of an
+        -- ERC4626 conversionRate test).
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_telescope(uint256 s, uint256 q) external pure {
+              require(s <= 1000000000000000000000000000000);   // 1e30
+              require(q >= 1000000000000000000000000000);      // 1e27
+              require(q <= 1000000000000000000000000000000);   // 1e30
+              assert(s * q / 1000000000000000000000000000 - s
+                  == s * (q - 1000000000000000000000000000) / 1000000000000000000000000000);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "scaled-product-telescope-not-unsound" $ do
+        -- soundness guard: a wrong difference (+1) must stay Unknown, never QED.
+        -- Both products are abstract, so a violation downgrades SAT->Unknown rather
+        -- than producing a trusted Cex; the lemma must not over-prove the off-by-one.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_telescope_wrong(uint256 s, uint256 q) external pure {
+              require(s <= 1000000000000000000000000000000);
+              require(q >= 1000000000000000000000000000);
+              require(q <= 1000000000000000000000000000000);
+              assert(s * q / 1000000000000000000000000000 - s
+                  == s * (q - 1000000000000000000000000000) / 1000000000000000000000000000 + 1);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertBoolM "Wrong difference must be Unknown, never QED" (not (any isCex res) && any isUnknown res)
     ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -1585,6 +1585,37 @@ tests = testGroup "hevm"
           } |]
         (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertEqualM "Must be QED" [] res
+    , testAbstractArith "fraction-reduce" $ do
+        -- fraction-reduce: (c1*x)/c2 == x/(c2/c1) when c1 | c2 (mirror of
+        -- const-cancel, which needs c2 | c1). (x*1e6)/1e18 == x/1e12 — discharges
+        -- the precision step that scales DOWN to fewer decimals (convert-to-usdc).
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_fraction_reduce(uint256 x) external pure {
+              require(x < (1<<128));
+              uint256 y; uint256 z;
+              assembly { y := div(mul(x, 1000000), 1000000000000000000)  z := div(x, 1000000000000) }
+              assert(y == z);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "fraction-reduce-cex" $ do
+        -- soundness guard: the fraction-reduce lemma must not over-prove. A wrong
+        -- closed form ((x*1e6)/1e18 == x/1e12 + 1) is false for every x, so it
+        -- must NOT come back QED (the lemma pins the LHS to x/1e12, exposing the
+        -- off-by-one as a real counterexample rather than a spurious proof).
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_fraction_reduce_wrong(uint256 x) external pure {
+              require(x < (1<<128));
+              uint256 y; uint256 z;
+              assembly { y := div(mul(x, 1000000), 1000000000000000000)  z := add(div(x, 1000000000000), 1) }
+              assert(y == z);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertBoolM "Wrong closed form must not be QED" (not (null res))
     ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -1451,8 +1451,34 @@ tests = testGroup "hevm"
               assert(outv <= assets);
             }
           } |]
-        -- z3 closes the nested cross-divisor round-trip reliably here.
-        (_, res) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "roundtrip-checked-realcode" $ do
+        -- Same round-trip on real-code-shaped Solidity: ordinary checked
+        -- arithmetic (so each `*` carries the 0.8 overflow guard div(mul(a,b),a))
+        -- and the conversions are real functions that read storage, called as in
+        -- the contract. Confirms the cancellation synthesis survives the extra
+        -- overflow-guard divisions, i.e. the property proves on the code as
+        -- written, not only on raw assembly ops.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            uint256 public totalShares;
+            uint256 public totalAssets;
+            function convertToShares(uint256 assetValue) public view returns (uint256) {
+              if (totalAssets != 0) return assetValue * totalShares / totalAssets;
+              return assetValue;
+            }
+            function convertToAssetValue(uint256 numShares) public view returns (uint256) {
+              if (totalShares != 0) return numShares * totalAssets / totalShares;
+              return numShares;
+            }
+            function prove_roundtrip(uint256 x) external view {
+              require(totalShares != 0 && totalAssets != 0);
+              require(x < (1<<128) && totalShares < (1<<128) && totalAssets < (1<<128));
+              assert(convertToAssetValue(convertToShares(x)) <= x);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertEqualM "Must be QED" [] res
     , testAbstractArith "div-cex-preserved" $ do
         -- No symbolic*symbolic mul => div is exact => a real counterexample is
@@ -1538,9 +1564,7 @@ tests = testGroup "hevm"
               assert(a1 <= a2);
             }
           } |]
-        -- z3 discharges the large-constant (1e27) multiply that bitwuzla
-        -- struggles with here; both are sound, this is purely a capability pick.
-        (_, res) <- withDefaultSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertEqualM "Must be QED" [] res
     ]
   , testGroup "max-iterations"

--- a/test/test.hs
+++ b/test/test.hs
@@ -1616,6 +1616,41 @@ tests = testGroup "hevm"
           } |]
         (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertBoolM "Wrong closed form must not be QED" (not (null res))
+    , testAbstractArith "ceildiv-cancel" $ do
+        -- ceilDiv-cancel: Math.ceilDiv(c1*x, c2) == (c1/c2)*x when c2 | c1 (the
+        -- product is always divisible, so round-up equals round-down). The divide is
+        -- abstracted over the (c1*x - 1) dividend, so the lemma pins it. Discharges
+        -- the round-up multiply-up in previewSwapExactOut (e.g. usds->usdc == x*1e12).
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+              return a == 0 ? 0 : (a - 1) / b + 1;
+            }
+            function prove_ceildiv_cancel(uint256 x) external pure {
+              require(x < (1<<128));
+              uint256 y = ceilDiv(x * 1000000000000000000, 1000000);
+              uint256 z; unchecked { z = x * 1000000000000; }
+              assert(y == z);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
+    , testAbstractArith "ceildiv-cancel-cex" $ do
+        -- soundness guard: a wrong closed form (off by one) must NOT be QED.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function ceilDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+              return a == 0 ? 0 : (a - 1) / b + 1;
+            }
+            function prove_ceildiv_cancel_wrong(uint256 x) external pure {
+              require(x < (1<<128));
+              uint256 y = ceilDiv(x * 1000000000000000000, 1000000);
+              uint256 z; unchecked { z = x * 1000000000000 + 1; }
+              assert(y == z);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertBoolM "Wrong closed form must not be QED" (not (null res))
     ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -1515,6 +1515,27 @@ tests = testGroup "hevm"
           } |]
         (_, res) <- withShortBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertBoolM "Must be Unknown, never QED" (not (any isCex res) && any isUnknown res)
+    , testAbstractArith "constmul-div-monotone" $ do
+        -- (v * 1e27) / rate is monotonic in v. The dividend is a multiplication
+        -- by a large literal (1e27), which stays a native bvmul; const-mul
+        -- monotonicity lets the solver order the two dividends without
+        -- bit-blasting that multiply, which is otherwise the bottleneck.
+        -- Mirrors spark-psm convertToAssets(sUSDS): value * 1e9 * 1e18 / rate.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_constmul_div_monotone(uint256 v1, uint256 v2, uint256 rate) external pure {
+              require(rate != 0);
+              require(v1 <= v2 && v2 < (1<<80));
+              uint256 a1; uint256 a2;
+              assembly {
+                a1 := div(mul(v1, 1000000000000000000000000000), rate)
+                a2 := div(mul(v2, 1000000000000000000000000000), rate)
+              }
+              assert(a1 <= a2);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
     ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do

--- a/test/test.hs
+++ b/test/test.hs
@@ -1538,6 +1538,22 @@ tests = testGroup "hevm"
           } |]
         (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
         assertEqualM "Must be QED" [] res
+    , testAbstractArith "const-cancel" $ do
+        -- (x * c) / c == x for a literal c (const-cancellation lemma). The
+        -- multiply by c stays a native bvmul but the divide is abstracted
+        -- (uninterpreted), so without the lemma this identity is not provable.
+        -- This is what discharges precision-scaling wrappers like
+        -- `amount * 1e18 / 1e18` that otherwise block round-trip properties.
+        Just c <- solcRuntime "C" [i|
+          contract C {
+            function prove_const_cancel(uint256 x) external pure {
+              require(x < (1<<128));
+              uint256 y; assembly { y := div(mul(x, 1000000000000000000), 1000000000000000000) }
+              assert(y == x);
+            }
+          } |]
+        (_, res) <- withBitwuzlaSolver $ \s -> checkAssert s defaultPanicCodes c Nothing [] defaultVeriOpts
+        assertEqualM "Must be QED" [] res
     ]
   , testGroup "max-iterations"
     [ test "concrete-loops-reached" $ do


### PR DESCRIPTION
## Description

Stacked on #996 (base branch `poc-div-encoding`). Extends the arithmetic
abstraction from division to **multiplication** — the missing piece for
verifying vault-style (ERC-4626) properties, where the hard part is the
nonlinear `q·S ≤ q·A` cancellation, not the division itself.

Symbolic×symbolic `Mul` is encoded as an uninterpreted function
`abst_evm_bvmul` (concrete / `0` / `1` / power-of-two factors stay native), with
**no ground truth**, so the solver never bit-blasts a symbolic product. Meaning
is given by sound lemmas only:

- commutativity, and `0`/`1` identities (`x*0 == 0`, `x*1 == x`)
- div×mul link: `(x/y)*y <= x`
- division monotonicity in the dividend, and anti-monotonicity in the divisor
- multiplication monotonicity, guarded by a cheap *sufficient* no-overflow
  condition `x <= 2^128-1 && y <= 2^128-1` (so the product fits in 256 bits).
  This is the width-budget idea Halmos uses; it replaces the exact bound-free
  predicate `extract 511 256 (zext x * zext y) = 0`, whose 512-bit multiply was
  the dominant solver cost and timed out for large operands.
- mulDiv bound: for `(x*y)/z`, `y <= z => (x*y)/z <= x` (guarded by no-overflow)
- const-mul monotonicity: `x <= y => c*x <= c*y` for a literal `c`. Constant
  multiplies stay native `bvmul`, but a symbolic operand times a large constant
  is costly to bit-blast and compare; since `c` is concrete the exact no-overflow
  bound `floor((2^256-1)/c)` is computed at encode time, so the guard is one
  constant comparison.
- const cancellation: `(c1*x)/c2 == (c1/c2)*x` for literals with `c2 | c1` (its
  special case `c1==c2` gives `(c*x)/c == x`). The multiply stays native `bvmul`
  but the surrounding divide is abstracted, so a precision-scaling wrapper
  (`x * 1e18 / 1e18`, the identity, or the rescale `x * 1e18 / 1e6 == x * 1e12`) is
  not otherwise provably exact; this pins it, under the encode-time bound
  `floor((2^256-1)/c1)`. It fires when the divisor literal divides the multiplier
  literal.
- nested-division collapse: `(A/c1)/c2 == A/(c1*c2)` for literals `c1,c2` with
  `c1*c2 < 2^256`. Two successive constant divides of an abstracted quotient stay
  uninterpreted and unrelatable to the single combined divide; this folds them, so
  a two-step constant rescale (`A / 1e9 / 1e18 == A / 1e27`) is equatable with its
  one-step form. The collapsed single divide `A/(c1*c2)` is also added to the div
  set, so the lemmas below (const-cancel, fraction-reduce, telescoping) match code
  that splits precision across two divides (e.g. `_getSUsdsValue`'s `x*rate/1e9/1e18`,
  whose collapsed `x*rate/1e27` is what they key on) — not only the one-step form.
- fraction-reduce: `(c1*x)/c2 == x/(c2/c1)` for literals with `c1 | c2`. The mirror
  of const cancellation (which needs `c2 | c1`): this is the `c1 | c2` direction —
  multiply by a small constant, divide by a large one — such as `x * 1e6 / 1e18 ==
  x / 1e12` (precision scaling *down*, e.g. converting to a lower-decimal token).
  Sound because, under the same encode-time bound `floor((2^256-1)/c1)`, `c1*x` is
  exact and `floor(c1*x / (c1*k)) = floor(x/k)`. It fires when the multiplier
  literal divides the divisor literal (and `c1 != c2`, the const-cancel case).
- ceilDiv-cancel: the round-up sibling of const-cancel. OpenZeppelin
  `Math.ceilDiv(c1*x, c2)` is `(c1*x == 0) ? 0 : (c1*x - 1)/c2 + 1`, so the
  abstracted divide is over the `c1*x - 1` dividend. When `c2 | c1` the product is
  always a multiple of `c2`, hence ceil == floor and the whole ceilDiv collapses to
  `(c1/c2)*x`; the lemma pins the inner divide — for `x >= 1`,
  `(c1*x - 1)/c2 == (c1/c2)*x - 1` (then `+1` recovers `(c1/c2)*x`), under the same
  `floor((2^256-1)/c1)` bound. This discharges round-up precision conversions that
  scale to a coarser unit exactly (e.g. an 18→6→18-decimal `ceilDiv(x*1e18, 1e6) ==
  x*1e12`).
- cancellation synthesis: when an abstract product `a*b` has a factor reused as a
  divisor elsewhere, the synthetic exact division `(a*b)/b` is added to the div
  set, letting the lemmas above bridge nested divisions (`(a*b)/b <= a` plus
  div-monotonicity across the shared divisor). This is what proves cross-divisor
  round-trips like `((x*s)/a)*a/s <= x`, and it also discharges Solidity 0.8's
  `div(mul(a,b),a)` overflow guards, so checked arithmetic proves as written.
- scaled-product telescoping: `(a*b)/c - (a*(b-k))/c == a*(k/c)` for a literal
  divisor `c` and literal step `k` with `c | k` (no-overflow guarded, and `b >= k`
  so the step is a true difference). Every lemma above relates a product to a
  *constant* or to itself; this is the only one that pins the EXACT difference of
  two *distinct* abstract products. It discharges value-change accounting — the
  recurring vault-test shape "Δvalue == driver × rate-delta" — e.g.
  `susds*rate/1e27 - susds == susds*(rate-1e27)/1e27`. Sound because
  `a*b = a*(b-k) + a*k` and `a*k` is an exact multiple of `c`, so removing it shifts
  the floor by exactly `a*(k/c)`.

Operand bounding (e.g. `require(x < 2**128)`) is supplied in Solidity. Enabled by
the same `--abstract-arith` flag as #996.

## Soundness

hevm stays sound — it is a prover here, never a source of false bugs:

- A `QED` is a real proof: every lemma over-approximates real EVM arithmetic, so
  `unsat` under abstraction implies `unsat` in reality.
- Because `abst_evm_bvmul` is uninterpreted, a SAT model may assign products
  inconsistent with real multiplication, so a counterexample cannot be trusted.
  When the mul abstraction is active a SAT result is downgraded to `Unknown`
  rather than reported. Division-only counterexamples (division is exact via its
  ground truth) are unaffected.
- The lemmas are mutually consistent: the `*-not-unsound` tests confirm
  genuinely-false properties stay `Unknown` (never a spurious `QED`) and the
  `*-cex-preserved` tests confirm real counterexamples are still reported.

## Properties it proves

Monotonicity of conversion functions (more in ⇒ at least as much out; a higher
backing ratio ⇒ at least as much value), divisor ordering, mulDiv bounds, and
cross-divisor round-trips (`convertToAssets(convertToShares(x)) <= x` and its
reverse — value in/out cannot increase across a round-trip). The const-cancel and
nested-division-collapse lemmas additionally prove *exact-value* constant-rescale
identities (e.g. a `x * 1e18 / 1e6` precision conversion equals `x * 1e12`) — a
qualitative step past the relational facts above, since an abstracted divide
otherwise leaves the quotient uninterpreted. All are `unknown` natively (the
nested symbolic products bit-blast) and `QED` with `--abstract-arith`.

## Example

A minimal ERC-4626 vault, ordinary checked arithmetic. Share-price monotonicity
and the round-trip both prove `QED` with `--abstract-arith` (and `unknown`
natively):

```solidity
contract Vault {
    uint256 public totalAssets;
    uint256 public totalShares;

    function convertToShares(uint256 assets) public view returns (uint256) {
        if (totalAssets != 0) return assets * totalShares / totalAssets;
        return assets;
    }
    function convertToAssets(uint256 shares) public view returns (uint256) {
        if (totalShares != 0) return shares * totalAssets / totalShares;
        return shares;
    }

    // more assets in => never fewer shares minted
    function prove_shares_monotonic(uint256 a, uint256 b) external view {
        require(totalAssets != 0);
        require(a < 2**128 && b < 2**128 && totalShares < 2**128);
        require(a <= b);
        assert(convertToShares(a) <= convertToShares(b));
    }

    // value -> shares -> value never creates value
    function prove_roundtrip(uint256 x) external view {
        require(totalAssets != 0 && totalShares != 0);
        require(x < 2**128 && totalShares < 2**128 && totalAssets < 2**128);
        assert(convertToAssets(convertToShares(x)) <= x);
    }
}
```

Use **bitwuzla** (the bit-vector solver hevm defaults to): it discharges the
checked-arithmetic overflow guards that z3 struggles with on the deepest nested
round-trips. Both solvers are sound.

## Verification status

Every property's result (QED / Unknown / CEX) was confirmed through the `hevm`
CLI locally (bitwuzla 0.8.2). The test group `Mul-Abstraction` runs in CI.

## Known limitation: undefined symbol with abstracted arithmetic over storage-resolved values

The abstraction lemmas (`assertPropsAbstract`) are encoded over the raw props `ps`,
whereas SMT variables are declared from the *eliminated* props
(`eliminateProps . concKeccak[Simp] . [decompose] $ ps`). When a calldata value
reaches the abstracted arithmetic through storage — e.g. written into a mapping slot
via `vm.store`, or read back across a contract boundary — the lemma encoder
(`exprToSMTWith`) resolves the read to the calldata symbol, but the
variable-declaration pass (`referencedVars` over the eliminated props) represents it
differently and never declares it. The emitted lemma then mentions an undeclared
symbol and the solver errors:

```
[error] undefined symbol 'arg2'
while sending: (assert (= ... (abst_evm_bvudiv (bvmul (_ bv1000000000000000000 256) arg2)
                                               (_ bv1000000000000000000 256)) ...))
```

This is **not unsoundness** — the solver errors out and hevm reports the property as
`unknown` / partially-explored, never a spurious `QED`. But it turns some provable
properties into false negatives.

Observed on PSM3's `previewWithdraw` under `--abstract-arith`: a `vm.store`'d
`shares[msg.sender]` mapping read, plus a `totalAssets` formed as a sum of
cross-contract balance reads, feeding a general-branch round-up division. It does
not reduce to a small standalone contract — a single mapping store, a cross-contract
read, and the round-up `ceilDiv` each prove fine in isolation — so the divergence
depends on the specific elimination/decomposition of the combined query.

Partial fix direction: encoding the abstraction lemmas over the *same* eliminated
props the declarations use removes the `vm.store`-into-mapping class of this; a
deeper case remains for cross-contract balance reads that `exprToSMTWith` resolves
only inside nested arithmetic, where `referencedVars` still does not declare the
symbol. Left as a known limitation for now since it yields `unknown`, not a wrong
answer.

## Checklist

- [ ] tested locally
- [x] added automated tests (group `Mul-Abstraction`)
- [ ] updated the docs
- [ ] updated the changelog






